### PR TITLE
New payloads from actions should be added to existing records in store

### DIFF
--- a/src/store/ducks/goals.ts
+++ b/src/store/ducks/goals.ts
@@ -32,19 +32,33 @@ export const GOALS_FETCHED = 'reveal/reducer/goals/GOALS_FETCHED';
 /** SET_CURRENT_GOAL action type */
 export const SET_CURRENT_GOAL = 'reveal/reducer/goals/SET_CURRENT_GOAL';
 
+/** REMOVE_GOALS action type */
+export const REMOVE_GOALS = 'reveal/reducer/goals/REMOVE_GOALS';
+
 /** interface for authorize action */
 interface FetchGoalsAction extends AnyAction {
   goalsById: { [key: string]: Goal };
   type: typeof GOALS_FETCHED;
 }
 
+/** interface for setting current goal action */
 interface SetCurrentGoalAction extends AnyAction {
   currentGoal: string | null;
   type: typeof SET_CURRENT_GOAL;
 }
 
+/** Interface for remove goals action */
+interface RemoveGoalsAction extends AnyAction {
+  type: typeof REMOVE_GOALS;
+  goalsById: {};
+}
+
 /** Create type for Goal reducer action */
-export type GoalActionTypes = FetchGoalsAction | SetCurrentGoalAction | AnyAction;
+export type GoalActionTypes =
+  | FetchGoalsAction
+  | SetCurrentGoalAction
+  | RemoveGoalsAction
+  | AnyAction;
 
 /** interface for Goal state */
 interface GoalState {
@@ -73,6 +87,11 @@ export default function reducer(state = initialState, action: GoalActionTypes): 
       return SeamlessImmutable({
         ...state,
         currentGoal: action.currentGoal,
+      });
+    case REMOVE_GOALS:
+      return SeamlessImmutable({
+        ...state,
+        goalsById: action.goalsById,
       });
     default:
       return state;
@@ -109,6 +128,13 @@ export const setCurrentGoal = (currentGoal: string | null): SetCurrentGoalAction
     currentGoal,
     type: SET_CURRENT_GOAL,
   };
+};
+
+// Actions
+
+export const removeGoalsAction: RemoveGoalsAction = {
+  goalsById: {},
+  type: REMOVE_GOALS,
 };
 
 // selectors

