### PR TITLE
Fix type variable spelling error

### DIFF
--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -84,7 +84,7 @@ export type PROGRESS = typeof PROGRESS;
 export const STRUCTURES = 'structure(s)';
 export type STRUCTURES = typeof STRUCTURES;
 export const PERSONS = 'person(s)';
-export type PERSON = typeof PERSONS;
+export type PERSONS = typeof PERSONS;
 
 export const JURISDICTION_ID = 'jurisdiction_id';
 export type JURISDICTION_ID = typeof JURISDICTION_ID;


### PR DESCRIPTION
Change type for const ```PERSONS``` from ```PERSON``` to ```PERSONS```