### PR TITLE
Fix unhandled promise rejection error in SingleFi component

### DIFF
--- a/src/containers/pages/FocusInvestigation/single/index.tsx
+++ b/src/containers/pages/FocusInvestigation/single/index.tsx
@@ -163,7 +163,7 @@ class SingleFI extends React.Component<RouteComponentProps<RouteParams> & Single
       await supersetService(SUPERSET_GOALS_SLICE, goalsParams).then((result2: Goal[]) =>
         fetchGoalsActionCreator(result2)
       );
-      await supersetFetch(SUPERSET_JURISDICTIONS_SLICE, jurisdictionsParams).then(
+      await supersetService(SUPERSET_JURISDICTIONS_SLICE, jurisdictionsParams).then(
         (result: Jurisdiction[]) => fetchJurisdictionsActionCreator(result)
       );
     }

--- a/src/containers/pages/FocusInvestigation/single/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/pages/FocusInvestigation/single/tests/__snapshots__/index.test.tsx.snap
@@ -151,6 +151,9 @@ exports[`containers/pages/SingleFI It works with the Redux store 1`] = `
           },
         ]
       }
+      fetchGoalsActionCreator={[MockFunction]}
+      fetchJurisdictionActionCreator={[MockFunction]}
+      fetchPlansActionCreator={[MockFunction]}
       history={
         Object {
           "action": "POP",
@@ -290,6 +293,33 @@ exports[`containers/pages/SingleFI It works with the Redux store 1`] = `
           "url": "/focus-investigation/view/16",
         }
       }
+      supersetService={
+        [MockFunction] {
+          "calls": Array [
+            Array [
+              0,
+              Object {
+                "adhoc_filters": Array [
+                  Object {
+                    "clause": "WHERE",
+                    "comparator": "450fc15b-5bd2-468a-927a-49cb10d3bcac",
+                    "expressionType": "SIMPLE",
+                    "operator": "==",
+                    "subject": "jurisdiction_id",
+                  },
+                ],
+                "row_limit": 3000,
+              },
+            ],
+          ],
+          "results": Array [
+            Object {
+              "isThrow": false,
+              "value": Promise {},
+            },
+          ],
+        }
+      }
     >
       <SingleFI
         completeReactivePlansArray={Array []}
@@ -325,6 +355,7 @@ exports[`containers/pages/SingleFI It works with the Redux store 1`] = `
           ]
         }
         fetchGoalsActionCreator={[Function]}
+        fetchJurisdictionActionCreator={[MockFunction]}
         fetchJurisdictionsActionCreator={[Function]}
         fetchPlansActionCreator={[Function]}
         goalsArray={
@@ -564,7 +595,33 @@ exports[`containers/pages/SingleFI It works with the Redux store 1`] = `
             "ed2b4b7c-3388-53d9-b9f6-6a19d1ffde1f",
           ]
         }
-        supersetService={[Function]}
+        supersetService={
+          [MockFunction] {
+            "calls": Array [
+              Array [
+                0,
+                Object {
+                  "adhoc_filters": Array [
+                    Object {
+                      "clause": "WHERE",
+                      "comparator": "450fc15b-5bd2-468a-927a-49cb10d3bcac",
+                      "expressionType": "SIMPLE",
+                      "operator": "==",
+                      "subject": "jurisdiction_id",
+                    },
+                  ],
+                  "row_limit": 3000,
+                },
+              ],
+            ],
+            "results": Array [
+              Object {
+                "isThrow": false,
+                "value": Promise {},
+              },
+            ],
+          }
+        }
       >
         <div
           className="mb-5"