--- a/src/store/ducks/goals.ts
+++ b/src/store/ducks/goals.ts
@@ -81,7 +81,7 @@ export default function reducer(state = initialState, action: GoalActionTypes): 
     case GOALS_FETCHED:
       return SeamlessImmutable({
         ...state,
-        goalsById: action.goalsById,
+        goalsById: { ...state.goalsById, ...action.goalsById },
       });
     case SET_CURRENT_GOAL:
       return SeamlessImmutable({

--- a/src/store/ducks/jurisdictions.ts
+++ b/src/store/ducks/jurisdictions.ts
@@ -37,6 +37,7 @@ export interface AllJurisdictionIds {
 export const FETCH_JURISDICTION = 'reveal/reducer/jurisdiction/FETCH_JURISDICTION';
 export const FETCH_ALL_JURISDICTION_IDS = 'reveal/reducer/jurisdiction/FETCH_ALL_JURISDICTION_IDS';
 export const REMOVE_JURISDICTIONS = 'reveal/reducer/jurisdiction/REMOVE_JURISDICTIONS';
+export const REMOVE_ALL_JURISDICTION_IDS = 'reveal/reducer/jurisdiction/REMOVE_ALL_JURISDICTIONIDS';
 
 /** fetch jurisdiction action */
 interface FetchJurisdictionAction extends AnyAction {
@@ -57,11 +58,18 @@ interface RemoveJurisdictionsAction extends AnyAction {
   type: typeof REMOVE_JURISDICTIONS;
 }
 
+/** Interface for remove all jurisdictions ids action */
+interface RemoveAllJurisdictionIdsAction extends AnyAction {
+  type: typeof REMOVE_ALL_JURISDICTION_IDS;
+  allJurisdictionIds: {};
+}
+
 /** jurisdiction action types */
 export type JurisdictionActionTypes =
   | FetchJurisdictionAction
   | FetchAllJurisdictionIdsAction
   | RemoveJurisdictionsAction
+  | RemoveAllJurisdictionIdsAction
   | AnyAction;
 
 /** interface to describe jurisdiction state */
@@ -108,6 +116,11 @@ export default function reducer(
       return SeamlessImmutable({
         ...state,
         jurisdictionsById: action.jurisdictionsById,
+      });
+    case REMOVE_ALL_JURISDICTION_IDS:
+      return SeamlessImmutable({
+        ...state,
+        allJurisdictionIds: action.allJurisdictionIds,
       });
     default:
       return state;
@@ -173,6 +186,12 @@ export const fetchAllJurisdictionIds = (jurisdictionIds: string[]) => ({
 export const removeJurisdictionsAction = {
   jurisdictionsById: {},
   type: REMOVE_JURISDICTIONS,
+};
+
+/** remove all jurisdiction ids Actoin */
+export const removeAllJurisdictionIdsAction: RemoveAllJurisdictionIdsAction = {
+  allJurisdictionIds: {},
+  type: REMOVE_ALL_JURISDICTION_IDS,
 };
 
 // selectors

--- a/src/store/ducks/jurisdictions.ts
+++ b/src/store/ducks/jurisdictions.ts
@@ -99,7 +99,7 @@ export default function reducer(
       if (action.jurisdictionsById) {
         return SeamlessImmutable({
           ...state,
-          allJurisdictionIds: action.allJurisdictionIds,
+          allJurisdictionIds: { ...state.allJurisdictionIds, ...action.allJurisdictionIds },
           jurisdictionsById: {
             ...state.jurisdictionsById,
             ...action.jurisdictionsById,
@@ -110,7 +110,7 @@ export default function reducer(
     case FETCH_ALL_JURISDICTION_IDS:
       return SeamlessImmutable({
         ...state,
-        allJurisdictionIds: action.allJurisdictionIds,
+        allJurisdictionIds: { ...state.allJurisdictionIds, ...action.allJurisdictionIds },
       });
     case REMOVE_JURISDICTIONS:
       return SeamlessImmutable({

--- a/src/store/ducks/jurisdictions.ts
+++ b/src/store/ducks/jurisdictions.ts
@@ -15,7 +15,7 @@ export interface JurisdictionGeoJSON extends GeoJSON {
   };
 }
 
-// todo - distingquish non-geo Jurisdiction, inheritted by new JurisdictionGeo type
+// todo - distinguish non-geo Jurisdiction, inheritted by new JurisdictionGeo type
 /** interface to describe Jurisdiction */
 export interface Jurisdiction {
   geographic_level?: number;
@@ -33,9 +33,10 @@ export interface AllJurisdictionIds {
   };
 }
 
-// actions
+// action types
 export const FETCH_JURISDICTION = 'reveal/reducer/jurisdiction/FETCH_JURISDICTION';
 export const FETCH_ALL_JURISDICTION_IDS = 'reveal/reducer/jurisdiction/FETCH_ALL_JURISDICTION_IDS';
+export const REMOVE_JURISDICTIONS = 'reveal/reducer/jurisdiction/REMOVE_JURISDICTIONS';
 
 /** fetch jurisdiction action */
 interface FetchJurisdictionAction extends AnyAction {
@@ -50,10 +51,17 @@ interface FetchAllJurisdictionIdsAction extends AnyAction {
   type: typeof FETCH_ALL_JURISDICTION_IDS;
 }
 
+/** Remove jurisdictions action interface */
+interface RemoveJurisdictionsAction extends AnyAction {
+  jurisdictionsById: {};
+  type: typeof REMOVE_JURISDICTIONS;
+}
+
 /** jurisdiction action types */
 export type JurisdictionActionTypes =
   | FetchJurisdictionAction
   | FetchAllJurisdictionIdsAction
+  | RemoveJurisdictionsAction
   | AnyAction;
 
 /** interface to describe jurisdiction state */
@@ -95,6 +103,11 @@ export default function reducer(
       return SeamlessImmutable({
         ...state,
         allJurisdictionIds: action.allJurisdictionIds,
+      });
+    case REMOVE_JURISDICTIONS:
+      return SeamlessImmutable({
+        ...state,
+        jurisdictionsById: action.jurisdictionsById,
       });
     default:
       return state;
@@ -154,6 +167,13 @@ export const fetchAllJurisdictionIds = (jurisdictionIds: string[]) => ({
   ),
   type: FETCH_ALL_JURISDICTION_IDS,
 });
+
+// actions
+/** removeJurisdictions Action */
+export const removeJurisdictionsAction = {
+  jurisdictionsById: {},
+  type: REMOVE_JURISDICTIONS,
+};
 
 // selectors
 /** get jurisdictions by id

--- a/src/store/ducks/opensrp/PlanDefinition/index.ts
+++ b/src/store/ducks/opensrp/PlanDefinition/index.ts
@@ -14,8 +14,8 @@ export const PLAN_DEFINITIONS_FETCHED =
   'reveal/reducer/opensrp/PlanDefinition/PLAN_DEFINITIONS_FETCHED';
 
 /** PLAN_DEFINITION_FETCHED action type */
-export const PLAN_DEFINITIONS_RESET =
-  'reveal/reducer/opensrp/PlanDefinition/PLAN_DEFINITIONS_RESET';
+export const REMOVE_PLAN_DEFINITIONS =
+  'reveal/reducer/opensrp/PlanDefinition/REMOVE_PLAN_DEFINITIONS';
 
 /** interface for fetch PlanDefinitions action */
 interface FetchPlanDefinitionsAction extends AnyAction {
@@ -24,15 +24,15 @@ interface FetchPlanDefinitionsAction extends AnyAction {
 }
 
 /** interface for fetch PlanDefinitions action */
-interface ResetPlanDefinitionsAction extends AnyAction {
+interface RemovePlanDefinitionsAction extends AnyAction {
   planDefinitionsById: { [key: string]: PlanDefinition };
-  type: typeof PLAN_DEFINITIONS_RESET;
+  type: typeof REMOVE_PLAN_DEFINITIONS;
 }
 
 /** Create type for PlanDefinition reducer actions */
 export type PlanDefinitionActionTypes =
   | FetchPlanDefinitionsAction
-  | ResetPlanDefinitionsAction
+  | RemovePlanDefinitionsAction
   | AnyAction;
 
 // action creators
@@ -49,9 +49,9 @@ export const fetchPlanDefinitions = (
 });
 
 /** Reset plan definitions state action creator */
-export const resetPlanDefinitions = () => ({
+export const removePlanDefinitions = () => ({
   planDefinitionsById: {},
-  type: PLAN_DEFINITIONS_RESET,
+  type: REMOVE_PLAN_DEFINITIONS,
 });
 
 // the reducer
@@ -84,7 +84,7 @@ export default function reducer(
         });
       }
       return state;
-    case PLAN_DEFINITIONS_RESET:
+    case REMOVE_PLAN_DEFINITIONS:
       return SeamlessImmutable({
         planDefinitionsById: action.planDefinitionsById,
       });

--- a/src/store/ducks/opensrp/PlanDefinition/tests/index.test.ts
+++ b/src/store/ducks/opensrp/PlanDefinition/tests/index.test.ts
@@ -10,7 +10,7 @@ import reducer, {
   getPlanDefinitionsArray,
   getPlanDefinitionsById,
   reducerName,
-  resetPlanDefinitions,
+  removePlanDefinitions,
 } from '../index';
 import * as fixtures from './fixtures';
 
@@ -60,7 +60,7 @@ describe('reducers/opensrp/PlanDefinition', () => {
     );
 
     // reset
-    store.dispatch(resetPlanDefinitions());
+    store.dispatch(removePlanDefinitions());
     expect(getPlanDefinitionsArray(store.getState())).toEqual([]);
   });
 

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -344,7 +344,7 @@ export default function reducer(state = initialState, action: PlanActionTypes): 
     case PLANS_FETCHED:
       return SeamlessImmutable({
         ...state,
-        plansById: action.plansById,
+        plansById: { ...state.plansById, ...action.plansById },
       });
     case PLAN_RECORDS_FETCHED:
       return SeamlessImmutable({

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -296,6 +296,8 @@ export const extractPlanRecordFromPlanPayload = (planPayload: PlanPayload): Plan
 export const PLANS_FETCHED = 'reveal/reducer/plans/PLANS_FETCHED';
 /** PLAN_RECORDS_FETCHED action type */
 export const PLAN_RECORDS_FETCHED = 'reveal/reducer/plans/PLAN_RECORDS_FETCHED';
+/** REMOVE_PLANS action_type */
+export const REMOVE_PLANS = 'reveal/reducer/plans/REMOVE_PLANS';
 
 /** FetchPlansAction interface for PLANS_FETCHED */
 interface FetchPlansAction extends AnyAction {
@@ -308,8 +310,18 @@ interface FetchPlanRecordsAction extends AnyAction {
   type: typeof PLAN_RECORDS_FETCHED;
 }
 
+/** removePlansAction interface for REMOVE_PLANS */
+interface RemovePlansAction extends AnyAction {
+  type: typeof REMOVE_PLANS;
+  plansById: {};
+}
+
 /** Create type for Plan reducer actions */
-export type PlanActionTypes = FetchPlansAction | FetchPlanRecordsAction | AnyAction;
+export type PlanActionTypes =
+  | FetchPlansAction
+  | FetchPlanRecordsAction
+  | RemovePlansAction
+  | AnyAction;
 
 /** interface for Plan state */
 interface PlanState {
@@ -339,12 +351,23 @@ export default function reducer(state = initialState, action: PlanActionTypes): 
         ...state,
         planRecordsById: action.planRecordsById,
       });
+    case REMOVE_PLANS:
+      return SeamlessImmutable({
+        ...state,
+        plansById: action.plansById,
+      });
     default:
       return state;
   }
 }
 
 // action creators
+
+/** removePlansAction */
+export const removePlansAction: RemovePlansAction = {
+  plansById: {},
+  type: REMOVE_PLANS,
+};
 
 /** fetchPlans - action creator setting plansById
  * @param {Plan[]} plansList - array of plan objects

--- a/src/store/ducks/structures.ts
+++ b/src/store/ducks/structures.ts
@@ -41,8 +41,11 @@ export interface Structure {
 }
 
 // actions
+
 /** STRUCTURES_SET action type */
 export const STRUCTURES_SET = 'reveal/reducer/structures/STRUCTURES_SET';
+/** REMOVE_STRUCTURES action type */
+export const REMOVE_STRUCTURES = 'reveal/reducer/structures/REMOVE_STRUCTURES';
 
 /** interface for setStructure action */
 interface SetStructuresAction extends AnyAction {
@@ -50,8 +53,14 @@ interface SetStructuresAction extends AnyAction {
   type: typeof STRUCTURES_SET;
 }
 
+/** interface for RemoveStructuresAction */
+interface RemoveStructuresAction extends AnyAction {
+  structuresById: {};
+  type: typeof REMOVE_STRUCTURES;
+}
+
 /** Create type for Structure reducer actions */
-export type StructureActionTypes = SetStructuresAction | AnyAction;
+export type StructureActionTypes = SetStructuresAction | RemoveStructuresAction | AnyAction;
 
 /** interface for Structure state */
 interface StructureState {
@@ -81,6 +90,11 @@ export default function reducer(
         });
       }
       return state;
+    case REMOVE_STRUCTURES:
+      return SeamlessImmutable({
+        ...state,
+        structuresById: action.structuresById,
+      });
     default:
       return state;
   }
@@ -111,6 +125,12 @@ export const setStructures = (structuresList: Structure[] = []): SetStructuresAc
     ),
     type: STRUCTURES_SET,
   };
+};
+
+// actions
+export const removeStructuresAction: RemoveStructuresAction = {
+  structuresById: {},
+  type: REMOVE_STRUCTURES,
 };
 
 // selectors

--- a/src/store/ducks/structures.ts
+++ b/src/store/ducks/structures.ts
@@ -86,7 +86,7 @@ export default function reducer(
       if (action.structuresById) {
         return SeamlessImmutable({
           ...state,
-          structuresById: action.structuresById,
+          structuresById: { ...state.structuresById, ...action.structuresById },
         });
       }
       return state;

--- a/src/store/ducks/tasks.ts
+++ b/src/store/ducks/tasks.ts
@@ -82,7 +82,7 @@ export type Task = UpdateType<InitialTask, GeoJSONUpdate>;
 // actions
 /** TASKS_FETCHED action type */
 export const TASKS_FETCHED = 'reveal/reducer/tasks/TASKS_FETCHED';
-export const RESET_TASKS = 'reveal/reducer/tasks/RESET_TASKS';
+export const REMOVE_TASKS = 'reveal/reducer/tasks/REMOVE_TASKS';
 
 /** interface for authorize action */
 interface FetchTasksAction extends AnyAction {
@@ -93,7 +93,7 @@ interface FetchTasksAction extends AnyAction {
 /** Interface for reset tasks action */
 interface ResetTaskAction extends AnyAction {
   tasksById: {};
-  type: typeof RESET_TASKS;
+  type: typeof REMOVE_TASKS;
 }
 
 /** Create type for Task reducer actions */
@@ -123,8 +123,9 @@ export default function reducer(state = initialState, action: TaskActionTypes): 
         });
       }
       return state;
-    case RESET_TASKS:
+    case REMOVE_TASKS:
       return SeamlessImmutable({
+        ...state,
         tasksById: action.tasksById,
       });
     default:
@@ -158,11 +159,13 @@ export const fetchTasks = (tasksList: InitialTask[] = []): FetchTasksAction => (
   type: TASKS_FETCHED,
 });
 
-/** Reset-tasks-state action creator */
-export const resetTasks = (): ResetTaskAction => ({
+// actions
+
+/** remove tasks action */
+export const removeTasksAction: ResetTaskAction = {
   tasksById: {},
-  type: RESET_TASKS,
-});
+  type: REMOVE_TASKS,
+};
 
 // selectors
 

--- a/src/store/ducks/tasks.ts
+++ b/src/store/ducks/tasks.ts
@@ -119,7 +119,7 @@ export default function reducer(state = initialState, action: TaskActionTypes): 
       if (action.tasksById) {
         return SeamlessImmutable({
           ...state,
-          tasksById: action.tasksById,
+          tasksById: { ...state.tasksById, ...action.tasksById },
         });
       }
       return state;

--- a/src/store/ducks/tests/goals.test.ts
+++ b/src/store/ducks/tests/goals.test.ts
@@ -13,6 +13,7 @@ import reducer, {
   getGoalsByPlanId,
   Goal,
   reducerName,
+  removeGoalsAction,
   setCurrentGoal,
 } from '../goals';
 import * as fixtures from './fixtures';
@@ -102,7 +103,23 @@ describe('reducers/goals', () => {
     }
   });
 
+  it('should reset goal records in store', () => {
+    store.dispatch(removeGoalsAction);
+    let goalsInStore = getGoalsById(store.getState());
+    expect(goalsInStore).toEqual({});
+
+    store.dispatch(fetchGoals(fixtures.goals));
+    goalsInStore = getGoalsById(store.getState());
+    goalsInStore = getGoalsById(store.getState());
+
+    store.dispatch(removeGoalsAction);
+    expect(goalsInStore).not.toEqual({});
+    goalsInStore = getGoalsById(store.getState());
+    expect(goalsInStore).toEqual({});
+  });
+
   it('Should add new goals to existing goals in store', () => {
+    store.dispatch(removeGoalsAction);
     const plan1Id = '10f9e9fa-ce34-4b27-a961-72fab5206ab6';
     let goalNumberInStore = getGoalsByPlanId(store.getState(), plan1Id).length;
     expect(goalNumberInStore).toEqual(0);

--- a/src/store/ducks/tests/goals.test.ts
+++ b/src/store/ducks/tests/goals.test.ts
@@ -101,4 +101,30 @@ describe('reducers/goals', () => {
       });
     }
   });
+
+  it('Should add new goals to existing goals in store', () => {
+    const plan1Id = '10f9e9fa-ce34-4b27-a961-72fab5206ab6';
+    let goalNumberInStore = getGoalsByPlanId(store.getState(), plan1Id).length;
+    expect(goalNumberInStore).toEqual(0);
+
+    store.dispatch(fetchGoals([fixtures.goal1]));
+    const goal1Id = '5a27ec10-7a5f-563c-ba11-4de150b336af';
+    let goal1FromStore = getGoalById(store.getState(), goal1Id);
+    expect(goal1FromStore).not.toBe(null);
+    goalNumberInStore = getGoalsByPlanId(store.getState(), plan1Id).length;
+    expect(goalNumberInStore).toEqual(1);
+
+    store.dispatch(fetchGoals([fixtures.goal2]));
+    const goal2Id = 'f8d4e0a9-5867-5c78-9e26-de45d72556c4';
+    const goal2FromStore = getGoalById(store.getState(), goal2Id);
+    goal1FromStore = getGoalById(store.getState(), goal1Id);
+    expect(goal2FromStore).not.toBe(null);
+    expect(goal1FromStore).not.toBe(null);
+    goalNumberInStore = getGoalsByPlanId(store.getState(), plan1Id).length;
+    expect(goalNumberInStore).toEqual(2);
+
+    store.dispatch(fetchGoals([fixtures.goal1]));
+    goalNumberInStore = getGoalsByPlanId(store.getState(), plan1Id).length;
+    expect(goalNumberInStore).toEqual(2);
+  });
 });

--- a/src/store/ducks/tests/jurisdictions.test.ts
+++ b/src/store/ducks/tests/jurisdictions.test.ts
@@ -3,13 +3,16 @@ import { keyBy, values } from 'lodash';
 import { FlushThunks } from 'redux-testkit';
 import store from '../../index';
 import reducer, {
+  fetchAllJurisdictionIds,
   fetchJurisdictions,
+  getAllJurisdictionsIdArray,
   getJurisdictionById,
   getJurisdictionsArray,
   getJurisdictionsById,
   getJurisdictionsIdArray,
   Jurisdiction,
   reducerName,
+  removeAllJurisdictionsIdsAction,
   removeJurisdictionsAction,
 } from '../jurisdictions';
 import * as fixtures from './fixtures';
@@ -111,7 +114,7 @@ describe('reducers/jurisdictions', () => {
     expect(jurisdictionsInStore).toEqual({});
   });
 
-  it('new jurisdictions not overwrite but appended to existing', () => {
+  it('new jurisdictions not overwrite but added to existing', () => {
     store.dispatch(removeJurisdictionsAction);
     const jurisdictionsInStore = getJurisdictionsById(store.getState());
     expect(jurisdictionsInStore).toEqual({});
@@ -120,5 +123,23 @@ describe('reducers/jurisdictions', () => {
     store.dispatch(fetchJurisdictions([fixtures.jurisdictions] as any));
     const jurisdiction3FromStore = getJurisdictionById(store.getState(), 'abcde');
     expect(jurisdiction3FromStore).not.toBeNull();
+  });
+
+  it('can remove allJurisdictionsIds', () => {
+    store.dispatch(removeAllJurisdictionsIdsAction);
+    let alljurisdictionsIdsNumber = getAllJurisdictionsIdArray(store.getState()).length;
+    expect(alljurisdictionsIdsNumber).toEqual(0);
+
+    store.dispatch(fetchAllJurisdictionIds(['id1']));
+    alljurisdictionsIdsNumber = getAllJurisdictionsIdArray(store.getState()).length;
+    expect(alljurisdictionsIdsNumber).toEqual(1);
+
+    store.dispatch(removeAllJurisdictionsIdsAction);
+    alljurisdictionsIdsNumber = getAllJurisdictionsIdArray(store.getState()).length;
+    expect(alljurisdictionsIdsNumber).toEqual(0);
+  });
+
+  it('new jurisdictionsIds do not overwrite but added to existing', () => {
+    // some tests here
   });
 });

--- a/src/store/ducks/tests/jurisdictions.test.ts
+++ b/src/store/ducks/tests/jurisdictions.test.ts
@@ -140,6 +140,20 @@ describe('reducers/jurisdictions', () => {
   });
 
   it('new jurisdictionsIds do not overwrite but added to existing', () => {
-    // some tests here
+    store.dispatch(removeAllJurisdictionIdsAction);
+    let alljurisdictionsIdsNumber = getAllJurisdictionsIdArray(store.getState()).length;
+    expect(alljurisdictionsIdsNumber).toEqual(0);
+
+    store.dispatch(fetchAllJurisdictionIds(['id1']));
+    alljurisdictionsIdsNumber = getAllJurisdictionsIdArray(store.getState()).length;
+    expect(alljurisdictionsIdsNumber).toEqual(1);
+
+    store.dispatch(fetchAllJurisdictionIds(['id2']));
+    alljurisdictionsIdsNumber = getAllJurisdictionsIdArray(store.getState()).length;
+    expect(alljurisdictionsIdsNumber).toEqual(2);
+
+    store.dispatch(fetchJurisdictions([fixtures.jurisdiction3] as any));
+    alljurisdictionsIdsNumber = getAllJurisdictionsIdArray(store.getState()).length;
+    expect(alljurisdictionsIdsNumber).toEqual(3);
   });
 });

--- a/src/store/ducks/tests/jurisdictions.test.ts
+++ b/src/store/ducks/tests/jurisdictions.test.ts
@@ -12,7 +12,7 @@ import reducer, {
   getJurisdictionsIdArray,
   Jurisdiction,
   reducerName,
-  removeAllJurisdictionsIdsAction,
+  removeAllJurisdictionIdsAction,
   removeJurisdictionsAction,
 } from '../jurisdictions';
 import * as fixtures from './fixtures';
@@ -126,7 +126,7 @@ describe('reducers/jurisdictions', () => {
   });
 
   it('can remove allJurisdictionsIds', () => {
-    store.dispatch(removeAllJurisdictionsIdsAction);
+    store.dispatch(removeAllJurisdictionIdsAction);
     let alljurisdictionsIdsNumber = getAllJurisdictionsIdArray(store.getState()).length;
     expect(alljurisdictionsIdsNumber).toEqual(0);
 
@@ -134,7 +134,7 @@ describe('reducers/jurisdictions', () => {
     alljurisdictionsIdsNumber = getAllJurisdictionsIdArray(store.getState()).length;
     expect(alljurisdictionsIdsNumber).toEqual(1);
 
-    store.dispatch(removeAllJurisdictionsIdsAction);
+    store.dispatch(removeAllJurisdictionIdsAction);
     alljurisdictionsIdsNumber = getAllJurisdictionsIdArray(store.getState()).length;
     expect(alljurisdictionsIdsNumber).toEqual(0);
   });

--- a/src/store/ducks/tests/jurisdictions.test.ts
+++ b/src/store/ducks/tests/jurisdictions.test.ts
@@ -110,4 +110,15 @@ describe('reducers/jurisdictions', () => {
     expect(jurisdiction3FromStore).toBeNull();
     expect(jurisdictionsInStore).toEqual({});
   });
+
+  it('new jurisdictions not overwrite but appended to existing', () => {
+    store.dispatch(removeJurisdictionsAction);
+    const jurisdictionsInStore = getJurisdictionsById(store.getState());
+    expect(jurisdictionsInStore).toEqual({});
+
+    store.dispatch(fetchJurisdictions([fixtures.jurisdiction3] as any));
+    store.dispatch(fetchJurisdictions([fixtures.jurisdictions] as any));
+    const jurisdiction3FromStore = getJurisdictionById(store.getState(), 'abcde');
+    expect(jurisdiction3FromStore).not.toBeNull();
+  });
 });

--- a/src/store/ducks/tests/jurisdictions.test.ts
+++ b/src/store/ducks/tests/jurisdictions.test.ts
@@ -10,6 +10,7 @@ import reducer, {
   getJurisdictionsIdArray,
   Jurisdiction,
   reducerName,
+  removeJurisdictionsAction,
 } from '../jurisdictions';
 import * as fixtures from './fixtures';
 
@@ -90,5 +91,23 @@ describe('reducers/jurisdictions', () => {
         jurisdiction_id: 'abcde',
       });
     }
+  });
+
+  it('can remove jurisdictions from store', () => {
+    store.dispatch(removeJurisdictionsAction);
+    let jurisdictionsInStore = getJurisdictionsById(store.getState());
+    expect(jurisdictionsInStore).toEqual({});
+
+    store.dispatch(fetchJurisdictions([fixtures.jurisdiction3] as any));
+    let jurisdiction3FromStore = getJurisdictionById(store.getState(), 'abcde');
+    jurisdictionsInStore = getJurisdictionsById(store.getState());
+    expect(jurisdiction3FromStore).not.toBeNull();
+    expect(jurisdictionsInStore).not.toEqual({});
+
+    store.dispatch(removeJurisdictionsAction);
+    jurisdiction3FromStore = getJurisdictionById(store.getState(), 'abcde');
+    jurisdictionsInStore = getJurisdictionsById(store.getState());
+    expect(jurisdiction3FromStore).toBeNull();
+    expect(jurisdictionsInStore).toEqual({});
   });
 });

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -19,6 +19,7 @@ import reducer, {
   PlanRecord,
   PlanStatus,
   reducerName,
+  removePlansAction,
 } from '../plans';
 import * as fixtures from './fixtures';
 
@@ -141,5 +142,34 @@ describe('reducers/plans', () => {
       ]);
       expect(plan3FromStore).toEqual(fixtures.plan3);
     }
+  });
+  it('resets plansById records', () => {
+    store.dispatch(removePlansAction);
+    let numberOfPlansInStore = getPlansArray(store.getState(), undefined, []).length;
+    expect(numberOfPlansInStore).toEqual(0);
+
+    store.dispatch(fetchPlans([fixtures.plan3] as any));
+    numberOfPlansInStore = getPlansArray(store.getState(), undefined, []).length;
+    expect(numberOfPlansInStore).toEqual(1);
+
+    store.dispatch(removePlansAction);
+    numberOfPlansInStore = getPlansArray(store.getState(), undefined, []).length;
+    expect(numberOfPlansInStore).toEqual(0);
+  });
+
+  it('Concatenates new plans to existing plans after fetching', () => {
+    store.dispatch(removePlansAction);
+    let numberOfPlansInStore = getPlansArray(store.getState(), undefined, []).length;
+    expect(numberOfPlansInStore).toEqual(0);
+    store.dispatch(fetchPlans([fixtures.plan3] as any));
+    let plan3FromStore = getPlanById(store.getState(), '1502e539');
+    expect(plan3FromStore).not.toBeNull();
+    store.dispatch(fetchPlans([fixtures.plan99] as any));
+    plan3FromStore = getPlanById(store.getState(), '1502e539');
+    const plan99FromStore = getPlanById(store.getState(), '236ca3fb-1b74-5028-a0c8-ab954bb28044');
+    expect(plan3FromStore).not.toBeNull();
+    expect(plan99FromStore).not.toBeNull();
+    numberOfPlansInStore = getPlansArray(store.getState(), undefined, []).length;
+    expect(numberOfPlansInStore).toEqual(2);
   });
 });