@@ -5463,9 +5520,10 @@ exports[`containers/pages/SingleFI renders SingleFI correctly 1`] = `
         },
       ]
     }
-    fetchGoalsActionCreator={[Function]}
+    fetchGoalsActionCreator={[MockFunction]}
+    fetchJurisdictionActionCreator={[MockFunction]}
     fetchJurisdictionsActionCreator={[Function]}
-    fetchPlansActionCreator={[Function]}
+    fetchPlansActionCreator={[MockFunction]}
     goalsArray={
       Array [
         Object {

--- a/src/containers/pages/FocusInvestigation/single/tests/index.test.tsx
+++ b/src/containers/pages/FocusInvestigation/single/tests/index.test.tsx
@@ -58,8 +58,7 @@ describe('containers/pages/SingleFI', () => {
 
   it('renders SingleFI correctly', () => {
     const mock: any = jest.fn();
-    const supersetMock: any = jest.fn();
-    supersetMock.mockImplementation(() => Promise.resolve(fixtures.plans));
+    const supersetServiceMock: any = jest.fn(async () => []);
     const props = {
       completeReactivePlansArray: [fixtures.completeReactivePlan],
       completeRoutinePlansArray: [fixtures.completeRoutinePlan],
@@ -77,7 +76,11 @@ describe('containers/pages/SingleFI', () => {
       },
       planById: fixtures.plan1 as Plan,
       plansIdArray: fixtures.plansIdArray,
-      supersetService: supersetMock,
+      supersetService: supersetServiceMock,
+      // tslint:disable-next-line: object-literal-sort-keys
+      fetchPlansActionCreator: jest.fn(),
+      fetchGoalsActionCreator: jest.fn(),
+      fetchJurisdictionActionCreator: jest.fn(),
     };
     const wrapper = mount(
       <Router history={history}>
@@ -96,8 +99,7 @@ describe('containers/pages/SingleFI', () => {
 
   it('renders SingleFI correctly for null plan jurisdction id', () => {
     const mock: any = jest.fn();
-    const supersetMock: any = jest.fn();
-    supersetMock.mockImplementation(() => Promise.resolve(fixtures.plan5));
+    const supersetServiceMock: any = jest.fn(async () => []);
     const props = {
       completeReactivePlansArray: [],
       completeRoutinePlansArray: [],
@@ -116,7 +118,11 @@ describe('containers/pages/SingleFI', () => {
       planById: fixtures.plan5,
       plansArray: [fixtures.plan5],
       plansIdArray: [fixtures.plan5.id],
-      supersetService: supersetMock,
+      supersetService: supersetServiceMock,
+      // tslint:disable-next-line: object-literal-sort-keys
+      fetchPlansActionCreator: jest.fn(),
+      fetchGoalsActionCreator: jest.fn(),
+      fetchJurisdictionActionCreator: jest.fn(),
     };
     const wrapper = mount(
       <Router history={history}>
@@ -130,6 +136,7 @@ describe('containers/pages/SingleFI', () => {
 
   it('It works with the Redux store', () => {
     const mock: any = jest.fn();
+    const supersetServiceMock: any = jest.fn(async () => []);
     store.dispatch(fetchPlans(fixtures.plans as Plan[]));
     store.dispatch(fetchGoals(fixtures.goals));
     store.dispatch(fetchJurisdictions(fixtures.jurisdictions));
@@ -147,6 +154,11 @@ describe('containers/pages/SingleFI', () => {
         path: `${FI_SINGLE_URL}/:id`,
         url: `${FI_SINGLE_URL}/16`,
       },
+      supersetService: supersetServiceMock,
+      // tslint:disable-next-line: object-literal-sort-keys
+      fetchPlansActionCreator: jest.fn(),
+      fetchGoalsActionCreator: jest.fn(),
+      fetchJurisdictionActionCreator: jest.fn(),
     };
     const wrapper = mount(
       <Provider store={store}>


### PR DESCRIPTION
closes #256 

Note:
These errors were caused since the supersetServiceMock prop did not have an async implementation, therefore inside the components; the `supersetService` response object was not thenable. 
Making sure the props passed in the tests conforms to the expected interface of input and output data for operations such as `supersetService(supersetFetch)` will resolve this issue only for the tests, however it does not guarantee that this would not happen in production environment since that would require modifying the code; specifically adding a `.catch` block to `supersetService` calls.

This is what i mean:

__Current supersetService calls__:
```typescript
await supersetService(SUPERSET_PLANS_SLICE, jurisdictionsParams).then((result: Plan[]) =>
        fetchPlansActionCreator(result)
      )
```
__What might be eventually needed is__:
```typescript
await supersetService(SUPERSET_PLANS_SLICE, jurisdictionsParams).then((result: Plan[]) =>
        fetchPlansActionCreator(result)
      ).catch((err: <errorType>) => console.log("Maybe display the error", err))
```
@moshthepitt Should i leave this as it is and modify the tests only?