--- a/src/store/ducks/tests/structures.test.ts
+++ b/src/store/ducks/tests/structures.test.ts
@@ -35,6 +35,7 @@ describe('reducers/tasks', () => {
   });
 
   it('should have all the properties inside structure', () => {
+    store.dispatch(removeStructuresAction);
     store.dispatch(setStructures(cloneDeep([fixtures.structure1])));
     const structure = store.getState().structures.structuresById;
     if (structure) {
@@ -102,7 +103,7 @@ describe('reducers/tasks', () => {
     });
   });
 
-  it('should add new structures to existing structures, no overwrite', () => {
+  it('should add new structures to existing structures, not overwrite', () => {
     store.dispatch(removeStructuresAction);
     let structuresinStore = getAllStructuresFC(store.getState());
     expect(structuresinStore).toEqual({

--- a/src/store/ducks/tests/structures.test.ts
+++ b/src/store/ducks/tests/structures.test.ts
@@ -101,6 +101,22 @@ describe('reducers/tasks', () => {
       type: FEATURE_COLLECTION,
     });
   });
+
+  it('should add new structures to existing structures, no overwrite', () => {
+    store.dispatch(removeStructuresAction);
+    let structuresinStore = getAllStructuresFC(store.getState());
+    expect(structuresinStore).toEqual({
+      features: [],
+      type: FEATURE_COLLECTION,
+    });
+
+    store.dispatch(setStructures(cloneDeep([fixtures.structure1])));
+    structuresinStore = getAllStructuresFC(store.getState());
+    expect(structuresinStore.features.length).toEqual(1);
+    store.dispatch(setStructures(cloneDeep([fixtures.structure2])));
+    structuresinStore = getAllStructuresFC(store.getState());
+    expect(structuresinStore.features.length).toEqual(2);
+  });
 });
 
 describe('reducers/structures/FeatureCollectionSelectors', () => {

--- a/src/store/ducks/tests/structures.test.ts
+++ b/src/store/ducks/tests/structures.test.ts
@@ -1,5 +1,6 @@
 import reducerRegistry from '@onaio/redux-reducer-registry';
 import { cloneDeep, keyBy } from 'lodash';
+import { FEATURE_COLLECTION } from '../../../constants';
 import { FeatureCollection } from '../../../helpers/utils';
 import store from '../../index';
 import reducer, {
@@ -7,6 +8,7 @@ import reducer, {
   getStructuresFCByJurisdictionId,
   getStructuresGeoJsonData,
   reducerName,
+  removeStructuresAction,
   setStructures,
   Structure,
   StructureGeoJSON,
@@ -31,6 +33,7 @@ describe('reducers/tasks', () => {
     const expectedStoreData = keyBy(fixtures.structures, (structure: Structure) => structure.id);
     expect(store.getState().structures.structuresById).toEqual(expectedStoreData);
   });
+
   it('should have all the properties inside structure', () => {
     store.dispatch(setStructures(cloneDeep([fixtures.structure1])));
     const structure = store.getState().structures.structuresById;
@@ -77,6 +80,26 @@ describe('reducers/tasks', () => {
     store.dispatch(setStructures(cloneDeep(fixtures.structures)));
     const expected = cloneDeep([fixtures.structure1.geojson, fixtures.structure2.geojson]);
     expect(getStructuresGeoJsonData(store.getState(), false)).toEqual(expected);
+  });
+
+  it('should reset structures', () => {
+    store.dispatch(removeStructuresAction);
+    let structuresinStore = getAllStructuresFC(store.getState());
+    expect(structuresinStore).toEqual({
+      features: [],
+      type: FEATURE_COLLECTION,
+    });
+
+    store.dispatch(setStructures(cloneDeep(fixtures.structures)));
+    const expected = cloneDeep([fixtures.structure1.geojson, fixtures.structure2.geojson]);
+    expect(getStructuresGeoJsonData(store.getState(), false)).toEqual(expected);
+
+    store.dispatch(removeStructuresAction);
+    structuresinStore = getAllStructuresFC(store.getState());
+    expect(structuresinStore).toEqual({
+      features: [],
+      type: FEATURE_COLLECTION,
+    });
   });
 });
 

--- a/src/store/ducks/tests/tasks.test.ts
+++ b/src/store/ducks/tests/tasks.test.ts
@@ -1,3 +1,4 @@
+import { initialState } from '@onaio/gatekeeper/dist/types/ducks/gatekeeper';
 import reducerRegistry from '@onaio/redux-reducer-registry';
 import { cloneDeep, keyBy, values } from 'lodash';
 import { FlushThunks } from 'redux-testkit';
@@ -28,7 +29,7 @@ import reducer, {
   getTasksIdArray,
   InitialTaskGeoJSON,
   reducerName,
-  resetTasks,
+  removeTasksAction,
   Task,
 } from '../tasks';
 import * as fixtures from './fixtures';
@@ -44,7 +45,7 @@ describe('reducers/tasks', () => {
   });
 
   afterEach(() => {
-    store.dispatch(resetTasks());
+    store.dispatch(removeTasksAction);
   });
 
   it('should have initial state', () => {
@@ -152,6 +153,33 @@ describe('reducers/tasks', () => {
       });
     }
   });
+
+  it('removes tasks correctly', () => {
+    store.dispatch(removeTasksAction);
+    let tasksInStore = getTasksById(store.getState());
+    expect(tasksInStore).toEqual({});
+
+    store.dispatch(fetchTasks([fixtures.task1]));
+    tasksInStore = getTasksById(store.getState());
+    expect(tasksInStore).not.toEqual({});
+
+    store.dispatch(removeTasksAction);
+    tasksInStore = getTasksById(store.getState());
+    expect(tasksInStore).toEqual({});
+  });
+
+  it('Tasks do not overwrite existing tasks', () => {
+    store.dispatch(removeTasksAction);
+    const tasksInStore = getTasksById(store.getState());
+    expect(tasksInStore).toEqual({});
+
+    store.dispatch(fetchTasks([fixtures.task1]));
+    let tasksNumberInStore = getTasksArray(store.getState()).length;
+    expect(tasksNumberInStore).toEqual(1);
+    store.dispatch(fetchTasks([fixtures.task2]));
+    tasksNumberInStore = getTasksArray(store.getState()).length;
+    expect(tasksNumberInStore).toEqual(2);
+  });
 });
 
 // goeJSON Feature Collection selectors tests
@@ -164,7 +192,7 @@ describe('reducers/tasks/FeatureCollectionSelectors', () => {
   });
 
   afterEach(() => {
-    store.dispatch(resetTasks());
+    store.dispatch(removeTasksAction);
   });
 
   it('works for initial state', () => {


### PR DESCRIPTION
Tests to check if payloads from dispatched actions replace the existing records. The expected behavior is that new dispatched records should be added to existing records if the record was not in the store. 

closes #289 