### PR TITLE
Add Page to Edit Plans

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "bootstrap": "^4.2.1",
     "client-oauth2": "^4.2.3",
     "connected-react-router": "^6.4.0",
-    "date-fns": "^1.30.1",
     "formik": "^1.5.8",
     "gisida": "^1.2.5",
     "gisida-react": "^1.2.8",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "bootstrap": "^4.2.1",
     "client-oauth2": "^4.2.3",
     "connected-react-router": "^6.4.0",
+    "date-fns": "^1.30.1",
     "formik": "^1.5.8",
     "gisida": "^1.2.5",
     "gisida-react": "^1.2.8",

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -21,6 +21,7 @@ import {
   LOGOUT_URL,
   NEW_PLAN_URL,
   PLAN_LIST_URL,
+  PLAN_UPDATE_URL,
 } from '../constants';
 import ConnectedHeader from '../containers/ConnectedHeader';
 import ActiveFocusInvestigation from '../containers/pages/FocusInvestigation/active';
@@ -32,6 +33,7 @@ import IrsPlans from '../containers/pages/InterventionPlan/IRS';
 import IrsPlan from '../containers/pages/InterventionPlan/IRS/plan';
 import NewPlan from '../containers/pages/InterventionPlan/NewPlan';
 import ConnectedPlanDefinitionList from '../containers/pages/InterventionPlan/PlanDefinitionList';
+import ConnectedUpdatePlan from '../containers/pages/InterventionPlan/UpdatePlan';
 import { oAuthUserInfoGetter } from '../helpers/utils';
 
 library.add(faMap);
@@ -125,6 +127,12 @@ class App extends Component {
                 exact={true}
                 path={NEW_PLAN_URL}
                 component={NewPlan}
+              />
+              <ConnectedPrivateRoute
+                disableLoginProtection={DISABLE_LOGIN_PROTECTION}
+                exact={true}
+                path={`${PLAN_UPDATE_URL}/:id`}
+                component={ConnectedUpdatePlan}
               />
               <ConnectedPrivateRoute
                 disableLoginProtection={DISABLE_LOGIN_PROTECTION}

--- a/src/configs/env.ts
+++ b/src/configs/env.ts
@@ -136,6 +136,9 @@ export type IRS_PLAN_COUNTRIES = typeof IRS_PLAN_COUNTRIES;
 export const DATE_FORMAT = process.env.REACT_APP_DATE_FORMAT || 'yyyy-MM-dd';
 export type DATE_FORMAT = typeof DATE_FORMAT;
 
+export const DEFAULT_TIME = process.env.REACT_APP_DEFAULT_TIME || 'T00:00:00+00:00';
+export type DEFAULT_TIME = typeof DEFAULT_TIME;
+
 export const DEFAULT_PLAN_DURATION_DAYS = process.env.REACT_APP_DEFAULT_PLAN_DURATION_DAYS || 20;
 export type DEFAULT_PLAN_DURATION_DAYS = typeof DEFAULT_PLAN_DURATION_DAYS;
 

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -144,6 +144,8 @@ export const NEW_PLAN_URL = '/plans/new';
 export type NEW_PLAN_URL = typeof NEW_PLAN_URL;
 export const PLAN_LIST_URL = '/plans/list';
 export type PLAN_LIST_URL = typeof PLAN_LIST_URL;
+export const PLAN_UPDATE_URL = '/plans/update';
+export type PLAN_UPDATE_URL = typeof PLAN_UPDATE_URL;
 
 // OpenSRP API strings
 export const OPENSRP_FIND_BY_PROPERTIES = 'findByProperties';

--- a/src/containers/forms/PlanForm/helpers.ts
+++ b/src/containers/forms/PlanForm/helpers.ts
@@ -33,7 +33,7 @@ import {
   PlanGoalTarget,
   UseContext,
 } from '../../../configs/settings';
-import { DATE, IRS_TITLE, IS, NAME, REQUIRED } from '../../../constants';
+import { DATE, IS, NAME, REQUIRED } from '../../../constants';
 import { generateNameSpacedUUID } from '../../../helpers/utils';
 import { InterventionType, PlanStatus } from '../../../store/ducks/plans';
 

--- a/src/containers/forms/PlanForm/helpers.ts
+++ b/src/containers/forms/PlanForm/helpers.ts
@@ -460,12 +460,12 @@ export function generatePlanDefinition(
     },
   ];
 
-  if (formValue.fiReason) {
-    useContext.push({ code: 'fiReason', valueCodableConcept: formValue.fiReason });
-  }
-
   if (formValue.fiStatus) {
     useContext.push({ code: 'fiStatus', valueCodableConcept: formValue.fiStatus });
+  }
+
+  if (formValue.fiReason) {
+    useContext.push({ code: 'fiReason', valueCodableConcept: formValue.fiReason });
   }
 
   if (formValue.caseNum) {

--- a/src/containers/forms/PlanForm/helpers.ts
+++ b/src/containers/forms/PlanForm/helpers.ts
@@ -216,42 +216,96 @@ export function extractActivitiesFromPlanForm(
   activities.forEach((element, index) => {
     const prefix = index + 1;
     if (PlanActionCodes.includes(element.actionCode as PlanActionCodesType)) {
+      const planActionGoal = (planObj &&
+        getActivityFromPlan(planObj, element.actionCode as PlanActionCodesType)) || {
+        action: {},
+        goal: {},
+      };
+
       // we must declare them with some value. BCC chosen randomly here
       let thisAction: PlanAction = planActivities.BCC.action;
       let thisGoal: PlanGoal = planActivities.BCC.goal;
 
       // first populate with default values
       if (element.actionCode === 'BCC') {
-        thisAction = planActivities.BCC.action;
-        thisGoal = planActivities.BCC.goal;
+        thisAction = {
+          ...planActivities.BCC.action,
+          ...planActionGoal.action,
+        };
+        thisGoal = {
+          ...planActivities.BCC.goal,
+          ...planActionGoal.goal,
+        };
       }
       if (element.actionCode === 'IRS') {
-        thisAction = planActivities.IRS.action;
-        thisGoal = planActivities.IRS.goal;
+        thisAction = {
+          ...planActivities.IRS.action,
+          ...planActionGoal.action,
+        };
+        thisGoal = {
+          ...planActivities.IRS.goal,
+          ...planActionGoal.goal,
+        };
       }
       if (element.actionCode === 'Bednet Distribution') {
-        thisAction = planActivities.bednetDistribution.action;
-        thisGoal = planActivities.bednetDistribution.goal;
+        thisAction = {
+          ...planActivities.bednetDistribution.action,
+          ...planActionGoal.action,
+        };
+        thisGoal = {
+          ...planActivities.bednetDistribution.goal,
+          ...planActionGoal.goal,
+        };
       }
       if (element.actionCode === 'Blood Screening') {
-        thisAction = planActivities.bloodScreening.action;
-        thisGoal = planActivities.bloodScreening.goal;
+        thisAction = {
+          ...planActivities.bloodScreening.action,
+          ...planActionGoal.action,
+        };
+        thisGoal = {
+          ...planActivities.bloodScreening.goal,
+          ...planActionGoal.goal,
+        };
       }
       if (element.actionCode === 'Case Confirmation') {
-        thisAction = planActivities.caseConfirmation.action;
-        thisGoal = planActivities.caseConfirmation.goal;
+        thisAction = {
+          ...planActivities.caseConfirmation.action,
+          ...planActionGoal.action,
+        };
+        thisGoal = {
+          ...planActivities.caseConfirmation.goal,
+          ...planActionGoal.goal,
+        };
       }
       if (element.actionCode === 'RACD Register Family') {
-        thisAction = planActivities.familyRegistration.action;
-        thisGoal = planActivities.familyRegistration.goal;
+        thisAction = {
+          ...planActivities.familyRegistration.action,
+          ...planActionGoal.action,
+        };
+        thisGoal = {
+          ...planActivities.familyRegistration.goal,
+          ...planActionGoal.goal,
+        };
       }
       if (element.actionCode === 'Larval Dipping') {
-        thisAction = planActivities.larvalDipping.action;
-        thisGoal = planActivities.larvalDipping.goal;
+        thisAction = {
+          ...planActivities.larvalDipping.action,
+          ...planActionGoal.action,
+        };
+        thisGoal = {
+          ...planActivities.larvalDipping.goal,
+          ...planActionGoal.goal,
+        };
       }
       if (element.actionCode === 'Mosquito Collection') {
-        thisAction = planActivities.mosquitoCollection.action;
-        thisGoal = planActivities.mosquitoCollection.goal;
+        thisAction = {
+          ...planActivities.mosquitoCollection.action,
+          ...planActionGoal.action,
+        };
+        thisGoal = {
+          ...planActivities.mosquitoCollection.goal,
+          ...planActionGoal.goal,
+        };
       }
 
       const thisActionIdentifier =
@@ -383,7 +437,10 @@ export function doesFieldHaveErrors(
  * @param formValue - the value gotten from the PlanForm
  * @returns {PlanDefinition} - the plan definition object
  */
-export function generatePlanDefinition(formValue: PlanFormFields): PlanDefinition {
+export function generatePlanDefinition(
+  formValue: PlanFormFields,
+  planObj: PlanDefinition | null = null
+): PlanDefinition {
   const planIdentifier =
     formValue.identifier && formValue.identifier !== '' // is this an existing plan?
       ? formValue.identifier
@@ -420,7 +477,11 @@ export function generatePlanDefinition(formValue: PlanFormFields): PlanDefinitio
   }
 
   return {
-    ...extractActivitiesFromPlanForm(formValue.activities), // action and goal
+    ...extractActivitiesFromPlanForm(
+      formValue.activities,
+      planObj ? planObj.identifier : '',
+      planObj
+    ), // action and goal
     date: moment(formValue.date).format(DATE_FORMAT.toUpperCase()),
     effectivePeriod: {
       end: moment(formValue.end).format(DATE_FORMAT.toUpperCase()),

--- a/src/containers/forms/PlanForm/helpers.ts
+++ b/src/containers/forms/PlanForm/helpers.ts
@@ -177,13 +177,38 @@ export function getFormActivities(items: typeof FIActivities | typeof IRSActivit
 }
 
 /**
+ * Get a plan activity from a plan definition object
+ * @param {PlanDefinition} planObj - the plan definition
+ * @param {PlanActionCodesType} actionCode - the action code
+ * @returns {PlanActivity | null} - the plan activity or null
+ */
+export function getActivityFromPlan(
+  planObj: PlanDefinition,
+  actionCode: PlanActionCodesType
+): PlanActivity | null {
+  const actions = planObj.action.filter(e => e.code === actionCode);
+  if (actions.length > 0) {
+    const goals = planObj.goal.filter(e => e.id === actions[0].goalId);
+    if (goals.length > 0) {
+      return {
+        action: actions[0],
+        goal: goals[0],
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
  * Get action and plans from PlanForm activities
  * @param {PlanActivityFormFields[]} activities - this of activities from PlanForm
  * @param {string} planIdentifier - this plan identifier
  */
 export function extractActivitiesFromPlanForm(
   activities: PlanActivityFormFields[],
-  planIdentifier: string = ''
+  planIdentifier: string = '',
+  planObj: PlanDefinition | null = null
 ) {
   const actions: PlanAction[] = [];
   const goals: PlanGoal[] = [];

--- a/src/containers/forms/PlanForm/helpers.ts
+++ b/src/containers/forms/PlanForm/helpers.ts
@@ -428,23 +428,6 @@ export function getPlanFormValues(planObject: PlanDefinition): PlanFormFields {
       ? (typeUseContext[0].valueCodableConcept as InterventionType)
       : InterventionType.FI;
 
-  // const defaultActivities =
-  //   interventionType === InterventionType.IRS
-  //     ? getFormActivities(IRSActivities)
-  //     : getFormActivities(FIActivities);
-
-  // const activities: PlanActivityFormFields[] = defaultActivities;
-  // let result: PlanActivityFormFields[] = [];
-
-  // const x = planObject.action.map((currentAction) => {
-  //   const goalArray = planObject.goal.filter(goal => goal.id === currentAction.goalId);
-  //   if (goalArray.length > 0) {
-
-  //   }
-  //   const currentActivitry = extractActivityForForm({action: currentAction, goal: goalArray[0]})
-  //   return result.push(currentActivitry);
-  // })
-
   let activities = planObject.action.reduce(
     (accumulator: PlanActivityFormFields[], currentAction) => {
       const goalArray = planObject.goal.filter(goal => goal.id === currentAction.goalId);
@@ -466,16 +449,6 @@ export function getPlanFormValues(planObject: PlanDefinition): PlanFormFields {
         ? getFormActivities(IRSActivities)
         : getFormActivities(FIActivities);
   }
-
-  // const activities: PlanActivityFormFields[] = planObject.action.map(action => {
-  //   const goalArray = planObject.goal.filter(goal => goal.id === action.goalId);
-  //   if (goalArray.length > 0) {
-  //     const goalActivities = goalArray.map(goal => ({ action, goal }));
-  //     return defaultActivities;
-  //   } else {
-  //     return defaultActivities;
-  //   }
-  // })
 
   return {
     activities,

--- a/src/containers/forms/PlanForm/helpers.ts
+++ b/src/containers/forms/PlanForm/helpers.ts
@@ -147,7 +147,7 @@ export function extractActivityForForm(activityObj: PlanActivity): PlanActivityF
     goalDescription: activityObj.goal.description || '',
     goalDue:
       activityObj.goal.target[0].due && activityObj.goal.target[0].due !== ''
-        ? moment(activityObj.goal.target[0].due).toDate()
+        ? parseISO(`${activityObj.goal.target[0].due}${DEFAULT_TIME}`)
         : moment()
             .add(DEFAULT_ACTIVITY_DURATION_DAYS, 'days')
             .toDate(),
@@ -155,13 +155,13 @@ export function extractActivityForForm(activityObj: PlanActivity): PlanActivityF
     goalValue: activityObj.goal.target[0].detail.detailQuantity.value || 0,
     timingPeriodEnd:
       activityObj.action.timingPeriod.end && activityObj.action.timingPeriod.end !== ''
-        ? moment(activityObj.action.timingPeriod.end).toDate()
+        ? parseISO(`${activityObj.action.timingPeriod.end}${DEFAULT_TIME}`)
         : moment()
             .add(DEFAULT_ACTIVITY_DURATION_DAYS, 'days')
             .toDate(),
     timingPeriodStart:
       activityObj.action.timingPeriod.start && activityObj.action.timingPeriod.start !== ''
-        ? moment(activityObj.action.timingPeriod.start).toDate()
+        ? parseISO(`${activityObj.action.timingPeriod.start}${DEFAULT_TIME}`)
         : moment().toDate(),
   };
 }

--- a/src/containers/forms/PlanForm/helpers.ts
+++ b/src/containers/forms/PlanForm/helpers.ts
@@ -1,3 +1,4 @@
+import { parseISO } from 'date-fns';
 import { FormikErrors } from 'formik';
 import { omit, pick } from 'lodash';
 import moment from 'moment';
@@ -8,6 +9,7 @@ import {
   DATE_FORMAT,
   DEFAULT_ACTIVITY_DURATION_DAYS,
   DEFAULT_PLAN_VERSION,
+  DEFAULT_TIME,
   PLAN_UUID_NAMESPACE,
 } from '../../../configs/env';
 import {
@@ -453,8 +455,8 @@ export function getPlanFormValues(planObject: PlanDefinition): PlanFormFields {
   return {
     activities,
     caseNum: caseNumUseContext.length > 0 ? caseNumUseContext[0].valueCodableConcept : '',
-    date: moment(planObject.date).toDate(),
-    end: moment(planObject.effectivePeriod.end).toDate(),
+    date: parseISO(`${planObject.date}${DEFAULT_TIME}`),
+    end: parseISO(`${planObject.effectivePeriod.end}${DEFAULT_TIME}`),
     fiReason:
       reasonUseContext.length > 0
         ? (reasonUseContext[0].valueCodableConcept as FIReasonType)
@@ -472,7 +474,7 @@ export function getPlanFormValues(planObject: PlanDefinition): PlanFormFields {
     name: planObject.name,
     opensrpEventId:
       eventIdUseContext.length > 0 ? eventIdUseContext[0].valueCodableConcept : undefined,
-    start: moment(planObject.effectivePeriod.start).toDate(),
+    start: parseISO(`${planObject.effectivePeriod.start}${DEFAULT_TIME}`),
     status: planObject.status as PlanStatus,
     title: planObject.title,
     version: planObject.version,

--- a/src/containers/forms/PlanForm/helpers.ts
+++ b/src/containers/forms/PlanForm/helpers.ts
@@ -179,6 +179,7 @@ export function getFormActivities(items: typeof FIActivities | typeof IRSActivit
 /**
  * Get action and plans from PlanForm activities
  * @param {PlanActivityFormFields[]} activities - this of activities from PlanForm
+ * @param {string} planIdentifier - this plan identifier
  */
 export function extractActivitiesFromPlanForm(
   activities: PlanActivityFormFields[],
@@ -193,6 +194,7 @@ export function extractActivitiesFromPlanForm(
       // we must declare them with some value. BCC chosen randomly here
       let thisAction: PlanAction = planActivities.BCC.action;
       let thisGoal: PlanGoal = planActivities.BCC.goal;
+
       // first populate with default values
       if (element.actionCode === 'BCC') {
         thisAction = planActivities.BCC.action;

--- a/src/containers/forms/PlanForm/index.tsx
+++ b/src/containers/forms/PlanForm/index.tsx
@@ -74,6 +74,13 @@ const PlanForm = (props: PlanFormProps) => {
   const { disabledActivityFields, disabledFields, initialValues, redirectAfterAction } = props;
   const editMode: boolean = initialValues.identifier !== '';
 
+  const disAllowedStatusChoices: string[] = [];
+  if (editMode) {
+    if (initialValues.status !== PlanStatus.DRAFT) {
+      disAllowedStatusChoices.push(PlanStatus.DRAFT);
+    }
+  }
+
   return (
     <div className="form-container">
       {areWeDoneHere === true && <Redirect to={redirectAfterAction} />}
@@ -362,11 +369,13 @@ const PlanForm = (props: PlanFormProps) => {
                 disabled={disabledFields.includes('status')}
                 className={errors.status ? 'form-control is-invalid' : 'form-control'}
               >
-                {Object.entries(PlanStatus).map(e => (
-                  <option key={e[0]} value={e[1]}>
-                    {e[1]}
-                  </option>
-                ))}
+                {Object.entries(PlanStatus)
+                  .filter(e => !disAllowedStatusChoices.includes(e[1]))
+                  .map(e => (
+                    <option key={e[0]} value={e[1]}>
+                      {e[1]}
+                    </option>
+                  ))}
               </Field>
               <ErrorMessage name="status" component="small" className="form-text text-danger" />
             </FormGroup>

--- a/src/containers/forms/PlanForm/index.tsx
+++ b/src/containers/forms/PlanForm/index.tsx
@@ -153,92 +153,96 @@ const PlanForm = (props: PlanFormProps) => {
             </FormGroup>
 
             <h5 className="mt-5">Locations</h5>
-            <FieldArray
-              name="jurisdictions"
-              /* tslint:disable-next-line jsx-no-lambda */
-              render={arrayHelpers => (
-                <div className="mb-5">
-                  {values.jurisdictions.map((jurisdiction, index) => (
-                    <fieldset key={index}>
-                      {errors.jurisdictions && errors.jurisdictions[index] && (
-                        <div className="alert alert-danger" role="alert">
-                          <h6 className="alert-heading">Please fix these errors</h6>
-                          <ul className="list-unstyled">
-                            {Object.entries(errors.jurisdictions[index] || {}).map(([key, val]) => (
-                              <li key={key}>
-                                <strong>Focus Area</strong>: {val}
-                              </li>
-                            ))}
-                          </ul>
-                        </div>
-                      )}
-                      <div className="jurisdiction-item position-relative">
-                        {values.jurisdictions && values.jurisdictions.length > 1 && (
-                          <button
-                            type="button"
-                            className="close position-absolute removeArrItem removeJurisdiction"
-                            aria-label="Close"
-                            onClick={() => arrayHelpers.remove(index)}
-                          >
-                            <span aria-hidden="true">&times;</span>
-                          </button>
+            <div id="jurisdictions-select-container">
+              <FieldArray
+                name="jurisdictions"
+                /* tslint:disable-next-line jsx-no-lambda */
+                render={arrayHelpers => (
+                  <div className="mb-5">
+                    {values.jurisdictions.map((jurisdiction, index) => (
+                      <fieldset key={index}>
+                        {errors.jurisdictions && errors.jurisdictions[index] && (
+                          <div className="alert alert-danger" role="alert">
+                            <h6 className="alert-heading">Please fix these errors</h6>
+                            <ul className="list-unstyled">
+                              {Object.entries(errors.jurisdictions[index] || {}).map(
+                                ([key, val]) => (
+                                  <li key={key}>
+                                    <strong>Focus Area</strong>: {val}
+                                  </li>
+                                )
+                              )}
+                            </ul>
+                          </div>
                         )}
-                        <FormGroup
-                          className={
-                            errors.jurisdictions &&
-                            doesFieldHaveErrors('id', index, errors.jurisdictions)
-                              ? 'is-invalid async-select-container'
-                              : 'async-select-container'
-                          }
-                        >
-                          <Label for={`jurisdictions-${index}-id`}>Focus Area</Label>
-                          <Field
-                            required={true}
-                            component={JurisdictionSelect}
-                            name={`jurisdictions[${index}].id`}
-                            id={`jurisdictions-${index}-id`}
-                            placeholder="Select Focus Area"
-                            aria-label="Select Focus Area"
-                            disabled={disabledFields.includes('jurisdictions')}
+                        <div className="jurisdiction-item position-relative">
+                          {values.jurisdictions && values.jurisdictions.length > 1 && (
+                            <button
+                              type="button"
+                              className="close position-absolute removeArrItem removeJurisdiction"
+                              aria-label="Close"
+                              onClick={() => arrayHelpers.remove(index)}
+                            >
+                              <span aria-hidden="true">&times;</span>
+                            </button>
+                          )}
+                          <FormGroup
                             className={
                               errors.jurisdictions &&
                               doesFieldHaveErrors('id', index, errors.jurisdictions)
-                                ? 'is-invalid async-select'
-                                : 'async-select'
+                                ? 'is-invalid async-select-container'
+                                : 'async-select-container'
                             }
-                            labelFieldName={`jurisdictions[${index}].name`}
-                          />
-                          <Field
-                            type="hidden"
-                            name={`jurisdictions[${index}].name`}
-                            id={`jurisdictions-${index}-name`}
-                          />
+                          >
+                            <Label for={`jurisdictions-${index}-id`}>Focus Area</Label>
+                            <Field
+                              required={true}
+                              component={JurisdictionSelect}
+                              name={`jurisdictions[${index}].id`}
+                              id={`jurisdictions-${index}-id`}
+                              placeholder="Select Focus Area"
+                              aria-label="Select Focus Area"
+                              disabled={disabledFields.includes('jurisdictions')}
+                              className={
+                                errors.jurisdictions &&
+                                doesFieldHaveErrors('id', index, errors.jurisdictions)
+                                  ? 'is-invalid async-select'
+                                  : 'async-select'
+                              }
+                              labelFieldName={`jurisdictions[${index}].name`}
+                            />
+                            <Field
+                              type="hidden"
+                              name={`jurisdictions[${index}].name`}
+                              id={`jurisdictions-${index}-name`}
+                            />
 
-                          {errors.jurisdictions && errors.jurisdictions[index] && (
-                            <small className="form-text text-danger">An Error Ocurred</small>
-                          )}
+                            {errors.jurisdictions && errors.jurisdictions[index] && (
+                              <small className="form-text text-danger">An Error Ocurred</small>
+                            )}
 
-                          <ErrorMessage
-                            name={`jurisdictions[${index}].id`}
-                            component="small"
-                            className="form-text text-danger"
-                          />
-                        </FormGroup>
-                      </div>
-                    </fieldset>
-                  ))}
-                  {values.interventionType === InterventionType.IRS && (
-                    <button
-                      type="button"
-                      className="btn btn-primary btn-sm mb-5 addJurisdiction"
-                      onClick={() => arrayHelpers.push(initialJurisdictionValues)}
-                    >
-                      Add Focus Area
-                    </button>
-                  )}
-                </div>
-              )}
-            />
+                            <ErrorMessage
+                              name={`jurisdictions[${index}].id`}
+                              component="small"
+                              className="form-text text-danger"
+                            />
+                          </FormGroup>
+                        </div>
+                      </fieldset>
+                    ))}
+                    {values.interventionType === InterventionType.IRS && (
+                      <button
+                        type="button"
+                        className="btn btn-primary btn-sm mb-5 addJurisdiction"
+                        onClick={() => arrayHelpers.push(initialJurisdictionValues)}
+                      >
+                        Add Focus Area
+                      </button>
+                    )}
+                  </div>
+                )}
+              />
+            </div>
 
             {values.interventionType === InterventionType.FI && (
               <FormGroup>

--- a/src/containers/forms/PlanForm/index.tsx
+++ b/src/containers/forms/PlanForm/index.tsx
@@ -72,6 +72,8 @@ const PlanForm = (props: PlanFormProps) => {
   const [areWeDoneHere, setAreWeDoneHere] = useState<boolean>(false);
 
   const { disabledFields, initialValues, redirectAfterAction } = props;
+  const editMode: boolean = initialValues.identifier !== '';
+
   return (
     <div className="form-container">
       {areWeDoneHere === true && <Redirect to={redirectAfterAction} />}
@@ -153,96 +155,101 @@ const PlanForm = (props: PlanFormProps) => {
             </FormGroup>
 
             <h5 className="mt-5">Locations</h5>
-            <div id="jurisdictions-select-container">
-              <FieldArray
-                name="jurisdictions"
-                /* tslint:disable-next-line jsx-no-lambda */
-                render={arrayHelpers => (
-                  <div className="mb-5">
-                    {values.jurisdictions.map((jurisdiction, index) => (
-                      <fieldset key={index}>
-                        {errors.jurisdictions && errors.jurisdictions[index] && (
-                          <div className="alert alert-danger" role="alert">
-                            <h6 className="alert-heading">Please fix these errors</h6>
-                            <ul className="list-unstyled">
-                              {Object.entries(errors.jurisdictions[index] || {}).map(
-                                ([key, val]) => (
-                                  <li key={key}>
-                                    <strong>Focus Area</strong>: {val}
-                                  </li>
-                                )
-                              )}
-                            </ul>
-                          </div>
-                        )}
-                        <div className="jurisdiction-item position-relative">
-                          {values.jurisdictions && values.jurisdictions.length > 1 && (
-                            <button
-                              type="button"
-                              className="close position-absolute removeArrItem removeJurisdiction"
-                              aria-label="Close"
-                              onClick={() => arrayHelpers.remove(index)}
-                            >
-                              <span aria-hidden="true">&times;</span>
-                            </button>
-                          )}
-                          <FormGroup
-                            className={
-                              errors.jurisdictions &&
-                              doesFieldHaveErrors('id', index, errors.jurisdictions)
-                                ? 'is-invalid async-select-container'
-                                : 'async-select-container'
-                            }
-                          >
-                            <Label for={`jurisdictions-${index}-id`}>Focus Area</Label>
-                            <Field
-                              required={true}
-                              component={JurisdictionSelect}
-                              name={`jurisdictions[${index}].id`}
-                              id={`jurisdictions-${index}-id`}
-                              placeholder="Select Focus Area"
-                              aria-label="Select Focus Area"
-                              disabled={disabledFields.includes('jurisdictions')}
-                              className={
-                                errors.jurisdictions &&
-                                doesFieldHaveErrors('id', index, errors.jurisdictions)
-                                  ? 'is-invalid async-select'
-                                  : 'async-select'
-                              }
-                              labelFieldName={`jurisdictions[${index}].name`}
-                            />
-                            <Field
-                              type="hidden"
-                              name={`jurisdictions[${index}].name`}
-                              id={`jurisdictions-${index}-name`}
-                            />
 
+            <FieldArray
+              name="jurisdictions"
+              /* tslint:disable-next-line jsx-no-lambda */
+              render={arrayHelpers => (
+                <div>
+                  {editMode !== true && (
+                    <div id="jurisdictions-select-container">
+                      <div className="mb-5">
+                        {values.jurisdictions.map((jurisdiction, index) => (
+                          <fieldset key={index}>
                             {errors.jurisdictions && errors.jurisdictions[index] && (
-                              <small className="form-text text-danger">An Error Ocurred</small>
+                              <div className="alert alert-danger" role="alert">
+                                <h6 className="alert-heading">Please fix these errors</h6>
+                                <ul className="list-unstyled">
+                                  {Object.entries(errors.jurisdictions[index] || {}).map(
+                                    ([key, val]) => (
+                                      <li key={key}>
+                                        <strong>Focus Area</strong>: {val}
+                                      </li>
+                                    )
+                                  )}
+                                </ul>
+                              </div>
                             )}
+                            <div className="jurisdiction-item position-relative">
+                              {values.jurisdictions && values.jurisdictions.length > 1 && (
+                                <button
+                                  type="button"
+                                  className="close position-absolute removeArrItem removeJurisdiction"
+                                  aria-label="Close"
+                                  onClick={() => arrayHelpers.remove(index)}
+                                >
+                                  <span aria-hidden="true">&times;</span>
+                                </button>
+                              )}
+                              <FormGroup
+                                className={
+                                  errors.jurisdictions &&
+                                  doesFieldHaveErrors('id', index, errors.jurisdictions)
+                                    ? 'is-invalid async-select-container'
+                                    : 'async-select-container'
+                                }
+                              >
+                                <Label for={`jurisdictions-${index}-id`}>Focus Area</Label>
+                                <Field
+                                  required={true}
+                                  component={JurisdictionSelect}
+                                  name={`jurisdictions[${index}].id`}
+                                  id={`jurisdictions-${index}-id`}
+                                  placeholder="Select Focus Area"
+                                  aria-label="Select Focus Area"
+                                  disabled={disabledFields.includes('jurisdictions')}
+                                  className={
+                                    errors.jurisdictions &&
+                                    doesFieldHaveErrors('id', index, errors.jurisdictions)
+                                      ? 'is-invalid async-select'
+                                      : 'async-select'
+                                  }
+                                  labelFieldName={`jurisdictions[${index}].name`}
+                                />
+                                <Field
+                                  type="hidden"
+                                  name={`jurisdictions[${index}].name`}
+                                  id={`jurisdictions-${index}-name`}
+                                />
 
-                            <ErrorMessage
-                              name={`jurisdictions[${index}].id`}
-                              component="small"
-                              className="form-text text-danger"
-                            />
-                          </FormGroup>
-                        </div>
-                      </fieldset>
-                    ))}
-                    {values.interventionType === InterventionType.IRS && (
-                      <button
-                        type="button"
-                        className="btn btn-primary btn-sm mb-5 addJurisdiction"
-                        onClick={() => arrayHelpers.push(initialJurisdictionValues)}
-                      >
-                        Add Focus Area
-                      </button>
-                    )}
-                  </div>
-                )}
-              />
-            </div>
+                                {errors.jurisdictions && errors.jurisdictions[index] && (
+                                  <small className="form-text text-danger">An Error Ocurred</small>
+                                )}
+
+                                <ErrorMessage
+                                  name={`jurisdictions[${index}].id`}
+                                  component="small"
+                                  className="form-text text-danger"
+                                />
+                              </FormGroup>
+                            </div>
+                          </fieldset>
+                        ))}
+                        {values.interventionType === InterventionType.IRS && (
+                          <button
+                            type="button"
+                            className="btn btn-primary btn-sm mb-5 addJurisdiction"
+                            onClick={() => arrayHelpers.push(initialJurisdictionValues)}
+                          >
+                            Add Focus Area
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            />
 
             {values.interventionType === InterventionType.FI && (
               <FormGroup>

--- a/src/containers/forms/PlanForm/index.tsx
+++ b/src/containers/forms/PlanForm/index.tsx
@@ -6,7 +6,6 @@ import { Button, FormGroup, Label } from 'reactstrap';
 import DatePickerWrapper from '../../../components/DatePickerWrapper';
 import {
   DATE_FORMAT,
-  DEFAULT_ACTIVITY_DURATION_DAYS,
   DEFAULT_PLAN_DURATION_DAYS,
   DEFAULT_PLAN_VERSION,
 } from '../../../configs/env';

--- a/src/containers/forms/PlanForm/index.tsx
+++ b/src/containers/forms/PlanForm/index.tsx
@@ -91,15 +91,27 @@ const PlanForm = (props: PlanFormProps) => {
           const payload = generatePlanDefinition(values);
           const apiService = new OpenSRPService('/plans');
 
-          apiService
-            .create(payload)
-            .then(() => {
-              setSubmitting(false);
-              setAreWeDoneHere(true);
-            })
-            .catch((e: Error) => {
-              setGlobalError(e.message);
-            });
+          if (editMode) {
+            apiService
+              .update(payload)
+              .then(() => {
+                setSubmitting(false);
+                setAreWeDoneHere(true);
+              })
+              .catch((e: Error) => {
+                setGlobalError(e.message);
+              });
+          } else {
+            apiService
+              .create(payload)
+              .then(() => {
+                setSubmitting(false);
+                setAreWeDoneHere(true);
+              })
+              .catch((e: Error) => {
+                setGlobalError(e.message);
+              });
+          }
         }}
         validationSchema={PlanSchema}
       >

--- a/src/containers/forms/PlanForm/index.tsx
+++ b/src/containers/forms/PlanForm/index.tsx
@@ -163,24 +163,29 @@ const PlanForm = (props: PlanFormProps) => {
                 <div>
                   {editMode ? (
                     <div id="jurisdictions-display-container" className="mb-5">
-                      {values.jurisdictions.map((jurisdiction, index) => (
-                        <fieldset key={index}>
-                          <Field
-                            type="hidden"
-                            readOnly={true}
-                            name={`jurisdictions[${index}].id`}
-                            id={`jurisdictions-${index}-id`}
-                            value={jurisdiction.id}
-                          />
-                          <Field
-                            type="hidden"
-                            readOnly={true}
-                            name={`jurisdictions[${index}].name`}
-                            id={`jurisdictions-${index}-name`}
-                            value={jurisdiction.name}
-                          />
-                        </fieldset>
-                      ))}
+                      <ul id="selected-jurisdiction-list">
+                        {values.jurisdictions.map((jurisdiction, index) => (
+                          <li key={index}>
+                            <span>{jurisdiction.name}</span>
+                            <fieldset>
+                              <Field
+                                type="hidden"
+                                readOnly={true}
+                                name={`jurisdictions[${index}].id`}
+                                id={`jurisdictions-${index}-id`}
+                                value={jurisdiction.id}
+                              />
+                              <Field
+                                type="hidden"
+                                readOnly={true}
+                                name={`jurisdictions[${index}].name`}
+                                id={`jurisdictions-${index}-name`}
+                                value={jurisdiction.name}
+                              />
+                            </fieldset>
+                          </li>
+                        ))}
+                      </ul>
                     </div>
                   ) : (
                     <div id="jurisdictions-select-container" className="mb-5">

--- a/src/containers/forms/PlanForm/index.tsx
+++ b/src/containers/forms/PlanForm/index.tsx
@@ -672,15 +672,12 @@ const defaultProps: PlanFormProps = {
  * We are defining these here to keep things DRY
  */
 export const propsForUpdatingPlans: Partial<PlanFormProps> = {
-  disabledActivityFields: ['actionReason', 'goalPriority', 'timingPeriodStart', 'timingPeriodEnd'],
+  disabledActivityFields: ['actionReason', 'goalPriority'],
   disabledFields: [
     'interventionType',
     'fiReason',
     'fiStatus',
     'identifier',
-    'start',
-    'date',
-    'end',
     'name',
     'caseNum',
     'opensrpEventId',

--- a/src/containers/forms/PlanForm/index.tsx
+++ b/src/containers/forms/PlanForm/index.tsx
@@ -161,7 +161,9 @@ const PlanForm = (props: PlanFormProps) => {
               /* tslint:disable-next-line jsx-no-lambda */
               render={arrayHelpers => (
                 <div>
-                  {editMode !== true && (
+                  {editMode ? (
+                    <div id="jurisdictions-display-container" />
+                  ) : (
                     <div id="jurisdictions-select-container">
                       <div className="mb-5">
                         {values.jurisdictions.map((jurisdiction, index) => (

--- a/src/containers/forms/PlanForm/index.tsx
+++ b/src/containers/forms/PlanForm/index.tsx
@@ -76,6 +76,7 @@ const PlanForm = (props: PlanFormProps) => {
 
   const disAllowedStatusChoices: string[] = [];
   if (editMode) {
+    // Dont allow setting status back to draft
     if (initialValues.status !== PlanStatus.DRAFT) {
       disAllowedStatusChoices.push(PlanStatus.DRAFT);
     }

--- a/src/containers/forms/PlanForm/index.tsx
+++ b/src/containers/forms/PlanForm/index.tsx
@@ -80,6 +80,13 @@ const PlanForm = (props: PlanFormProps) => {
     if (initialValues.status !== PlanStatus.DRAFT) {
       disAllowedStatusChoices.push(PlanStatus.DRAFT);
     }
+    // set these fields to friendly defaults if not set or else the form cant be submitted
+    if (
+      initialValues.interventionType === InterventionType.FI &&
+      (!initialValues.fiReason || !FIReasons.includes(initialValues.fiReason))
+    ) {
+      initialValues.fiReason = FIReasons[0];
+    }
   }
 
   return (

--- a/src/containers/forms/PlanForm/index.tsx
+++ b/src/containers/forms/PlanForm/index.tsx
@@ -668,6 +668,26 @@ const defaultProps: PlanFormProps = {
   redirectAfterAction: PLAN_LIST_URL,
 };
 
+/** props for updating plan definition objects
+ * We are defining these here to keep things DRY
+ */
+export const propsForUpdatingPlans: Partial<PlanFormProps> = {
+  disabledActivityFields: ['actionReason', 'goalPriority', 'timingPeriodStart', 'timingPeriodEnd'],
+  disabledFields: [
+    'interventionType',
+    'fiReason',
+    'fiStatus',
+    'identifier',
+    'start',
+    'date',
+    'end',
+    'name',
+    'caseNum',
+    'opensrpEventId',
+    'jurisdictions',
+  ],
+};
+
 PlanForm.defaultProps = defaultProps;
 
 export default PlanForm;

--- a/src/containers/forms/PlanForm/index.tsx
+++ b/src/containers/forms/PlanForm/index.tsx
@@ -61,6 +61,7 @@ export const defaultInitialValues: PlanFormFields = {
 
 /** interface for plan form props */
 interface PlanFormProps {
+  disabledActivityFields: string[];
   disabledFields: string[];
   initialValues: PlanFormFields;
   redirectAfterAction: string;
@@ -71,7 +72,7 @@ const PlanForm = (props: PlanFormProps) => {
   const [globalError, setGlobalError] = useState<string>('');
   const [areWeDoneHere, setAreWeDoneHere] = useState<boolean>(false);
 
-  const { disabledFields, initialValues, redirectAfterAction } = props;
+  const { disabledActivityFields, disabledFields, initialValues, redirectAfterAction } = props;
   const editMode: boolean = initialValues.identifier !== '';
 
   return (
@@ -429,7 +430,10 @@ const PlanForm = (props: PlanFormProps) => {
                           name={`activities[${index}].actionTitle`}
                           id={`activities-${index}-actionTitle`}
                           required={true}
-                          disabled={disabledFields.includes('activities')}
+                          disabled={
+                            disabledFields.includes('activities') ||
+                            disabledActivityFields.includes('actionTitle')
+                          }
                           className={
                             errors.activities &&
                             doesFieldHaveErrors('actionTitle', index, errors.activities)
@@ -465,7 +469,10 @@ const PlanForm = (props: PlanFormProps) => {
                           name={`activities[${index}].actionDescription`}
                           id={`activities-${index}-actionDescription`}
                           required={true}
-                          disabled={disabledFields.includes('activities')}
+                          disabled={
+                            disabledFields.includes('activities') ||
+                            disabledActivityFields.includes('actionDescription')
+                          }
                           className={
                             errors.activities &&
                             doesFieldHaveErrors('actionDescription', index, errors.activities)
@@ -492,7 +499,10 @@ const PlanForm = (props: PlanFormProps) => {
                           name={`activities[${index}].goalValue`}
                           id={`activities-${index}-goalValue`}
                           required={true}
-                          disabled={disabledFields.includes('activities')}
+                          disabled={
+                            disabledFields.includes('activities') ||
+                            disabledActivityFields.includes('goalValue')
+                          }
                           className={
                             errors.activities &&
                             doesFieldHaveErrors('goalValue', index, errors.activities)
@@ -513,7 +523,10 @@ const PlanForm = (props: PlanFormProps) => {
                           name={`activities[${index}].timingPeriodStart`}
                           id={`activities-${index}-timingPeriodStart`}
                           required={true}
-                          disabled={disabledFields.includes('activities')}
+                          disabled={
+                            disabledFields.includes('activities') ||
+                            disabledActivityFields.includes('timingPeriodStart')
+                          }
                           dateFormat={DATE_FORMAT}
                           className={
                             errors.activities &&
@@ -538,7 +551,10 @@ const PlanForm = (props: PlanFormProps) => {
                           name={`activities[${index}].timingPeriodEnd`}
                           id={`activities-${index}-timingPeriodEnd`}
                           required={true}
-                          disabled={disabledFields.includes('activities')}
+                          disabled={
+                            disabledFields.includes('activities') ||
+                            disabledActivityFields.includes('timingPeriodEnd')
+                          }
                           dateFormat={DATE_FORMAT}
                           className={
                             errors.activities &&
@@ -569,7 +585,10 @@ const PlanForm = (props: PlanFormProps) => {
                           name={`activities[${index}].actionReason`}
                           id={`activities-${index}-actionReason`}
                           required={true}
-                          disabled={disabledFields.includes('activities')}
+                          disabled={
+                            disabledFields.includes('activities') ||
+                            disabledActivityFields.includes('actionReason')
+                          }
                           className={
                             errors.activities &&
                             doesFieldHaveErrors('actionReason', index, errors.activities)
@@ -596,7 +615,10 @@ const PlanForm = (props: PlanFormProps) => {
                           name={`activities[${index}].goalPriority`}
                           id={`activities-${index}-goalPriority`}
                           required={true}
-                          disabled={disabledFields.includes('activities')}
+                          disabled={
+                            disabledFields.includes('activities') ||
+                            disabledActivityFields.includes('goalPriority')
+                          }
                           className={
                             errors.activities &&
                             doesFieldHaveErrors('goalPriority', index, errors.activities)
@@ -640,6 +662,7 @@ const PlanForm = (props: PlanFormProps) => {
 };
 
 const defaultProps: PlanFormProps = {
+  disabledActivityFields: [],
   disabledFields: [],
   initialValues: defaultInitialValues,
   redirectAfterAction: PLAN_LIST_URL,

--- a/src/containers/forms/PlanForm/index.tsx
+++ b/src/containers/forms/PlanForm/index.tsx
@@ -162,91 +162,108 @@ const PlanForm = (props: PlanFormProps) => {
               render={arrayHelpers => (
                 <div>
                   {editMode ? (
-                    <div id="jurisdictions-display-container" />
+                    <div id="jurisdictions-display-container" className="mb-5">
+                      {values.jurisdictions.map((jurisdiction, index) => (
+                        <fieldset key={index}>
+                          <Field
+                            type="hidden"
+                            readOnly={true}
+                            name={`jurisdictions[${index}].id`}
+                            id={`jurisdictions-${index}-id`}
+                            value={jurisdiction.id}
+                          />
+                          <Field
+                            type="hidden"
+                            readOnly={true}
+                            name={`jurisdictions[${index}].name`}
+                            id={`jurisdictions-${index}-name`}
+                            value={jurisdiction.name}
+                          />
+                        </fieldset>
+                      ))}
+                    </div>
                   ) : (
-                    <div id="jurisdictions-select-container">
-                      <div className="mb-5">
-                        {values.jurisdictions.map((jurisdiction, index) => (
-                          <fieldset key={index}>
-                            {errors.jurisdictions && errors.jurisdictions[index] && (
-                              <div className="alert alert-danger" role="alert">
-                                <h6 className="alert-heading">Please fix these errors</h6>
-                                <ul className="list-unstyled">
-                                  {Object.entries(errors.jurisdictions[index] || {}).map(
-                                    ([key, val]) => (
-                                      <li key={key}>
-                                        <strong>Focus Area</strong>: {val}
-                                      </li>
-                                    )
-                                  )}
-                                </ul>
-                              </div>
+                    <div id="jurisdictions-select-container" className="mb-5">
+                      {values.jurisdictions.map((jurisdiction, index) => (
+                        <fieldset key={index}>
+                          {errors.jurisdictions && errors.jurisdictions[index] && (
+                            <div className="alert alert-danger" role="alert">
+                              <h6 className="alert-heading">Please fix these errors</h6>
+                              <ul className="list-unstyled">
+                                {Object.entries(errors.jurisdictions[index] || {}).map(
+                                  ([key, val]) => (
+                                    <li key={key}>
+                                      <strong>Focus Area</strong>: {val}
+                                    </li>
+                                  )
+                                )}
+                              </ul>
+                            </div>
+                          )}
+                          <div className="jurisdiction-item position-relative">
+                            {values.jurisdictions && values.jurisdictions.length > 1 && (
+                              <button
+                                type="button"
+                                className="close position-absolute removeArrItem removeJurisdiction"
+                                aria-label="Close"
+                                onClick={() => arrayHelpers.remove(index)}
+                              >
+                                <span aria-hidden="true">&times;</span>
+                              </button>
                             )}
-                            <div className="jurisdiction-item position-relative">
-                              {values.jurisdictions && values.jurisdictions.length > 1 && (
-                                <button
-                                  type="button"
-                                  className="close position-absolute removeArrItem removeJurisdiction"
-                                  aria-label="Close"
-                                  onClick={() => arrayHelpers.remove(index)}
-                                >
-                                  <span aria-hidden="true">&times;</span>
-                                </button>
-                              )}
-                              <FormGroup
+                            <FormGroup
+                              className={
+                                errors.jurisdictions &&
+                                doesFieldHaveErrors('id', index, errors.jurisdictions)
+                                  ? 'is-invalid async-select-container'
+                                  : 'async-select-container'
+                              }
+                            >
+                              <Label for={`jurisdictions-${index}-id`}>Focus Area</Label>
+                              <Field
+                                required={true}
+                                component={JurisdictionSelect}
+                                name={`jurisdictions[${index}].id`}
+                                id={`jurisdictions-${index}-id`}
+                                placeholder="Select Focus Area"
+                                aria-label="Select Focus Area"
+                                disabled={disabledFields.includes('jurisdictions')}
                                 className={
                                   errors.jurisdictions &&
                                   doesFieldHaveErrors('id', index, errors.jurisdictions)
-                                    ? 'is-invalid async-select-container'
-                                    : 'async-select-container'
+                                    ? 'is-invalid async-select'
+                                    : 'async-select'
                                 }
-                              >
-                                <Label for={`jurisdictions-${index}-id`}>Focus Area</Label>
-                                <Field
-                                  required={true}
-                                  component={JurisdictionSelect}
-                                  name={`jurisdictions[${index}].id`}
-                                  id={`jurisdictions-${index}-id`}
-                                  placeholder="Select Focus Area"
-                                  aria-label="Select Focus Area"
-                                  disabled={disabledFields.includes('jurisdictions')}
-                                  className={
-                                    errors.jurisdictions &&
-                                    doesFieldHaveErrors('id', index, errors.jurisdictions)
-                                      ? 'is-invalid async-select'
-                                      : 'async-select'
-                                  }
-                                  labelFieldName={`jurisdictions[${index}].name`}
-                                />
-                                <Field
-                                  type="hidden"
-                                  name={`jurisdictions[${index}].name`}
-                                  id={`jurisdictions-${index}-name`}
-                                />
+                                labelFieldName={`jurisdictions[${index}].name`}
+                              />
+                              <Field
+                                type="hidden"
+                                name={`jurisdictions[${index}].name`}
+                                id={`jurisdictions-${index}-name`}
+                              />
 
-                                {errors.jurisdictions && errors.jurisdictions[index] && (
-                                  <small className="form-text text-danger">An Error Ocurred</small>
-                                )}
+                              {errors.jurisdictions && errors.jurisdictions[index] && (
+                                <small className="form-text text-danger">An Error Ocurred</small>
+                              )}
 
-                                <ErrorMessage
-                                  name={`jurisdictions[${index}].id`}
-                                  component="small"
-                                  className="form-text text-danger"
-                                />
-                              </FormGroup>
-                            </div>
-                          </fieldset>
-                        ))}
-                        {values.interventionType === InterventionType.IRS && (
-                          <button
-                            type="button"
-                            className="btn btn-primary btn-sm mb-5 addJurisdiction"
-                            onClick={() => arrayHelpers.push(initialJurisdictionValues)}
-                          >
-                            Add Focus Area
-                          </button>
-                        )}
-                      </div>
+                              <ErrorMessage
+                                name={`jurisdictions[${index}].id`}
+                                component="small"
+                                className="form-text text-danger"
+                              />
+                            </FormGroup>
+                          </div>
+                        </fieldset>
+                      ))}
+                      {values.interventionType === InterventionType.IRS && (
+                        <button
+                          type="button"
+                          className="btn btn-primary btn-sm mb-5 addJurisdiction"
+                          onClick={() => arrayHelpers.push(initialJurisdictionValues)}
+                        >
+                          Add Focus Area
+                        </button>
+                      )}
                     </div>
                   )}
                 </div>

--- a/src/containers/forms/PlanForm/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/forms/PlanForm/tests/__snapshots__/index.test.tsx.snap
@@ -148,7 +148,7 @@ exports[`containers/forms/PlanForm - Edit renders activity fields correctly: act
 exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[0].timingPeriodEnd field 1`] = `
 <input
   className="form-control"
-  disabled={true}
+  disabled={false}
   id="activities-0-timingPeriodEnd"
   onBlur={[Function]}
   onChange={[Function]}
@@ -165,7 +165,7 @@ exports[`containers/forms/PlanForm - Edit renders activity fields correctly: act
 exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[0].timingPeriodStart field 1`] = `
 <input
   className="form-control"
-  disabled={true}
+  disabled={false}
   id="activities-0-timingPeriodStart"
   onBlur={[Function]}
   onChange={[Function]}
@@ -327,7 +327,7 @@ exports[`containers/forms/PlanForm - Edit renders activity fields correctly: act
 exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[1].timingPeriodEnd field 1`] = `
 <input
   className="form-control"
-  disabled={true}
+  disabled={false}
   id="activities-1-timingPeriodEnd"
   onBlur={[Function]}
   onChange={[Function]}
@@ -344,7 +344,7 @@ exports[`containers/forms/PlanForm - Edit renders activity fields correctly: act
 exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[1].timingPeriodStart field 1`] = `
 <input
   className="form-control"
-  disabled={true}
+  disabled={false}
   id="activities-1-timingPeriodStart"
   onBlur={[Function]}
   onChange={[Function]}
@@ -394,7 +394,7 @@ exports[`containers/forms/PlanForm - Edit renders all fields correctly in edit m
 exports[`containers/forms/PlanForm - Edit renders all fields correctly in edit mode: end field 1`] = `
 <input
   className="form-control"
-  disabled={true}
+  disabled={false}
   id="end"
   onBlur={[Function]}
   onChange={[Function]}
@@ -536,7 +536,7 @@ exports[`containers/forms/PlanForm - Edit renders all fields correctly in edit m
 exports[`containers/forms/PlanForm - Edit renders all fields correctly in edit mode: start field 1`] = `
 <input
   className="form-control"
-  disabled={true}
+  disabled={false}
   id="start"
   onBlur={[Function]}
   onChange={[Function]}

--- a/src/containers/forms/PlanForm/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/forms/PlanForm/tests/__snapshots__/index.test.tsx.snap
@@ -234,6 +234,82 @@ exports[`containers/forms/PlanForm - Edit renders all fields correctly in edit m
 />
 `;
 
+exports[`containers/forms/PlanForm - Edit renders jurisdictions fields correctly: jurisdictions[0].id field 1`] = `
+<input
+  id="jurisdictions-0-id"
+  name="jurisdictions[0].id"
+  onBlur={[Function]}
+  onChange={[Function]}
+  readOnly={true}
+  type="hidden"
+  value="35968df5-f335-44ae-8ae5-25804caa2d86"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders jurisdictions fields correctly: jurisdictions[0].name field 1`] = `
+<input
+  id="jurisdictions-0-name"
+  name="jurisdictions[0].name"
+  onBlur={[Function]}
+  onChange={[Function]}
+  readOnly={true}
+  type="hidden"
+  value="35968df5-f335-44ae-8ae5-25804caa2d86"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders jurisdictions fields correctly: jurisdictions[1].id field 1`] = `
+<input
+  id="jurisdictions-1-id"
+  name="jurisdictions[1].id"
+  onBlur={[Function]}
+  onChange={[Function]}
+  readOnly={true}
+  type="hidden"
+  value="3952"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders jurisdictions fields correctly: jurisdictions[1].name field 1`] = `
+<input
+  id="jurisdictions-1-name"
+  name="jurisdictions[1].name"
+  onBlur={[Function]}
+  onChange={[Function]}
+  readOnly={true}
+  type="hidden"
+  value="3952"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders jurisdictions fields correctly: jurisdictions[2].id field 1`] = `
+<input
+  id="jurisdictions-2-id"
+  name="jurisdictions[2].id"
+  onBlur={[Function]}
+  onChange={[Function]}
+  readOnly={true}
+  type="hidden"
+  value="ac7ba751-35e8-4b46-9e53-3cbaad193697"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders jurisdictions fields correctly: jurisdictions[2].name field 1`] = `
+<input
+  id="jurisdictions-2-name"
+  name="jurisdictions[2].name"
+  onBlur={[Function]}
+  onChange={[Function]}
+  readOnly={true}
+  type="hidden"
+  value="ac7ba751-35e8-4b46-9e53-3cbaad193697"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders jurisdictions fields correctly: jurisdictions[3].id field 1`] = `null`;
+
+exports[`containers/forms/PlanForm - Edit renders jurisdictions fields correctly: jurisdictions[3].name field 1`] = `null`;
+
 exports[`containers/forms/PlanForm renders activity fields correctly: FI activities[0].actionCode field 1`] = `
 <input
   id="activities-0-actionCode"

--- a/src/containers/forms/PlanForm/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/forms/PlanForm/tests/__snapshots__/index.test.tsx.snap
@@ -417,7 +417,7 @@ exports[`containers/forms/PlanForm - Edit renders all fields correctly in edit m
   onBlur={[Function]}
   onChange={[Function]}
   required={true}
-  value="Case-triggered"
+  value="Routine"
 >
   <option>
     ----

--- a/src/containers/forms/PlanForm/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/forms/PlanForm/tests/__snapshots__/index.test.tsx.snap
@@ -574,12 +574,6 @@ exports[`containers/forms/PlanForm - Edit renders all fields correctly in edit m
     complete
   </option>
   <option
-    key="DRAFT"
-    value="draft"
-  >
-    draft
-  </option>
-  <option
     key="RETIRED"
     value="retired"
   >

--- a/src/containers/forms/PlanForm/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/forms/PlanForm/tests/__snapshots__/index.test.tsx.snap
@@ -310,6 +310,20 @@ exports[`containers/forms/PlanForm - Edit renders jurisdictions fields correctly
 
 exports[`containers/forms/PlanForm - Edit renders jurisdictions fields correctly: jurisdictions[3].name field 1`] = `null`;
 
+exports[`containers/forms/PlanForm - Edit renders jurisdictions fields correctly: selected jurisdictions 1`] = `
+Array [
+  <span>
+    35968df5-f335-44ae-8ae5-25804caa2d86
+  </span>,
+  <span>
+    3952
+  </span>,
+  <span>
+    ac7ba751-35e8-4b46-9e53-3cbaad193697
+  </span>,
+]
+`;
+
 exports[`containers/forms/PlanForm renders activity fields correctly: FI activities[0].actionCode field 1`] = `
 <input
   id="activities-0-actionCode"

--- a/src/containers/forms/PlanForm/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/forms/PlanForm/tests/__snapshots__/index.test.tsx.snap
@@ -1,5 +1,239 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`containers/forms/PlanForm - Edit renders all fields correctly in edit mode: date field 1`] = `
+<input
+  id="date"
+  name="date"
+  onBlur={[Function]}
+  onChange={[Function]}
+  type="hidden"
+  value={2019-05-19T00:00:00.000Z}
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders all fields correctly in edit mode: end field 1`] = `
+<input
+  className="form-control"
+  disabled={true}
+  id="end"
+  onBlur={[Function]}
+  onChange={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  readOnly={false}
+  required={true}
+  type="text"
+  value="2019-08-30"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders all fields correctly in edit mode: fiReason field 1`] = `
+<select
+  className="form-control"
+  disabled={true}
+  id="fiReason"
+  name="fiReason"
+  onBlur={[Function]}
+  onChange={[Function]}
+  required={true}
+  value="Case-triggered"
+>
+  <option>
+    ----
+  </option>
+  <option
+    key="Routine"
+    value="Routine"
+  >
+    Routine
+  </option>
+  <option
+    key="Case Triggered"
+    value="Case Triggered"
+  >
+    Case Triggered
+  </option>
+</select>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders all fields correctly in edit mode: fiStatus field 1`] = `
+<select
+  className="form-control"
+  disabled={true}
+  id="fiStatus"
+  name="fiStatus"
+  onBlur={[Function]}
+  onChange={[Function]}
+  required={true}
+  value="A2"
+>
+  <option>
+    ----
+  </option>
+  <option
+    key="A1"
+    value="A1"
+  >
+    A1
+     - 
+    Active
+  </option>
+  <option
+    key="A2"
+    value="A2"
+  >
+    A2
+     - 
+    Residual Non-Active
+  </option>
+  <option
+    key="B1"
+    value="B1"
+  >
+    B1
+     - 
+    Cleared Receptive
+  </option>
+  <option
+    key="B2"
+    value="B2"
+  >
+    B2
+     - 
+    Cleared Non-Receptive
+  </option>
+</select>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders all fields correctly in edit mode: identifier field 1`] = `
+<input
+  id="identifier"
+  name="identifier"
+  onBlur={[Function]}
+  onChange={[Function]}
+  readOnly={true}
+  type="hidden"
+  value="356b6b84-fc36-4389-a44a-2b038ed2f38d"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders all fields correctly in edit mode: interventionType field 1`] = `
+<select
+  className="form-control"
+  disabled={true}
+  id="interventionType"
+  name="interventionType"
+  onBlur={[Function]}
+  onChange={[Function]}
+  required={true}
+  value="FI"
+>
+  <option
+    value="FI"
+  >
+    Focus Investigation
+  </option>
+  <option
+    value="IRS"
+  >
+    IRS
+  </option>
+</select>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders all fields correctly in edit mode: name field 1`] = `
+<input
+  id="name"
+  name="name"
+  onBlur={[Function]}
+  onChange={[Function]}
+  type="hidden"
+  value="A2-Lusaka_Akros_Focus_2"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders all fields correctly in edit mode: start field 1`] = `
+<input
+  className="form-control"
+  disabled={true}
+  id="start"
+  onBlur={[Function]}
+  onChange={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  readOnly={false}
+  required={true}
+  type="text"
+  value="2019-05-20"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders all fields correctly in edit mode: status field 1`] = `
+<select
+  className="form-control"
+  disabled={false}
+  id="status"
+  name="status"
+  onBlur={[Function]}
+  onChange={[Function]}
+  required={true}
+  value="active"
+>
+  <option
+    key="ACTIVE"
+    value="active"
+  >
+    active
+  </option>
+  <option
+    key="COMPLETE"
+    value="complete"
+  >
+    complete
+  </option>
+  <option
+    key="DRAFT"
+    value="draft"
+  >
+    draft
+  </option>
+  <option
+    key="RETIRED"
+    value="retired"
+  >
+    retired
+  </option>
+</select>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders all fields correctly in edit mode: title field 1`] = `
+<input
+  className="form-control"
+  disabled={false}
+  id="title"
+  name="title"
+  onBlur={[Function]}
+  onChange={[Function]}
+  required={true}
+  type="text"
+  value="A2-Lusaka Akros Test Focus 2"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders all fields correctly in edit mode: version field 1`] = `
+<input
+  id="version"
+  name="version"
+  onBlur={[Function]}
+  onChange={[Function]}
+  readOnly={true}
+  type="hidden"
+  value="1"
+/>
+`;
+
 exports[`containers/forms/PlanForm renders activity fields correctly: FI activities[0].actionCode field 1`] = `
 <input
   id="activities-0-actionCode"

--- a/src/containers/forms/PlanForm/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/forms/PlanForm/tests/__snapshots__/index.test.tsx.snap
@@ -1,5 +1,385 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[0].actionCode field 1`] = `
+<input
+  id="activities-0-actionCode"
+  name="activities[0].actionCode"
+  onBlur={[Function]}
+  onChange={[Function]}
+  readOnly={true}
+  type="hidden"
+  value="BCC"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[0].actionDescription field 1`] = `
+<textarea
+  className="form-control"
+  disabled={false}
+  id="activities-0-actionDescription"
+  name="activities[0].actionDescription"
+  onBlur={[Function]}
+  onChange={[Function]}
+  required={true}
+  value="Perform BCC for the operational area"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[0].actionIdentifier field 1`] = `
+<input
+  id="activities-0-actionIdentifier"
+  name="activities[0].actionIdentifier"
+  onBlur={[Function]}
+  onChange={[Function]}
+  readOnly={true}
+  type="hidden"
+  value="3f2eef38-38fe-4108-abb3-4e896b880302"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[0].actionReason field 1`] = `
+<select
+  className="form-control"
+  disabled={true}
+  id="activities-0-actionReason"
+  name="activities[0].actionReason"
+  onBlur={[Function]}
+  onChange={[Function]}
+  required={true}
+  value="Routine"
+>
+  <option
+    key="Investigation"
+    value="Investigation"
+  >
+    Investigation
+  </option>
+  <option
+    key="Routine"
+    value="Routine"
+  >
+    Routine
+  </option>
+</select>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[0].actionTitle field 1`] = `
+<input
+  className="form-control"
+  disabled={false}
+  id="activities-0-actionTitle"
+  name="activities[0].actionTitle"
+  onBlur={[Function]}
+  onChange={[Function]}
+  required={true}
+  type="text"
+  value="Perform BCC"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[0].goalDescription field 1`] = `
+<input
+  id="activities-0-goalDescription"
+  name="activities[0].goalDescription"
+  onBlur={[Function]}
+  onChange={[Function]}
+  type="hidden"
+  value="Perform BCC for the operational area"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[0].goalDue field 1`] = `
+<input
+  id="activities-0-goalDue"
+  name="activities[0].goalDue"
+  onBlur={[Function]}
+  onChange={[Function]}
+  type="hidden"
+  value={2019-07-30T00:00:00.000Z}
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[0].goalPriority field 1`] = `
+<select
+  className="form-control"
+  disabled={true}
+  id="activities-0-goalPriority"
+  name="activities[0].goalPriority"
+  onBlur={[Function]}
+  onChange={[Function]}
+  required={true}
+  value="medium-priority"
+>
+  <option
+    key="low-priority"
+    value="low-priority"
+  >
+    low-priority
+  </option>
+  <option
+    key="medium-priority"
+    value="medium-priority"
+  >
+    medium-priority
+  </option>
+  <option
+    key="high-priority"
+    value="high-priority"
+  >
+    high-priority
+  </option>
+</select>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[0].goalValue field 1`] = `
+<input
+  className="form-control"
+  disabled={false}
+  id="activities-0-goalValue"
+  name="activities[0].goalValue"
+  onBlur={[Function]}
+  onChange={[Function]}
+  required={true}
+  type="number"
+  value={1}
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[0].timingPeriodEnd field 1`] = `
+<input
+  className="form-control"
+  disabled={true}
+  id="activities-0-timingPeriodEnd"
+  onBlur={[Function]}
+  onChange={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  readOnly={false}
+  required={true}
+  type="text"
+  value="2019-07-30"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[0].timingPeriodStart field 1`] = `
+<input
+  className="form-control"
+  disabled={true}
+  id="activities-0-timingPeriodStart"
+  onBlur={[Function]}
+  onChange={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  readOnly={false}
+  required={true}
+  type="text"
+  value="2019-07-10"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[1].actionCode field 1`] = `
+<input
+  id="activities-1-actionCode"
+  name="activities[1].actionCode"
+  onBlur={[Function]}
+  onChange={[Function]}
+  readOnly={true}
+  type="hidden"
+  value="IRS"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[1].actionDescription field 1`] = `
+<textarea
+  className="form-control"
+  disabled={false}
+  id="activities-1-actionDescription"
+  name="activities[1].actionDescription"
+  onBlur={[Function]}
+  onChange={[Function]}
+  required={true}
+  value="Visit each structure in the operational area and attempt to spray"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[1].actionIdentifier field 1`] = `
+<input
+  id="activities-1-actionIdentifier"
+  name="activities[1].actionIdentifier"
+  onBlur={[Function]}
+  onChange={[Function]}
+  readOnly={true}
+  type="hidden"
+  value="95a5a00f-a411-4fe5-bd9c-460a856239c9"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[1].actionReason field 1`] = `
+<select
+  className="form-control"
+  disabled={true}
+  id="activities-1-actionReason"
+  name="activities[1].actionReason"
+  onBlur={[Function]}
+  onChange={[Function]}
+  required={true}
+  value="Routine"
+>
+  <option
+    key="Investigation"
+    value="Investigation"
+  >
+    Investigation
+  </option>
+  <option
+    key="Routine"
+    value="Routine"
+  >
+    Routine
+  </option>
+</select>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[1].actionTitle field 1`] = `
+<input
+  className="form-control"
+  disabled={false}
+  id="activities-1-actionTitle"
+  name="activities[1].actionTitle"
+  onBlur={[Function]}
+  onChange={[Function]}
+  required={true}
+  type="text"
+  value="Spray Structures"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[1].goalDescription field 1`] = `
+<input
+  id="activities-1-goalDescription"
+  name="activities[1].goalDescription"
+  onBlur={[Function]}
+  onChange={[Function]}
+  type="hidden"
+  value="Visit each structure in the operational area and attempt to spray"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[1].goalDue field 1`] = `
+<input
+  id="activities-1-goalDue"
+  name="activities[1].goalDue"
+  onBlur={[Function]}
+  onChange={[Function]}
+  type="hidden"
+  value={2019-07-30T00:00:00.000Z}
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[1].goalPriority field 1`] = `
+<select
+  className="form-control"
+  disabled={true}
+  id="activities-1-goalPriority"
+  name="activities[1].goalPriority"
+  onBlur={[Function]}
+  onChange={[Function]}
+  required={true}
+  value="medium-priority"
+>
+  <option
+    key="low-priority"
+    value="low-priority"
+  >
+    low-priority
+  </option>
+  <option
+    key="medium-priority"
+    value="medium-priority"
+  >
+    medium-priority
+  </option>
+  <option
+    key="high-priority"
+    value="high-priority"
+  >
+    high-priority
+  </option>
+</select>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[1].goalValue field 1`] = `
+<input
+  className="form-control"
+  disabled={false}
+  id="activities-1-goalValue"
+  name="activities[1].goalValue"
+  onBlur={[Function]}
+  onChange={[Function]}
+  required={true}
+  type="number"
+  value={90}
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[1].timingPeriodEnd field 1`] = `
+<input
+  className="form-control"
+  disabled={true}
+  id="activities-1-timingPeriodEnd"
+  onBlur={[Function]}
+  onChange={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  readOnly={false}
+  required={true}
+  type="text"
+  value="2019-07-30"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[1].timingPeriodStart field 1`] = `
+<input
+  className="form-control"
+  disabled={true}
+  id="activities-1-timingPeriodStart"
+  onBlur={[Function]}
+  onChange={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  readOnly={false}
+  required={true}
+  type="text"
+  value="2019-07-10"
+/>
+`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[2].actionCode field 1`] = `null`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[2].actionDescription field 1`] = `null`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[2].actionIdentifier field 1`] = `null`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[2].actionReason field 1`] = `null`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[2].actionTitle field 1`] = `null`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[2].goalDescription field 1`] = `null`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[2].goalDue field 1`] = `null`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[2].goalPriority field 1`] = `null`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[2].goalValue field 1`] = `null`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[2].timingPeriodEnd field 1`] = `null`;
+
+exports[`containers/forms/PlanForm - Edit renders activity fields correctly: activities[2].timingPeriodStart field 1`] = `null`;
+
 exports[`containers/forms/PlanForm - Edit renders all fields correctly in edit mode: date field 1`] = `
 <input
   id="date"

--- a/src/containers/forms/PlanForm/tests/fixtures.ts
+++ b/src/containers/forms/PlanForm/tests/fixtures.ts
@@ -1571,6 +1571,126 @@ export const planFormValues = {
   version: '1',
 };
 
+export const planFormValues2 = {
+  activities: [
+    {
+      actionCode: 'Case Confirmation',
+      actionDescription: 'Confirm the index case',
+      actionIdentifier: 'c711ae51-6432-4b68-84c3-d2b5b1fd1948',
+      actionReason: 'Investigation',
+      actionTitle: 'Case Confirmation',
+      goalDescription: 'Confirm the index case',
+      goalDue: moment('2019-05-21T00:00:00.000Z').toDate(),
+      goalPriority: 'medium-priority',
+      goalValue: 1,
+      timingPeriodEnd: moment('2019-05-24T00:00:00.000Z').toDate(),
+      timingPeriodStart: moment('2019-05-21T00:00:00.000Z').toDate(),
+    },
+    {
+      actionCode: 'RACD Register Family',
+      actionDescription:
+        'Register all families & famiy members in all residential structures enumerated (100%) within the operational area',
+      actionIdentifier: '402b8c13-6774-4515-929f-48e71a61a379',
+      actionReason: 'Investigation',
+      actionTitle: 'Family Registration',
+      goalDescription:
+        'Register all families and family members in all residential structures enumerated or added (100%) within operational area',
+      goalDue: moment('2019-08-30T00:00:00.000Z').toDate(),
+      goalPriority: 'medium-priority',
+      goalValue: 100,
+      timingPeriodEnd: moment('2019-08-30T00:00:00.000Z').toDate(),
+      timingPeriodStart: moment('2019-05-21T00:00:00.000Z').toDate(),
+    },
+    {
+      actionCode: 'Bednet Distribution',
+      actionDescription:
+        'Visit 100% of residential structures in the operational area and provide nets',
+      actionIdentifier: '1bd830ea-50e3-44dc-b855-9d5e9339e2be',
+      actionReason: 'Routine',
+      actionTitle: 'Bednet Distribution',
+      goalDescription:
+        'Visit 100% of residential structures in the operational area and provide nets',
+      goalDue: moment('2019-08-30T00:00:00.000Z').toDate(),
+      goalPriority: 'medium-priority',
+      goalValue: 100,
+      timingPeriodEnd: moment('2019-08-30T00:00:00.000Z').toDate(),
+      timingPeriodStart: moment('2019-05-21T00:00:00.000Z').toDate(),
+    },
+    {
+      actionCode: 'Blood Screening',
+      actionDescription:
+        'Visit all residential structures (100%) within a 1 km radius of a confirmed index case and test each registered person',
+      actionIdentifier: '2303a70e-4e3f-4fb9-a430-f0476010bfb5',
+      actionReason: 'Investigation',
+      actionTitle: 'RACD Blood screening',
+      goalDescription:
+        'Visit all residential structures (100%) within a 1 km radius of a confirmed index case and test each registered person',
+      goalDue: moment('2019-05-28T00:00:00.000Z').toDate(),
+      goalPriority: 'medium-priority',
+      goalValue: 100,
+      timingPeriodEnd: moment('2019-05-28T00:00:00.000Z').toDate(),
+      timingPeriodStart: moment('2019-05-21T00:00:00.000Z').toDate(),
+    },
+    {
+      actionCode: 'Larval Dipping',
+      actionDescription:
+        'Perform a minimum of three larval dipping activities in the operational area',
+      actionIdentifier: '2482dfd7-8284-43c6-bea1-a03dcda71ff4',
+      actionReason: 'Investigation',
+      actionTitle: 'Larval Dipping',
+      goalDescription:
+        'Perform a minimum of three larval dipping activities in the operational area',
+      goalDue: moment('2019-05-28T00:00:00.000Z').toDate(),
+      goalPriority: 'medium-priority',
+      goalValue: 3,
+      timingPeriodEnd: moment('2019-05-28T00:00:00.000Z').toDate(),
+      timingPeriodStart: moment('2019-05-21T00:00:00.000Z').toDate(),
+    },
+    {
+      actionCode: 'Mosquito Collection',
+      actionDescription:
+        'Set a minimum of three mosquito collection traps and complete the mosquito collection process',
+      actionIdentifier: '423f6665-5367-40be-855e-7c5e6941a0c3',
+      actionReason: 'Investigation',
+      actionTitle: 'Mosquito Collection',
+      goalDescription:
+        'Set a minimum of three mosquito collection traps and complete the mosquito collection process',
+      goalDue: moment('2019-05-28T00:00:00.000Z').toDate(),
+      goalPriority: 'medium-priority',
+      goalValue: 3,
+      timingPeriodEnd: moment('2019-05-28T00:00:00.000Z').toDate(),
+      timingPeriodStart: moment('2019-05-21T00:00:00.000Z').toDate(),
+    },
+    {
+      actionCode: 'BCC',
+      actionDescription: 'Conduct BCC activity',
+      actionIdentifier: 'c8fc89a9-cdd2-4746-8272-650883ae380e',
+      actionReason: 'Investigation',
+      actionTitle: 'Behaviour Change Communication',
+      goalDescription: 'Complete at least 1 BCC activity for the operational area',
+      goalDue: moment('2019-06-21T00:00:00.000Z').toDate(),
+      goalPriority: 'medium-priority',
+      goalValue: 1,
+      timingPeriodEnd: moment('2019-06-21T00:00:00.000Z').toDate(),
+      timingPeriodStart: moment('2019-05-21T00:00:00.000Z').toDate(),
+    },
+  ],
+  caseNum: '',
+  date: moment('2019-05-19T00:00:00.000Z').toDate(),
+  end: moment('2019-08-30T00:00:00.000Z').toDate(),
+  fiReason: 'Case-triggered',
+  fiStatus: 'A2',
+  identifier: '356b6b84-fc36-4389-a44a-2b038ed2f38d',
+  interventionType: 'FI',
+  jurisdictions: [{ id: '3952', name: '3952' }],
+  name: 'A2-Lusaka_Akros_Focus_2',
+  opensrpEventId: undefined,
+  start: moment('2019-05-20T00:00:00.000Z').toDate(),
+  status: 'active',
+  title: 'A2-Lusaka Akros Test Focus 2',
+  version: '1',
+};
+
 export const jurisdictionLevel0JSON =
   '[{"type":"Feature","id":"2942","properties":{"status":"Active","name":"Lusaka","geographicLevel":0,"version":0},"serverVersion":1545204913827},{"type":"Feature","id":"f8863022-ff88-4c22-b2d1-83f59f31b874","properties":{"status":"Active","name":"Oddar Meanchey Province","geographicLevel":0,"version":0},"serverVersion":1553900609745},{"type":"Feature","id":"9c3c2db4-bddd-44c5-870a-a0eef539e4da","properties":{"status":"Active","name":"Lop Buri","geographicLevel":0,"version":0},"serverVersion":1554861473099},{"type":"Feature","id":"3953","properties":{"status":"Active","name":"Siavonga","geographicLevel":0,"version":0},"serverVersion":1549235783958},{"type":"Feature","id":"3954","properties":{"status":"Active","name":"Siavonga","geographicLevel":0,"version":0},"serverVersion":1549387863860},{"type":"Feature","id":"2940","properties":{"status":"Active","name":"Katete","geographicLevel":0,"version":0},"serverVersion":1545218425249},{"type":"Feature","id":"2941","properties":{"status":"Active","name":"Sinda","geographicLevel":0,"version":0},"serverVersion":1545219282280},{"type":"Feature","id":"2939","properties":{"status":"Active","name":"Chadiza","geographicLevel":0,"version":0},"serverVersion":1545217996275},{"type":"Feature","id":"16a77bba-8777-4bc4-8566-d193cb04af4c","properties":{"status":"Active","name":"Botswana","geographicLevel":0,"version":0},"serverVersion":1563583239021},{"type":"Feature","id":"f45b9380-c970-4dd1-8533-9e95ab12f128","properties":{"status":"Active","name":"Namibia","geographicLevel":0,"version":0,"ADM0_EN":"Namibia","ADM0_PCODE":"NA"},"serverVersion":1564401702479}]';
 

--- a/src/containers/forms/PlanForm/tests/fixtures.ts
+++ b/src/containers/forms/PlanForm/tests/fixtures.ts
@@ -1364,16 +1364,16 @@ export const values2 = {
       actionReason: 'Routine',
       actionTitle: 'Spray Structures',
       goalDescription: 'Spray structures in the operational area',
-      goalDue: '2019-08-16T12:32:15.116Z',
+      goalDue: moment('2019-08-16T12:32:15.116Z').toDate(),
       goalPriority: 'medium-priority',
       goalValue: 90,
-      timingPeriodEnd: '2019-08-16T12:32:15.117Z',
-      timingPeriodStart: '2019-08-09T12:32:15.117Z',
+      timingPeriodEnd: moment('2019-08-16T12:32:01.685Z').toDate(),
+      timingPeriodStart: moment('2019-08-09T12:32:01.685Z').toDate(),
     },
   ],
   caseNum: '',
-  date: '2019-08-09T12:32:01.685Z',
-  end: '2019-08-29T12:32:01.685Z',
+  date: moment('2019-08-09T12:32:01.685Z').toDate(),
+  end: moment('2019-08-29T12:32:01.685Z').toDate(),
   identifier: '',
   interventionType: 'IRS',
   jurisdictions: [
@@ -1383,11 +1383,12 @@ export const values2 = {
     },
   ],
   name: 'IRS-2019-08-09',
-  start: '2019-08-09T12:32:01.685Z',
+  start: moment('2019-08-09T12:32:01.685Z').toDate(),
   status: 'draft',
   title: 'IRS 2019-08-09',
   version: '1',
 };
+
 export const jurisdictionLevel0JSON =
   '[{"type":"Feature","id":"2942","properties":{"status":"Active","name":"Lusaka","geographicLevel":0,"version":0},"serverVersion":1545204913827},{"type":"Feature","id":"f8863022-ff88-4c22-b2d1-83f59f31b874","properties":{"status":"Active","name":"Oddar Meanchey Province","geographicLevel":0,"version":0},"serverVersion":1553900609745},{"type":"Feature","id":"9c3c2db4-bddd-44c5-870a-a0eef539e4da","properties":{"status":"Active","name":"Lop Buri","geographicLevel":0,"version":0},"serverVersion":1554861473099},{"type":"Feature","id":"3953","properties":{"status":"Active","name":"Siavonga","geographicLevel":0,"version":0},"serverVersion":1549235783958},{"type":"Feature","id":"3954","properties":{"status":"Active","name":"Siavonga","geographicLevel":0,"version":0},"serverVersion":1549387863860},{"type":"Feature","id":"2940","properties":{"status":"Active","name":"Katete","geographicLevel":0,"version":0},"serverVersion":1545218425249},{"type":"Feature","id":"2941","properties":{"status":"Active","name":"Sinda","geographicLevel":0,"version":0},"serverVersion":1545219282280},{"type":"Feature","id":"2939","properties":{"status":"Active","name":"Chadiza","geographicLevel":0,"version":0},"serverVersion":1545217996275},{"type":"Feature","id":"16a77bba-8777-4bc4-8566-d193cb04af4c","properties":{"status":"Active","name":"Botswana","geographicLevel":0,"version":0},"serverVersion":1563583239021},{"type":"Feature","id":"f45b9380-c970-4dd1-8533-9e95ab12f128","properties":{"status":"Active","name":"Namibia","geographicLevel":0,"version":0,"ADM0_EN":"Namibia","ADM0_PCODE":"NA"},"serverVersion":1564401702479}]';
 

--- a/src/containers/forms/PlanForm/tests/fixtures.ts
+++ b/src/containers/forms/PlanForm/tests/fixtures.ts
@@ -1,6 +1,6 @@
 import { parseISO } from 'date-fns';
 import moment from 'moment';
-import { DEFAULT_ACTIVITY_DURATION_DAYS } from '../../../../configs/env';
+import { DEFAULT_ACTIVITY_DURATION_DAYS, DEFAULT_TIME } from '../../../../configs/env';
 import { PlanActivities } from '../../../../configs/settings';
 
 const goalDue = moment()
@@ -1365,16 +1365,16 @@ export const values2 = {
       actionReason: 'Routine',
       actionTitle: 'Spray Structures',
       goalDescription: 'Spray structures in the operational area',
-      goalDue: parseISO('2019-08-16'),
+      goalDue: parseISO(`2019-08-16${DEFAULT_TIME}`),
       goalPriority: 'medium-priority',
       goalValue: 90,
-      timingPeriodEnd: parseISO('2019-08-16'),
-      timingPeriodStart: parseISO('2019-08-09'),
+      timingPeriodEnd: parseISO(`2019-08-16${DEFAULT_TIME}`),
+      timingPeriodStart: parseISO(`2019-08-09${DEFAULT_TIME}`),
     },
   ],
   caseNum: '',
-  date: parseISO('2019-08-09'),
-  end: parseISO('2019-08-29'),
+  date: parseISO(`2019-08-09${DEFAULT_TIME}`),
+  end: parseISO(`2019-08-29${DEFAULT_TIME}`),
   identifier: '',
   interventionType: 'IRS',
   jurisdictions: [
@@ -1384,7 +1384,44 @@ export const values2 = {
     },
   ],
   name: 'IRS-2019-08-09',
-  start: parseISO('2019-08-09'),
+  start: parseISO(`2019-08-09${DEFAULT_TIME}`),
+  status: 'draft',
+  title: 'IRS 2019-08-09',
+  version: '1',
+};
+
+export const planFormValues = {
+  activities: [
+    {
+      actionCode: 'IRS',
+      actionDescription: 'Visit each structure in the operational area and attempt to spray',
+      actionIdentifier: 'ce6f39db-505a-5d44-b70d-c92a73be6c15',
+      actionReason: 'Routine',
+      actionTitle: 'Spray Structures',
+      goalDescription: 'Spray structures in the operational area',
+      goalDue: parseISO(`2019-08-16${DEFAULT_TIME}`),
+      goalPriority: 'medium-priority',
+      goalValue: 90,
+      timingPeriodEnd: parseISO(`2019-08-16${DEFAULT_TIME}`),
+      timingPeriodStart: parseISO(`2019-08-09${DEFAULT_TIME}`),
+    },
+  ],
+  caseNum: '',
+  date: parseISO(`2019-08-09${DEFAULT_TIME}`),
+  end: parseISO(`2019-08-29${DEFAULT_TIME}`),
+  fiReason: undefined,
+  fiStatus: undefined,
+  identifier: 'afbfc83d-c7a2-5293-9db5-081781235c60',
+  interventionType: 'IRS',
+  jurisdictions: [
+    {
+      id: '3952',
+      name: 'Akros_2',
+    },
+  ],
+  name: 'IRS-2019-08-09',
+  opensrpEventId: undefined,
+  start: parseISO(`2019-08-09${DEFAULT_TIME}`),
   status: 'draft',
   title: 'IRS 2019-08-09',
   version: '1',

--- a/src/containers/forms/PlanForm/tests/fixtures.ts
+++ b/src/containers/forms/PlanForm/tests/fixtures.ts
@@ -1,3 +1,4 @@
+import { parseISO } from 'date-fns';
 import moment from 'moment';
 import { DEFAULT_ACTIVITY_DURATION_DAYS } from '../../../../configs/env';
 import { PlanActivities } from '../../../../configs/settings';
@@ -1364,16 +1365,16 @@ export const values2 = {
       actionReason: 'Routine',
       actionTitle: 'Spray Structures',
       goalDescription: 'Spray structures in the operational area',
-      goalDue: moment('2019-08-16T12:32:15.116Z').toDate(),
+      goalDue: parseISO('2019-08-16'),
       goalPriority: 'medium-priority',
       goalValue: 90,
-      timingPeriodEnd: moment('2019-08-16T12:32:01.685Z').toDate(),
-      timingPeriodStart: moment('2019-08-09T12:32:01.685Z').toDate(),
+      timingPeriodEnd: parseISO('2019-08-16'),
+      timingPeriodStart: parseISO('2019-08-09'),
     },
   ],
   caseNum: '',
-  date: moment('2019-08-09T12:32:01.685Z').toDate(),
-  end: moment('2019-08-29T12:32:01.685Z').toDate(),
+  date: parseISO('2019-08-09'),
+  end: parseISO('2019-08-29'),
   identifier: '',
   interventionType: 'IRS',
   jurisdictions: [
@@ -1383,7 +1384,7 @@ export const values2 = {
     },
   ],
   name: 'IRS-2019-08-09',
-  start: moment('2019-08-09T12:32:01.685Z').toDate(),
+  start: parseISO('2019-08-09'),
   status: 'draft',
   title: 'IRS 2019-08-09',
   version: '1',

--- a/src/containers/forms/PlanForm/tests/helpers.test.ts
+++ b/src/containers/forms/PlanForm/tests/helpers.test.ts
@@ -94,58 +94,58 @@ describe('containers/forms/PlanForm/helpers', () => {
   //   );
   // });
 
-  it('check doesFieldHaveErrors returns the correct value', () => {
-    let errors = [
-      {
-        id: 'Required',
-      },
-    ];
-    let field = 'id';
-    let index = 0;
-    expect(doesFieldHaveErrors(field, index, errors)).toBe(true);
-    field = '';
-    index = NaN;
-    errors = [];
-    expect(doesFieldHaveErrors(field, index, errors)).toBe(false);
-  });
+  // it('check doesFieldHaveErrors returns the correct value', () => {
+  //   let errors = [
+  //     {
+  //       id: 'Required',
+  //     },
+  //   ];
+  //   let field = 'id';
+  //   let index = 0;
+  //   expect(doesFieldHaveErrors(field, index, errors)).toBe(true);
+  //   field = '';
+  //   index = NaN;
+  //   errors = [];
+  //   expect(doesFieldHaveErrors(field, index, errors)).toBe(false);
+  // });
 
-  it('check extractActivitiesFromPlanForm returns the correct value', () => {
-    MockDate.set('1/30/2000', 0);
-    expect(extractActivitiesFromPlanForm(activities)).toEqual(
-      expectedExtractActivityFromPlanformResult
-    );
-    MockDate.reset();
-  });
+  // it('check extractActivitiesFromPlanForm returns the correct value', () => {
+  //   MockDate.set('1/30/2000', 0);
+  //   expect(extractActivitiesFromPlanForm(activities)).toEqual(
+  //     expectedExtractActivityFromPlanformResult
+  //   );
+  //   MockDate.reset();
+  // });
 
-  it('check getNameTitle returns the correct value when Focus Investigation(FI) is selected', () => {
-    expect(getNameTitle(event, values)).toEqual(['A1--2019-08-09', 'A1  2019-08-09']);
-    expect(getNameTitle(event, valuesWithJurisdiction)).toEqual([
-      'A1-TLv2_01-2019-08-09',
-      'A1 TLv2_01 2019-08-09',
-    ]);
-  });
+  // it('check getNameTitle returns the correct value when Focus Investigation(FI) is selected', () => {
+  //   expect(getNameTitle(event, values)).toEqual(['A1--2019-08-09', 'A1  2019-08-09']);
+  //   expect(getNameTitle(event, valuesWithJurisdiction)).toEqual([
+  //     'A1-TLv2_01-2019-08-09',
+  //     'A1 TLv2_01 2019-08-09',
+  //   ]);
+  // });
 
-  it('check getNameTitle returns the correct value when IRS is selected', () => {
-    expect(getNameTitle(event2, values)).toEqual(['IRS-2019-08-09', 'IRS 2019-08-09']);
-    expect(getNameTitle(event2, valuesWithJurisdiction)).toEqual([
-      'IRS-2019-08-09',
-      'IRS 2019-08-09',
-    ]);
-  });
+  // it('check getNameTitle returns the correct value when IRS is selected', () => {
+  //   expect(getNameTitle(event2, values)).toEqual(['IRS-2019-08-09', 'IRS 2019-08-09']);
+  //   expect(getNameTitle(event2, valuesWithJurisdiction)).toEqual([
+  //     'IRS-2019-08-09',
+  //     'IRS 2019-08-09',
+  //   ]);
+  // });
 
-  it('check getNameTitle returns the correct value when nothing is selected', () => {
-    expect(getNameTitle(event3, values)).toEqual(['IRS-2019-08-09', 'IRS 2019-08-09']);
-    expect(getNameTitle(event3, valuesWithJurisdiction)).toEqual([
-      'IRS-2019-08-09',
-      'IRS 2019-08-09',
-    ]);
-  });
+  // it('check getNameTitle returns the correct value when nothing is selected', () => {
+  //   expect(getNameTitle(event3, values)).toEqual(['IRS-2019-08-09', 'IRS 2019-08-09']);
+  //   expect(getNameTitle(event3, valuesWithJurisdiction)).toEqual([
+  //     'IRS-2019-08-09',
+  //     'IRS 2019-08-09',
+  //   ]);
+  // });
 
-  it('check generatePlanDefinition returns the correct value', () => {
-    MockDate.set('1/30/2000', 0);
-    expect(generatePlanDefinition(values2)).toEqual(expectedPlanDefinition);
-    MockDate.reset();
-  });
+  // it('check generatePlanDefinition returns the correct value', () => {
+  //   MockDate.set('1/30/2000', 0);
+  //   expect(generatePlanDefinition(values2)).toEqual(expectedPlanDefinition);
+  //   MockDate.reset();
+  // });
 
   it('getPlanFormValues can get original planForm', () => {
     const planForm = planFormValues as PlanFormFields;
@@ -162,6 +162,19 @@ describe('containers/forms/PlanForm/helpers', () => {
         },
       ],
       version: '1', // the version is updated so we change it back
+    });
+  });
+
+  it('generatePlanDefinition can get original planDefinition', () => {
+    const plan = plans[0];
+
+    const generatedPlanForm = getPlanFormValues(plan);
+    const generatedPlan = generatePlanDefinition(generatedPlanForm, plan);
+
+    expect(plan).toEqual({
+      ...generatedPlan,
+      serverVersion: 1563303150422,
+      version: '1',
     });
   });
 

--- a/src/containers/forms/PlanForm/tests/helpers.test.ts
+++ b/src/containers/forms/PlanForm/tests/helpers.test.ts
@@ -29,69 +29,69 @@ import {
 } from './fixtures';
 
 describe('containers/forms/PlanForm/helpers', () => {
-  it('check extractActivityForForm returns the correct value for BCC', () => {
-    expect(extractActivityForForm(planActivities.BCC)).toEqual(expectedActivity.BCC);
-    expect(extractActivityForForm(planActivityWithEmptyfields.BCC)).toEqual(
-      expectedActivityEmptyField.BCC
-    );
-  });
+  // it('check extractActivityForForm returns the correct value for BCC', () => {
+  //   expect(extractActivityForForm(planActivities.BCC)).toEqual(expectedActivity.BCC);
+  //   expect(extractActivityForForm(planActivityWithEmptyfields.BCC)).toEqual(
+  //     expectedActivityEmptyField.BCC
+  //   );
+  // });
 
-  it('check extractActivityForForm returns the correct value for IRS', () => {
-    expect(extractActivityForForm(planActivities.bednetDistribution)).toEqual(
-      expectedActivity.bednetDistribution
-    );
-    expect(extractActivityForForm(planActivityWithEmptyfields.bednetDistribution)).toEqual(
-      expectedActivityEmptyField.bednetDistribution
-    );
-  });
+  // it('check extractActivityForForm returns the correct value for IRS', () => {
+  //   expect(extractActivityForForm(planActivities.bednetDistribution)).toEqual(
+  //     expectedActivity.bednetDistribution
+  //   );
+  //   expect(extractActivityForForm(planActivityWithEmptyfields.bednetDistribution)).toEqual(
+  //     expectedActivityEmptyField.bednetDistribution
+  //   );
+  // });
 
-  it('check extractActivityForForm returns the correct value for bloodScreening', () => {
-    expect(extractActivityForForm(planActivities.bloodScreening)).toEqual(
-      expectedActivity.bloodScreening
-    );
-    expect(extractActivityForForm(planActivityWithEmptyfields.bloodScreening)).toEqual(
-      expectedActivityEmptyField.bloodScreening
-    );
-  });
+  // it('check extractActivityForForm returns the correct value for bloodScreening', () => {
+  //   expect(extractActivityForForm(planActivities.bloodScreening)).toEqual(
+  //     expectedActivity.bloodScreening
+  //   );
+  //   expect(extractActivityForForm(planActivityWithEmptyfields.bloodScreening)).toEqual(
+  //     expectedActivityEmptyField.bloodScreening
+  //   );
+  // });
 
-  it('check extractActivityForForm returns the correct value for caseConfirmation', () => {
-    expect(extractActivityForForm(planActivities.caseConfirmation)).toEqual(
-      expectedActivity.caseConfirmation
-    );
-    expect(extractActivityForForm(planActivityWithEmptyfields.caseConfirmation)).toEqual(
-      expectedActivityEmptyField.caseConfirmation
-    );
-  });
+  // it('check extractActivityForForm returns the correct value for caseConfirmation', () => {
+  //   expect(extractActivityForForm(planActivities.caseConfirmation)).toEqual(
+  //     expectedActivity.caseConfirmation
+  //   );
+  //   expect(extractActivityForForm(planActivityWithEmptyfields.caseConfirmation)).toEqual(
+  //     expectedActivityEmptyField.caseConfirmation
+  //   );
+  // });
 
-  it('check extractActivityForForm returns the correct value for larvalDipping', () => {
-    expect(extractActivityForForm(planActivities.larvalDipping)).toEqual(
-      expectedActivity.larvalDipping
-    );
-    expect(extractActivityForForm(planActivityWithEmptyfields.larvalDipping)).toEqual(
-      expectedActivityEmptyField.larvalDipping
-    );
-  });
+  // it('check extractActivityForForm returns the correct value for larvalDipping', () => {
+  //   expect(extractActivityForForm(planActivities.larvalDipping)).toEqual(
+  //     expectedActivity.larvalDipping
+  //   );
+  //   expect(extractActivityForForm(planActivityWithEmptyfields.larvalDipping)).toEqual(
+  //     expectedActivityEmptyField.larvalDipping
+  //   );
+  // });
 
-  it('check extractActivityForForm returns the correct value for familyRegistration', () => {
-    expect(extractActivityForForm(planActivities.familyRegistration)).toEqual(
-      expectedActivity.familyRegistration
-    );
-  });
+  // it('check extractActivityForForm returns the correct value for familyRegistration', () => {
+  //   expect(extractActivityForForm(planActivities.familyRegistration)).toEqual(
+  //     expectedActivity.familyRegistration
+  //   );
+  // });
 
-  it('check extractActivityForForm returns the correct value for mosquitoCollection', () => {
-    expect(extractActivityForForm(planActivities.mosquitoCollection)).toEqual(
-      expectedActivity.mosquitoCollection
-    );
-    expect(extractActivityForForm(planActivityWithEmptyfields.mosquitoCollection)).toEqual(
-      expectedActivityEmptyField.mosquitoCollection
-    );
-  });
+  // it('check extractActivityForForm returns the correct value for mosquitoCollection', () => {
+  //   expect(extractActivityForForm(planActivities.mosquitoCollection)).toEqual(
+  //     expectedActivity.mosquitoCollection
+  //   );
+  //   expect(extractActivityForForm(planActivityWithEmptyfields.mosquitoCollection)).toEqual(
+  //     expectedActivityEmptyField.mosquitoCollection
+  //   );
+  // });
 
-  it('check getFormActivities returns the correct value', () => {
-    expect(JSON.stringify(getFormActivities(planActivities))).toEqual(
-      JSON.stringify(extractedActivitiesFromForms)
-    );
-  });
+  // it('check getFormActivities returns the correct value', () => {
+  //   expect(JSON.stringify(getFormActivities(planActivities))).toEqual(
+  //     JSON.stringify(extractedActivitiesFromForms)
+  //   );
+  // });
 
   it('check doesFieldHaveErrors returns the correct value', () => {
     let errors = [
@@ -166,11 +166,11 @@ describe('containers/forms/PlanForm/helpers', () => {
           actionReason: 'Investigation',
           actionTitle: 'Case Confirmation',
           goalDescription: 'Confirm the index case',
-          goalDue: moment('2019-05-20T21:00:00.000Z').toDate(),
+          goalDue: moment('2019-05-21T00:00:00.000Z').toDate(),
           goalPriority: 'medium-priority',
           goalValue: 1,
-          timingPeriodEnd: moment('2019-05-23T21:00:00.000Z').toDate(),
-          timingPeriodStart: moment('2019-05-20T21:00:00.000Z').toDate(),
+          timingPeriodEnd: moment('2019-05-24T00:00:00.000Z').toDate(),
+          timingPeriodStart: moment('2019-05-21T00:00:00.000Z').toDate(),
         },
         {
           actionCode: 'RACD Register Family',
@@ -181,11 +181,11 @@ describe('containers/forms/PlanForm/helpers', () => {
           actionTitle: 'Family Registration',
           goalDescription:
             'Register all families and family members in all residential structures enumerated or added (100%) within operational area',
-          goalDue: moment('2019-08-29T21:00:00.000Z').toDate(),
+          goalDue: moment('2019-08-30T00:00:00.000Z').toDate(),
           goalPriority: 'medium-priority',
           goalValue: 100,
-          timingPeriodEnd: moment('2019-08-29T21:00:00.000Z').toDate(),
-          timingPeriodStart: moment('2019-05-20T21:00:00.000Z').toDate(),
+          timingPeriodEnd: moment('2019-08-30T00:00:00.000Z').toDate(),
+          timingPeriodStart: moment('2019-05-21T00:00:00.000Z').toDate(),
         },
         {
           actionCode: 'Bednet Distribution',
@@ -196,11 +196,11 @@ describe('containers/forms/PlanForm/helpers', () => {
           actionTitle: 'Bednet Distribution',
           goalDescription:
             'Visit 100% of residential structures in the operational area and provide nets',
-          goalDue: moment('2019-08-29T21:00:00.000Z').toDate(),
+          goalDue: moment('2019-08-30T00:00:00.000Z').toDate(),
           goalPriority: 'medium-priority',
           goalValue: 100,
-          timingPeriodEnd: moment('2019-08-29T21:00:00.000Z').toDate(),
-          timingPeriodStart: moment('2019-05-20T21:00:00.000Z').toDate(),
+          timingPeriodEnd: moment('2019-08-30T00:00:00.000Z').toDate(),
+          timingPeriodStart: moment('2019-05-21T00:00:00.000Z').toDate(),
         },
         {
           actionCode: 'Blood Screening',
@@ -211,11 +211,11 @@ describe('containers/forms/PlanForm/helpers', () => {
           actionTitle: 'RACD Blood screening',
           goalDescription:
             'Visit all residential structures (100%) within a 1 km radius of a confirmed index case and test each registered person',
-          goalDue: moment('2019-05-27T21:00:00.000Z').toDate(),
+          goalDue: moment('2019-05-28T00:00:00.000Z').toDate(),
           goalPriority: 'medium-priority',
           goalValue: 100,
-          timingPeriodEnd: moment('2019-05-27T21:00:00.000Z').toDate(),
-          timingPeriodStart: moment('2019-05-20T21:00:00.000Z').toDate(),
+          timingPeriodEnd: moment('2019-05-28T00:00:00.000Z').toDate(),
+          timingPeriodStart: moment('2019-05-21T00:00:00.000Z').toDate(),
         },
         {
           actionCode: 'Larval Dipping',
@@ -226,11 +226,11 @@ describe('containers/forms/PlanForm/helpers', () => {
           actionTitle: 'Larval Dipping',
           goalDescription:
             'Perform a minimum of three larval dipping activities in the operational area',
-          goalDue: moment('2019-05-27T21:00:00.000Z').toDate(),
+          goalDue: moment('2019-05-28T00:00:00.000Z').toDate(),
           goalPriority: 'medium-priority',
           goalValue: 3,
-          timingPeriodEnd: moment('2019-05-27T21:00:00.000Z').toDate(),
-          timingPeriodStart: moment('2019-05-20T21:00:00.000Z').toDate(),
+          timingPeriodEnd: moment('2019-05-28T00:00:00.000Z').toDate(),
+          timingPeriodStart: moment('2019-05-21T00:00:00.000Z').toDate(),
         },
         {
           actionCode: 'Mosquito Collection',
@@ -241,11 +241,11 @@ describe('containers/forms/PlanForm/helpers', () => {
           actionTitle: 'Mosquito Collection',
           goalDescription:
             'Set a minimum of three mosquito collection traps and complete the mosquito collection process',
-          goalDue: moment('2019-05-27T21:00:00.000Z').toDate(),
+          goalDue: moment('2019-05-28T00:00:00.000Z').toDate(),
           goalPriority: 'medium-priority',
           goalValue: 3,
-          timingPeriodEnd: moment('2019-05-27T21:00:00.000Z').toDate(),
-          timingPeriodStart: moment('2019-05-20T21:00:00.000Z').toDate(),
+          timingPeriodEnd: moment('2019-05-28T00:00:00.000Z').toDate(),
+          timingPeriodStart: moment('2019-05-21T00:00:00.000Z').toDate(),
         },
         {
           actionCode: 'BCC',
@@ -254,11 +254,11 @@ describe('containers/forms/PlanForm/helpers', () => {
           actionReason: 'Investigation',
           actionTitle: 'Behaviour Change Communication',
           goalDescription: 'Complete at least 1 BCC activity for the operational area',
-          goalDue: moment('2019-06-20T21:00:00.000Z').toDate(),
+          goalDue: moment('2019-06-21T00:00:00.000Z').toDate(),
           goalPriority: 'medium-priority',
           goalValue: 1,
-          timingPeriodEnd: moment('2019-06-20T21:00:00.000Z').toDate(),
-          timingPeriodStart: moment('2019-05-20T21:00:00.000Z').toDate(),
+          timingPeriodEnd: moment('2019-06-21T00:00:00.000Z').toDate(),
+          timingPeriodStart: moment('2019-05-21T00:00:00.000Z').toDate(),
         },
       ],
       caseNum: '',

--- a/src/containers/forms/PlanForm/tests/helpers.test.ts
+++ b/src/containers/forms/PlanForm/tests/helpers.test.ts
@@ -30,122 +30,122 @@ import {
 } from './fixtures';
 
 describe('containers/forms/PlanForm/helpers', () => {
-  // it('check extractActivityForForm returns the correct value for BCC', () => {
-  //   expect(extractActivityForForm(planActivities.BCC)).toEqual(expectedActivity.BCC);
-  //   expect(extractActivityForForm(planActivityWithEmptyfields.BCC)).toEqual(
-  //     expectedActivityEmptyField.BCC
-  //   );
-  // });
+  it('check extractActivityForForm returns the correct value for BCC', () => {
+    expect(extractActivityForForm(planActivities.BCC)).toEqual(expectedActivity.BCC);
+    expect(extractActivityForForm(planActivityWithEmptyfields.BCC)).toEqual(
+      expectedActivityEmptyField.BCC
+    );
+  });
 
-  // it('check extractActivityForForm returns the correct value for IRS', () => {
-  //   expect(extractActivityForForm(planActivities.bednetDistribution)).toEqual(
-  //     expectedActivity.bednetDistribution
-  //   );
-  //   expect(extractActivityForForm(planActivityWithEmptyfields.bednetDistribution)).toEqual(
-  //     expectedActivityEmptyField.bednetDistribution
-  //   );
-  // });
+  it('check extractActivityForForm returns the correct value for IRS', () => {
+    expect(extractActivityForForm(planActivities.bednetDistribution)).toEqual(
+      expectedActivity.bednetDistribution
+    );
+    expect(extractActivityForForm(planActivityWithEmptyfields.bednetDistribution)).toEqual(
+      expectedActivityEmptyField.bednetDistribution
+    );
+  });
 
-  // it('check extractActivityForForm returns the correct value for bloodScreening', () => {
-  //   expect(extractActivityForForm(planActivities.bloodScreening)).toEqual(
-  //     expectedActivity.bloodScreening
-  //   );
-  //   expect(extractActivityForForm(planActivityWithEmptyfields.bloodScreening)).toEqual(
-  //     expectedActivityEmptyField.bloodScreening
-  //   );
-  // });
+  it('check extractActivityForForm returns the correct value for bloodScreening', () => {
+    expect(extractActivityForForm(planActivities.bloodScreening)).toEqual(
+      expectedActivity.bloodScreening
+    );
+    expect(extractActivityForForm(planActivityWithEmptyfields.bloodScreening)).toEqual(
+      expectedActivityEmptyField.bloodScreening
+    );
+  });
 
-  // it('check extractActivityForForm returns the correct value for caseConfirmation', () => {
-  //   expect(extractActivityForForm(planActivities.caseConfirmation)).toEqual(
-  //     expectedActivity.caseConfirmation
-  //   );
-  //   expect(extractActivityForForm(planActivityWithEmptyfields.caseConfirmation)).toEqual(
-  //     expectedActivityEmptyField.caseConfirmation
-  //   );
-  // });
+  it('check extractActivityForForm returns the correct value for caseConfirmation', () => {
+    expect(extractActivityForForm(planActivities.caseConfirmation)).toEqual(
+      expectedActivity.caseConfirmation
+    );
+    expect(extractActivityForForm(planActivityWithEmptyfields.caseConfirmation)).toEqual(
+      expectedActivityEmptyField.caseConfirmation
+    );
+  });
 
-  // it('check extractActivityForForm returns the correct value for larvalDipping', () => {
-  //   expect(extractActivityForForm(planActivities.larvalDipping)).toEqual(
-  //     expectedActivity.larvalDipping
-  //   );
-  //   expect(extractActivityForForm(planActivityWithEmptyfields.larvalDipping)).toEqual(
-  //     expectedActivityEmptyField.larvalDipping
-  //   );
-  // });
+  it('check extractActivityForForm returns the correct value for larvalDipping', () => {
+    expect(extractActivityForForm(planActivities.larvalDipping)).toEqual(
+      expectedActivity.larvalDipping
+    );
+    expect(extractActivityForForm(planActivityWithEmptyfields.larvalDipping)).toEqual(
+      expectedActivityEmptyField.larvalDipping
+    );
+  });
 
-  // it('check extractActivityForForm returns the correct value for familyRegistration', () => {
-  //   expect(extractActivityForForm(planActivities.familyRegistration)).toEqual(
-  //     expectedActivity.familyRegistration
-  //   );
-  // });
+  it('check extractActivityForForm returns the correct value for familyRegistration', () => {
+    expect(extractActivityForForm(planActivities.familyRegistration)).toEqual(
+      expectedActivity.familyRegistration
+    );
+  });
 
-  // it('check extractActivityForForm returns the correct value for mosquitoCollection', () => {
-  //   expect(extractActivityForForm(planActivities.mosquitoCollection)).toEqual(
-  //     expectedActivity.mosquitoCollection
-  //   );
-  //   expect(extractActivityForForm(planActivityWithEmptyfields.mosquitoCollection)).toEqual(
-  //     expectedActivityEmptyField.mosquitoCollection
-  //   );
-  // });
+  it('check extractActivityForForm returns the correct value for mosquitoCollection', () => {
+    expect(extractActivityForForm(planActivities.mosquitoCollection)).toEqual(
+      expectedActivity.mosquitoCollection
+    );
+    expect(extractActivityForForm(planActivityWithEmptyfields.mosquitoCollection)).toEqual(
+      expectedActivityEmptyField.mosquitoCollection
+    );
+  });
 
-  // it('check getFormActivities returns the correct value', () => {
-  //   expect(JSON.stringify(getFormActivities(planActivities))).toEqual(
-  //     JSON.stringify(extractedActivitiesFromForms)
-  //   );
-  // });
+  it('check getFormActivities returns the correct value', () => {
+    expect(JSON.stringify(getFormActivities(planActivities))).toEqual(
+      JSON.stringify(extractedActivitiesFromForms)
+    );
+  });
 
-  // it('check doesFieldHaveErrors returns the correct value', () => {
-  //   let errors = [
-  //     {
-  //       id: 'Required',
-  //     },
-  //   ];
-  //   let field = 'id';
-  //   let index = 0;
-  //   expect(doesFieldHaveErrors(field, index, errors)).toBe(true);
-  //   field = '';
-  //   index = NaN;
-  //   errors = [];
-  //   expect(doesFieldHaveErrors(field, index, errors)).toBe(false);
-  // });
+  it('check doesFieldHaveErrors returns the correct value', () => {
+    let errors = [
+      {
+        id: 'Required',
+      },
+    ];
+    let field = 'id';
+    let index = 0;
+    expect(doesFieldHaveErrors(field, index, errors)).toBe(true);
+    field = '';
+    index = NaN;
+    errors = [];
+    expect(doesFieldHaveErrors(field, index, errors)).toBe(false);
+  });
 
-  // it('check extractActivitiesFromPlanForm returns the correct value', () => {
-  //   MockDate.set('1/30/2000', 0);
-  //   expect(extractActivitiesFromPlanForm(activities)).toEqual(
-  //     expectedExtractActivityFromPlanformResult
-  //   );
-  //   MockDate.reset();
-  // });
+  it('check extractActivitiesFromPlanForm returns the correct value', () => {
+    MockDate.set('1/30/2000', 0);
+    expect(extractActivitiesFromPlanForm(activities)).toEqual(
+      expectedExtractActivityFromPlanformResult
+    );
+    MockDate.reset();
+  });
 
-  // it('check getNameTitle returns the correct value when Focus Investigation(FI) is selected', () => {
-  //   expect(getNameTitle(event, values)).toEqual(['A1--2019-08-09', 'A1  2019-08-09']);
-  //   expect(getNameTitle(event, valuesWithJurisdiction)).toEqual([
-  //     'A1-TLv2_01-2019-08-09',
-  //     'A1 TLv2_01 2019-08-09',
-  //   ]);
-  // });
+  it('check getNameTitle returns the correct value when Focus Investigation(FI) is selected', () => {
+    expect(getNameTitle(event, values)).toEqual(['A1--2019-08-09', 'A1  2019-08-09']);
+    expect(getNameTitle(event, valuesWithJurisdiction)).toEqual([
+      'A1-TLv2_01-2019-08-09',
+      'A1 TLv2_01 2019-08-09',
+    ]);
+  });
 
-  // it('check getNameTitle returns the correct value when IRS is selected', () => {
-  //   expect(getNameTitle(event2, values)).toEqual(['IRS-2019-08-09', 'IRS 2019-08-09']);
-  //   expect(getNameTitle(event2, valuesWithJurisdiction)).toEqual([
-  //     'IRS-2019-08-09',
-  //     'IRS 2019-08-09',
-  //   ]);
-  // });
+  it('check getNameTitle returns the correct value when IRS is selected', () => {
+    expect(getNameTitle(event2, values)).toEqual(['IRS-2019-08-09', 'IRS 2019-08-09']);
+    expect(getNameTitle(event2, valuesWithJurisdiction)).toEqual([
+      'IRS-2019-08-09',
+      'IRS 2019-08-09',
+    ]);
+  });
 
-  // it('check getNameTitle returns the correct value when nothing is selected', () => {
-  //   expect(getNameTitle(event3, values)).toEqual(['IRS-2019-08-09', 'IRS 2019-08-09']);
-  //   expect(getNameTitle(event3, valuesWithJurisdiction)).toEqual([
-  //     'IRS-2019-08-09',
-  //     'IRS 2019-08-09',
-  //   ]);
-  // });
+  it('check getNameTitle returns the correct value when nothing is selected', () => {
+    expect(getNameTitle(event3, values)).toEqual(['IRS-2019-08-09', 'IRS 2019-08-09']);
+    expect(getNameTitle(event3, valuesWithJurisdiction)).toEqual([
+      'IRS-2019-08-09',
+      'IRS 2019-08-09',
+    ]);
+  });
 
-  // it('check generatePlanDefinition returns the correct value', () => {
-  //   MockDate.set('1/30/2000', 0);
-  //   expect(generatePlanDefinition(values2)).toEqual(expectedPlanDefinition);
-  //   MockDate.reset();
-  // });
+  it('check generatePlanDefinition returns the correct value', () => {
+    MockDate.set('1/30/2000', 0);
+    expect(generatePlanDefinition(values2)).toEqual(expectedPlanDefinition);
+    MockDate.reset();
+  });
 
   it('getPlanFormValues can get original planForm', () => {
     const planForm = planFormValues as PlanFormFields;

--- a/src/containers/forms/PlanForm/tests/helpers.test.ts
+++ b/src/containers/forms/PlanForm/tests/helpers.test.ts
@@ -153,7 +153,6 @@ describe('containers/forms/PlanForm/helpers', () => {
     const generatedPlanForm = getPlanFormValues(generatedPlan);
 
     expect(planForm).toEqual(generatedPlanForm);
-    // expect(generatePlanDefinition(values2)).toEqual(expectedPlanDefinition);
     MockDate.reset();
   });
 
@@ -263,8 +262,8 @@ describe('containers/forms/PlanForm/helpers', () => {
         },
       ],
       caseNum: '',
-      date: moment('2019-05-18T21:00:00.000Z').toDate(),
-      end: moment('2019-08-29T21:00:00.000Z').toDate(),
+      date: moment('2019-05-19T00:00:00.000Z').toDate(),
+      end: moment('2019-08-30T00:00:00.000Z').toDate(),
       fiReason: 'Case-triggered',
       fiStatus: 'A2',
       identifier: '356b6b84-fc36-4389-a44a-2b038ed2f38d',
@@ -272,7 +271,7 @@ describe('containers/forms/PlanForm/helpers', () => {
       jurisdictions: [{ id: '3952', name: '3952' }],
       name: 'A2-Lusaka_Akros_Focus_2',
       opensrpEventId: undefined,
-      start: moment('2019-05-19T21:00:00.000Z').toDate(),
+      start: moment('2019-05-20T00:00:00.000Z').toDate(),
       status: 'active',
       title: 'A2-Lusaka Akros Test Focus 2',
       version: '1',

--- a/src/containers/forms/PlanForm/tests/helpers.test.ts
+++ b/src/containers/forms/PlanForm/tests/helpers.test.ts
@@ -1,7 +1,4 @@
-import { parseISO } from 'date-fns';
 import MockDate from 'mockdate';
-import moment from 'moment';
-import { DEFAULT_TIME } from '../../../../configs/env';
 import { plans } from '../../../../store/ducks/opensrp/PlanDefinition/tests/fixtures';
 import {
   doesFieldHaveErrors,
@@ -26,6 +23,7 @@ import {
   planActivities,
   planActivityWithEmptyfields,
   planFormValues,
+  planFormValues2,
   values,
   values2,
   valuesWithJurisdiction,
@@ -181,125 +179,7 @@ describe('containers/forms/PlanForm/helpers', () => {
   });
 
   it('getPlanFormValues returns the correct value', () => {
-    expect(getPlanFormValues(plans[0])).toEqual({
-      activities: [
-        {
-          actionCode: 'Case Confirmation',
-          actionDescription: 'Confirm the index case',
-          actionIdentifier: 'c711ae51-6432-4b68-84c3-d2b5b1fd1948',
-          actionReason: 'Investigation',
-          actionTitle: 'Case Confirmation',
-          goalDescription: 'Confirm the index case',
-          goalDue: moment('2019-05-21T00:00:00.000Z').toDate(),
-          goalPriority: 'medium-priority',
-          goalValue: 1,
-          timingPeriodEnd: moment('2019-05-24T00:00:00.000Z').toDate(),
-          timingPeriodStart: moment('2019-05-21T00:00:00.000Z').toDate(),
-        },
-        {
-          actionCode: 'RACD Register Family',
-          actionDescription:
-            'Register all families & famiy members in all residential structures enumerated (100%) within the operational area',
-          actionIdentifier: '402b8c13-6774-4515-929f-48e71a61a379',
-          actionReason: 'Investigation',
-          actionTitle: 'Family Registration',
-          goalDescription:
-            'Register all families and family members in all residential structures enumerated or added (100%) within operational area',
-          goalDue: moment('2019-08-30T00:00:00.000Z').toDate(),
-          goalPriority: 'medium-priority',
-          goalValue: 100,
-          timingPeriodEnd: moment('2019-08-30T00:00:00.000Z').toDate(),
-          timingPeriodStart: moment('2019-05-21T00:00:00.000Z').toDate(),
-        },
-        {
-          actionCode: 'Bednet Distribution',
-          actionDescription:
-            'Visit 100% of residential structures in the operational area and provide nets',
-          actionIdentifier: '1bd830ea-50e3-44dc-b855-9d5e9339e2be',
-          actionReason: 'Routine',
-          actionTitle: 'Bednet Distribution',
-          goalDescription:
-            'Visit 100% of residential structures in the operational area and provide nets',
-          goalDue: moment('2019-08-30T00:00:00.000Z').toDate(),
-          goalPriority: 'medium-priority',
-          goalValue: 100,
-          timingPeriodEnd: moment('2019-08-30T00:00:00.000Z').toDate(),
-          timingPeriodStart: moment('2019-05-21T00:00:00.000Z').toDate(),
-        },
-        {
-          actionCode: 'Blood Screening',
-          actionDescription:
-            'Visit all residential structures (100%) within a 1 km radius of a confirmed index case and test each registered person',
-          actionIdentifier: '2303a70e-4e3f-4fb9-a430-f0476010bfb5',
-          actionReason: 'Investigation',
-          actionTitle: 'RACD Blood screening',
-          goalDescription:
-            'Visit all residential structures (100%) within a 1 km radius of a confirmed index case and test each registered person',
-          goalDue: moment('2019-05-28T00:00:00.000Z').toDate(),
-          goalPriority: 'medium-priority',
-          goalValue: 100,
-          timingPeriodEnd: moment('2019-05-28T00:00:00.000Z').toDate(),
-          timingPeriodStart: moment('2019-05-21T00:00:00.000Z').toDate(),
-        },
-        {
-          actionCode: 'Larval Dipping',
-          actionDescription:
-            'Perform a minimum of three larval dipping activities in the operational area',
-          actionIdentifier: '2482dfd7-8284-43c6-bea1-a03dcda71ff4',
-          actionReason: 'Investigation',
-          actionTitle: 'Larval Dipping',
-          goalDescription:
-            'Perform a minimum of three larval dipping activities in the operational area',
-          goalDue: moment('2019-05-28T00:00:00.000Z').toDate(),
-          goalPriority: 'medium-priority',
-          goalValue: 3,
-          timingPeriodEnd: moment('2019-05-28T00:00:00.000Z').toDate(),
-          timingPeriodStart: moment('2019-05-21T00:00:00.000Z').toDate(),
-        },
-        {
-          actionCode: 'Mosquito Collection',
-          actionDescription:
-            'Set a minimum of three mosquito collection traps and complete the mosquito collection process',
-          actionIdentifier: '423f6665-5367-40be-855e-7c5e6941a0c3',
-          actionReason: 'Investigation',
-          actionTitle: 'Mosquito Collection',
-          goalDescription:
-            'Set a minimum of three mosquito collection traps and complete the mosquito collection process',
-          goalDue: moment('2019-05-28T00:00:00.000Z').toDate(),
-          goalPriority: 'medium-priority',
-          goalValue: 3,
-          timingPeriodEnd: moment('2019-05-28T00:00:00.000Z').toDate(),
-          timingPeriodStart: moment('2019-05-21T00:00:00.000Z').toDate(),
-        },
-        {
-          actionCode: 'BCC',
-          actionDescription: 'Conduct BCC activity',
-          actionIdentifier: 'c8fc89a9-cdd2-4746-8272-650883ae380e',
-          actionReason: 'Investigation',
-          actionTitle: 'Behaviour Change Communication',
-          goalDescription: 'Complete at least 1 BCC activity for the operational area',
-          goalDue: moment('2019-06-21T00:00:00.000Z').toDate(),
-          goalPriority: 'medium-priority',
-          goalValue: 1,
-          timingPeriodEnd: moment('2019-06-21T00:00:00.000Z').toDate(),
-          timingPeriodStart: moment('2019-05-21T00:00:00.000Z').toDate(),
-        },
-      ],
-      caseNum: '',
-      date: moment('2019-05-19T00:00:00.000Z').toDate(),
-      end: moment('2019-08-30T00:00:00.000Z').toDate(),
-      fiReason: 'Case-triggered',
-      fiStatus: 'A2',
-      identifier: '356b6b84-fc36-4389-a44a-2b038ed2f38d',
-      interventionType: 'FI',
-      jurisdictions: [{ id: '3952', name: '3952' }],
-      name: 'A2-Lusaka_Akros_Focus_2',
-      opensrpEventId: undefined,
-      start: moment('2019-05-20T00:00:00.000Z').toDate(),
-      status: 'active',
-      title: 'A2-Lusaka Akros Test Focus 2',
-      version: '1',
-    });
+    expect(getPlanFormValues(plans[0])).toEqual(planFormValues2);
 
     const plan = getPlanFormValues(plans[2]);
     // caseNum and opensrpEventId are gotten right

--- a/src/containers/forms/PlanForm/tests/helpers.test.ts
+++ b/src/containers/forms/PlanForm/tests/helpers.test.ts
@@ -9,6 +9,7 @@ import {
   getFormActivities,
   getNameTitle,
   getPlanFormValues,
+  PlanFormFields,
 } from '../helpers';
 import {
   activities,
@@ -142,6 +143,17 @@ describe('containers/forms/PlanForm/helpers', () => {
   it('check generatePlanDefinition returns the correct value', () => {
     MockDate.set('1/30/2000', 0);
     expect(generatePlanDefinition(values2)).toEqual(expectedPlanDefinition);
+    MockDate.reset();
+  });
+
+  it('getPlanFormValues and generatePlanDefinition are interoperable', () => {
+    MockDate.set('1/30/2000', 0);
+    const planForm = values2 as PlanFormFields;
+    const generatedPlan = generatePlanDefinition(planForm);
+    const generatedPlanForm = getPlanFormValues(generatedPlan);
+
+    expect(planForm).toEqual(generatedPlanForm);
+    // expect(generatePlanDefinition(values2)).toEqual(expectedPlanDefinition);
     MockDate.reset();
   });
 

--- a/src/containers/forms/PlanForm/tests/helpers.test.ts
+++ b/src/containers/forms/PlanForm/tests/helpers.test.ts
@@ -23,6 +23,7 @@ import {
   extractedActivitiesFromForms,
   planActivities,
   planActivityWithEmptyfields,
+  planFormValues,
   values,
   values2,
   valuesWithJurisdiction,
@@ -146,14 +147,22 @@ describe('containers/forms/PlanForm/helpers', () => {
     MockDate.reset();
   });
 
-  it('getPlanFormValues and generatePlanDefinition are interoperable', () => {
-    MockDate.set('1/30/2000', 0);
-    const planForm = values2 as PlanFormFields;
+  it('getPlanFormValues can get original planForm', () => {
+    const planForm = planFormValues as PlanFormFields;
+
     const generatedPlan = generatePlanDefinition(planForm);
     const generatedPlanForm = getPlanFormValues(generatedPlan);
 
-    expect(planForm).toEqual(generatedPlanForm);
-    MockDate.reset();
+    expect(planForm).toEqual({
+      ...generatedPlanForm,
+      jurisdictions: [
+        {
+          id: '3952',
+          name: 'Akros_2', // getPlanFormValues does not have access to the name
+        },
+      ],
+      version: '1', // the version is updated so we change it back
+    });
   });
 
   it('getPlanFormValues returns the correct value', () => {

--- a/src/containers/forms/PlanForm/tests/index.test.tsx
+++ b/src/containers/forms/PlanForm/tests/index.test.tsx
@@ -270,5 +270,6 @@ describe('containers/forms/PlanForm - Edit', () => {
     expect(toJson(wrapper.find('#start input'))).toMatchSnapshot('start field');
     expect(toJson(wrapper.find('#end input'))).toMatchSnapshot('end field');
     expect(toJson(wrapper.find('#date input'))).toMatchSnapshot('date field');
+    expect(wrapper.find('#jurisdictions-select-container').length).toEqual(0);
   });
 });

--- a/src/containers/forms/PlanForm/tests/index.test.tsx
+++ b/src/containers/forms/PlanForm/tests/index.test.tsx
@@ -47,6 +47,7 @@ describe('containers/forms/PlanForm', () => {
     expect(toJson(wrapper.find('#date input'))).toMatchSnapshot('date field');
     expect(toJson(wrapper.find('#planform-submit-button button'))).toMatchSnapshot('submit button');
     expect(wrapper.find('#jurisdictions-select-container').length).toEqual(1);
+    expect(wrapper.find('#jurisdictions-display-container').length).toEqual(0);
 
     // if you set fiReason to case triggered then caseNum and opensrpEventId are now rendered
     wrapper
@@ -271,5 +272,6 @@ describe('containers/forms/PlanForm - Edit', () => {
     expect(toJson(wrapper.find('#end input'))).toMatchSnapshot('end field');
     expect(toJson(wrapper.find('#date input'))).toMatchSnapshot('date field');
     expect(wrapper.find('#jurisdictions-select-container').length).toEqual(0);
+    expect(wrapper.find('#jurisdictions-display-container').length).toEqual(1);
   });
 });

--- a/src/containers/forms/PlanForm/tests/index.test.tsx
+++ b/src/containers/forms/PlanForm/tests/index.test.tsx
@@ -309,6 +309,10 @@ describe('containers/forms/PlanForm - Edit', () => {
 
     checkJurisdtictions(plans[1].jurisdiction.length);
 
+    expect(toJson(wrapper.find('#selected-jurisdiction-list li span'))).toMatchSnapshot(
+      'selected jurisdictions'
+    );
+
     // there is no button to remove jurisdictions
     expect(wrapper.find(`.removeJurisdiction`).length).toEqual(0);
     // there is no button to add more jurisdictions

--- a/src/containers/forms/PlanForm/tests/index.test.tsx
+++ b/src/containers/forms/PlanForm/tests/index.test.tsx
@@ -1,7 +1,7 @@
 import { mount, shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import React from 'react';
-import PlanForm from '..';
+import PlanForm, { propsForUpdatingPlans } from '..';
 import { plans } from '../../../../store/ducks/opensrp/PlanDefinition/tests/fixtures';
 import { getPlanFormValues } from '../helpers';
 import * as fixtures from './fixtures';
@@ -240,25 +240,7 @@ describe('containers/forms/PlanForm - Edit', () => {
   it('renders all fields correctly in edit mode', () => {
     fetch.mockResponseOnce(fixtures.jurisdictionLevel0JSON);
     const props = {
-      disabledActivityFields: [
-        'actionReason',
-        'goalPriority',
-        'timingPeriodStart',
-        'timingPeriodEnd',
-      ],
-      disabledFields: [
-        'interventionType',
-        'fiReason',
-        'fiStatus',
-        'identifier',
-        'start',
-        'date',
-        'end',
-        'name',
-        'caseNum',
-        'opensrpEventId',
-        'jurisdictions',
-      ],
+      ...propsForUpdatingPlans,
       initialValues: getPlanFormValues(plans[0]),
     };
     const wrapper = mount(<PlanForm {...props} />);
@@ -296,25 +278,7 @@ describe('containers/forms/PlanForm - Edit', () => {
 
     fetch.mockResponseOnce(fixtures.jurisdictionLevel0JSON);
     const props = {
-      disabledActivityFields: [
-        'actionReason',
-        'goalPriority',
-        'timingPeriodStart',
-        'timingPeriodEnd',
-      ],
-      disabledFields: [
-        'interventionType',
-        'fiReason',
-        'fiStatus',
-        'identifier',
-        'start',
-        'date',
-        'end',
-        'name',
-        'caseNum',
-        'opensrpEventId',
-        'jurisdictions',
-      ],
+      ...propsForUpdatingPlans,
       initialValues: getPlanFormValues(plans[1]),
     };
     const wrapper = mount(<PlanForm {...props} />);
@@ -376,25 +340,7 @@ describe('containers/forms/PlanForm - Edit', () => {
 
     fetch.mockResponseOnce(fixtures.jurisdictionLevel0JSON);
     const props = {
-      disabledActivityFields: [
-        'actionReason',
-        'goalPriority',
-        'timingPeriodStart',
-        'timingPeriodEnd',
-      ],
-      disabledFields: [
-        'interventionType',
-        'fiReason',
-        'fiStatus',
-        'identifier',
-        'start',
-        'date',
-        'end',
-        'name',
-        'caseNum',
-        'opensrpEventId',
-        'jurisdictions',
-      ],
+      ...propsForUpdatingPlans,
       initialValues: getPlanFormValues(plans[1]),
     };
     const wrapper = mount(<PlanForm {...props} />);

--- a/src/containers/forms/PlanForm/tests/index.test.tsx
+++ b/src/containers/forms/PlanForm/tests/index.test.tsx
@@ -238,6 +238,7 @@ describe('containers/forms/PlanForm - Edit', () => {
   });
 
   it('renders all fields correctly in edit mode', () => {
+    fetch.mockResponseOnce(fixtures.jurisdictionLevel0JSON);
     const props = {
       disabledFields: [
         'interventionType',
@@ -273,5 +274,46 @@ describe('containers/forms/PlanForm - Edit', () => {
     expect(toJson(wrapper.find('#date input'))).toMatchSnapshot('date field');
     expect(wrapper.find('#jurisdictions-select-container').length).toEqual(0);
     expect(wrapper.find('#jurisdictions-display-container').length).toEqual(1);
+  });
+
+  it('renders jurisdictions fields correctly', () => {
+    function checkJurisdtictions(num: number) {
+      for (let i = 0; i <= num; i++) {
+        expect(toJson(wrapper.find(`#jurisdictions-${i}-id input`))).toMatchSnapshot(
+          `jurisdictions[${i}].id field`
+        );
+        expect(toJson(wrapper.find(`#jurisdictions-${i}-name input`))).toMatchSnapshot(
+          `jurisdictions[${i}].name field`
+        );
+      }
+    }
+
+    fetch.mockResponseOnce(fixtures.jurisdictionLevel0JSON);
+    const props = {
+      disabledFields: [
+        'interventionType',
+        'fiReason',
+        'fiStatus',
+        'identifier',
+        'start',
+        'date',
+        'end',
+        'name',
+        'caseNum',
+        'opensrpEventId',
+        'jurisdictions',
+      ],
+      initialValues: getPlanFormValues(plans[1]),
+    };
+    const wrapper = mount(<PlanForm {...props} />);
+
+    checkJurisdtictions(plans[1].jurisdiction.length);
+
+    // there is no button to remove jurisdictions
+    expect(wrapper.find(`.removeJurisdiction`).length).toEqual(0);
+    // there is no button to add more jurisdictions
+    expect(wrapper.find(`.addJurisdiction`).length).toEqual(0);
+
+    wrapper.unmount();
   });
 });

--- a/src/containers/forms/PlanForm/tests/index.test.tsx
+++ b/src/containers/forms/PlanForm/tests/index.test.tsx
@@ -46,6 +46,7 @@ describe('containers/forms/PlanForm', () => {
     expect(wrapper.find({ for: 'date' }).length).toEqual(0);
     expect(toJson(wrapper.find('#date input'))).toMatchSnapshot('date field');
     expect(toJson(wrapper.find('#planform-submit-button button'))).toMatchSnapshot('submit button');
+    expect(wrapper.find('#jurisdictions-select-container').length).toEqual(1);
 
     // if you set fiReason to case triggered then caseNum and opensrpEventId are now rendered
     wrapper

--- a/src/containers/forms/PlanForm/tests/index.test.tsx
+++ b/src/containers/forms/PlanForm/tests/index.test.tsx
@@ -332,4 +332,75 @@ describe('containers/forms/PlanForm - Edit', () => {
 
     wrapper.unmount();
   });
+
+  it('renders activity fields correctly', () => {
+    function checkActivities(num: number) {
+      // FI activities by default
+      for (let i = 0; i <= num; i++) {
+        expect(toJson(wrapper.find(`#activities-${i}-actionTitle input`))).toMatchSnapshot(
+          `activities[${i}].actionTitle field`
+        );
+        expect(toJson(wrapper.find(`#activities-${i}-actionCode input`))).toMatchSnapshot(
+          `activities[${i}].actionCode field`
+        );
+        expect(toJson(wrapper.find(`#activities-${i}-actionIdentifier input`))).toMatchSnapshot(
+          `activities[${i}].actionIdentifier field`
+        );
+
+        expect(toJson(wrapper.find(`#activities-${i}-actionDescription textarea`))).toMatchSnapshot(
+          `activities[${i}].actionDescription field`
+        );
+        expect(toJson(wrapper.find(`#activities-${i}-goalDescription input`))).toMatchSnapshot(
+          `activities[${i}].goalDescription field`
+        );
+        expect(toJson(wrapper.find(`#activities-${i}-goalValue input`))).toMatchSnapshot(
+          `activities[${i}].goalValue field`
+        );
+        expect(toJson(wrapper.find(`#activities-${i}-timingPeriodStart input`))).toMatchSnapshot(
+          `activities[${i}].timingPeriodStart field`
+        );
+        expect(toJson(wrapper.find(`#activities-${i}-timingPeriodEnd input`))).toMatchSnapshot(
+          `activities[${i}].timingPeriodEnd field`
+        );
+        expect(toJson(wrapper.find(`#activities-${i}-goalDue input`))).toMatchSnapshot(
+          `activities[${i}].goalDue field`
+        );
+        expect(toJson(wrapper.find(`#activities-${i}-actionReason select`))).toMatchSnapshot(
+          `activities[${i}].actionReason field`
+        );
+        expect(toJson(wrapper.find(`#activities-${i}-goalPriority select`))).toMatchSnapshot(
+          `activities[${i}].goalPriority field`
+        );
+      }
+    }
+
+    fetch.mockResponseOnce(fixtures.jurisdictionLevel0JSON);
+    const props = {
+      disabledActivityFields: [
+        'actionReason',
+        'goalPriority',
+        'timingPeriodStart',
+        'timingPeriodEnd',
+      ],
+      disabledFields: [
+        'interventionType',
+        'fiReason',
+        'fiStatus',
+        'identifier',
+        'start',
+        'date',
+        'end',
+        'name',
+        'caseNum',
+        'opensrpEventId',
+        'jurisdictions',
+      ],
+      initialValues: getPlanFormValues(plans[1]),
+    };
+    const wrapper = mount(<PlanForm {...props} />);
+
+    checkActivities(plans[1].action.length);
+
+    wrapper.unmount();
+  });
 });

--- a/src/containers/forms/PlanForm/tests/index.test.tsx
+++ b/src/containers/forms/PlanForm/tests/index.test.tsx
@@ -240,6 +240,12 @@ describe('containers/forms/PlanForm - Edit', () => {
   it('renders all fields correctly in edit mode', () => {
     fetch.mockResponseOnce(fixtures.jurisdictionLevel0JSON);
     const props = {
+      disabledActivityFields: [
+        'actionReason',
+        'goalPriority',
+        'timingPeriodStart',
+        'timingPeriodEnd',
+      ],
       disabledFields: [
         'interventionType',
         'fiReason',
@@ -290,6 +296,12 @@ describe('containers/forms/PlanForm - Edit', () => {
 
     fetch.mockResponseOnce(fixtures.jurisdictionLevel0JSON);
     const props = {
+      disabledActivityFields: [
+        'actionReason',
+        'goalPriority',
+        'timingPeriodStart',
+        'timingPeriodEnd',
+      ],
       disabledFields: [
         'interventionType',
         'fiReason',

--- a/src/containers/forms/PlanForm/tests/index.test.tsx
+++ b/src/containers/forms/PlanForm/tests/index.test.tsx
@@ -2,6 +2,8 @@ import { mount, shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import React from 'react';
 import PlanForm from '..';
+import { plans } from '../../../../store/ducks/opensrp/PlanDefinition/tests/fixtures';
+import { getPlanFormValues } from '../helpers';
 import * as fixtures from './fixtures';
 
 /* tslint:disable-next-line no-var-requires */
@@ -241,12 +243,31 @@ describe('containers/forms/PlanForm - Edit', () => {
         'fiStatus',
         'identifier',
         'start',
+        'date',
         'end',
         'name',
+        'caseNum',
         'opensrpEventId',
         'jurisdictions',
       ],
+      initialValues: getPlanFormValues(plans[0]),
     };
     const wrapper = mount(<PlanForm {...props} />);
+    expect(toJson(wrapper.find('#interventionType select'))).toMatchSnapshot(
+      'interventionType field'
+    );
+    expect(toJson(wrapper.find('#fiStatus select'))).toMatchSnapshot('fiStatus field');
+    expect(toJson(wrapper.find('#fiReason select'))).toMatchSnapshot('fiReason field');
+    // caseNum and opensrpEventId are not present in this plan object
+    expect(wrapper.find('#caseNum').length).toEqual(0);
+    expect(wrapper.find('#opensrpEventId').length).toEqual(0);
+    expect(toJson(wrapper.find('#title input'))).toMatchSnapshot('title field');
+    expect(toJson(wrapper.find('#name input'))).toMatchSnapshot('name field');
+    expect(toJson(wrapper.find('#identifier input'))).toMatchSnapshot('identifier field');
+    expect(toJson(wrapper.find('#version input'))).toMatchSnapshot('version field');
+    expect(toJson(wrapper.find('#status select'))).toMatchSnapshot('status field');
+    expect(toJson(wrapper.find('#start input'))).toMatchSnapshot('start field');
+    expect(toJson(wrapper.find('#end input'))).toMatchSnapshot('end field');
+    expect(toJson(wrapper.find('#date input'))).toMatchSnapshot('date field');
   });
 });

--- a/src/containers/pages/InterventionPlan/PlanDefinitionList/index.tsx
+++ b/src/containers/pages/InterventionPlan/PlanDefinitionList/index.tsx
@@ -3,13 +3,14 @@ import reducerRegistry from '@onaio/redux-reducer-registry';
 import React, { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
 import { Col, Row } from 'reactstrap';
 import { Store } from 'redux';
 import LinkToNewPlans from '../../../../components/LinkToNewPlans';
 import HeaderBreadcrumb from '../../../../components/page/HeaderBreadcrumb/HeaderBreadcrumb';
 import Loading from '../../../../components/page/Loading';
 import { PlanDefinition } from '../../../../configs/settings';
-import { HOME, HOME_URL, PLAN_LIST_URL, PLANS } from '../../../../constants';
+import { HOME, HOME_URL, PLAN_LIST_URL, PLAN_UPDATE_URL, PLANS } from '../../../../constants';
 import { OpenSRPService } from '../../../../services/opensrp';
 import planDefinitionReducer, {
   fetchPlanDefinitions,
@@ -75,9 +76,9 @@ const PlanDefinitionList = (props: PlanListProps) => {
       const typeUseContext = planObj.useContext.filter(e => e.code === 'interventionType');
 
       return [
-        <a href="#" key={planObj.identifier}>
+        <Link to={`${PLAN_UPDATE_URL}/${planObj.identifier}`} key={planObj.identifier}>
           {planObj.title}
-        </a>,
+        </Link>,
         typeUseContext.length > 0 ? typeUseContext[0].valueCodableConcept : '',
         planObj.status,
         planObj.date,

--- a/src/containers/pages/InterventionPlan/PlanDefinitionList/index.tsx
+++ b/src/containers/pages/InterventionPlan/PlanDefinitionList/index.tsx
@@ -17,7 +17,7 @@ import planDefinitionReducer, {
   reducerName as planDefinitionReducerName,
 } from '../../../../store/ducks/opensrp/PlanDefinition';
 
-/** register the goals reducer */
+/** register the plan definitions reducer */
 reducerRegistry.register(planDefinitionReducerName, planDefinitionReducer);
 
 /** interface for PlanList props */

--- a/src/containers/pages/InterventionPlan/PlanDefinitionList/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/pages/InterventionPlan/PlanDefinitionList/tests/__snapshots__/index.test.tsx.snap
@@ -915,41 +915,45 @@ exports[`components/InterventionPlan/PlanDefinitionList renders plan definition 
                 data={
                   Array [
                     Array [
-                      <a
-                        href="#"
+                      <Link
+                        replace={false}
+                        to="/plans/update/356b6b84-fc36-4389-a44a-2b038ed2f38d"
                       >
                         A2-Lusaka Akros Test Focus 2
-                      </a>,
+                      </Link>,
                       "FI",
                       "active",
                       "2019-05-19",
                     ],
                     Array [
-                      <a
-                        href="#"
+                      <Link
+                        replace={false}
+                        to="/plans/update/8fa7eb32-99d7-4b49-8332-9ecedd6d51ae"
                       >
                         TwoTwoOne_01 IRS 2019-07-10
-                      </a>,
+                      </Link>,
                       "IRS",
                       "active",
                       "2019-07-10",
                     ],
                     Array [
-                      <a
-                        href="#"
+                      <Link
+                        replace={false}
+                        to="/plans/update/f0558ad1-396d-4d97-9fff-c46cf92b6ce6"
                       >
                         A1 - TwoTwoTwo_03 - 2019-07-18
-                      </a>,
+                      </Link>,
                       "FI",
                       "active",
                       "2019-07-18",
                     ],
                     Array [
-                      <a
-                        href="#"
+                      <Link
+                        replace={false}
+                        to="/plans/update/0e85c238-39c1-4cea-a926-3d89f0c98429"
                       >
                         A Test By Mosh
-                      </a>,
+                      </Link>,
                       "FI",
                       "draft",
                       "2019-05-19",
@@ -1033,11 +1037,12 @@ exports[`components/InterventionPlan/PlanDefinitionList renders plan definition 
                         className="listview-th"
                         items={
                           Array [
-                            <a
-                              href="#"
+                            <Link
+                              replace={false}
+                              to="/plans/update/356b6b84-fc36-4389-a44a-2b038ed2f38d"
                             >
                               A2-Lusaka Akros Test Focus 2
-                            </a>,
+                            </Link>,
                             "FI",
                             "active",
                             "2019-05-19",
@@ -1048,12 +1053,18 @@ exports[`components/InterventionPlan/PlanDefinitionList renders plan definition 
                           className="listview-th"
                           key="0"
                         >
-                          <a
-                            href="#"
+                          <Link
                             key="356b6b84-fc36-4389-a44a-2b038ed2f38d"
+                            replace={false}
+                            to="/plans/update/356b6b84-fc36-4389-a44a-2b038ed2f38d"
                           >
-                            A2-Lusaka Akros Test Focus 2
-                          </a>
+                            <a
+                              href="/plans/update/356b6b84-fc36-4389-a44a-2b038ed2f38d"
+                              onClick={[Function]}
+                            >
+                              A2-Lusaka Akros Test Focus 2
+                            </a>
+                          </Link>
                         </td>
                         <td
                           className="listview-th"
@@ -1084,11 +1095,12 @@ exports[`components/InterventionPlan/PlanDefinitionList renders plan definition 
                         className="listview-th"
                         items={
                           Array [
-                            <a
-                              href="#"
+                            <Link
+                              replace={false}
+                              to="/plans/update/8fa7eb32-99d7-4b49-8332-9ecedd6d51ae"
                             >
                               TwoTwoOne_01 IRS 2019-07-10
-                            </a>,
+                            </Link>,
                             "IRS",
                             "active",
                             "2019-07-10",
@@ -1099,12 +1111,18 @@ exports[`components/InterventionPlan/PlanDefinitionList renders plan definition 
                           className="listview-th"
                           key="0"
                         >
-                          <a
-                            href="#"
+                          <Link
                             key="8fa7eb32-99d7-4b49-8332-9ecedd6d51ae"
+                            replace={false}
+                            to="/plans/update/8fa7eb32-99d7-4b49-8332-9ecedd6d51ae"
                           >
-                            TwoTwoOne_01 IRS 2019-07-10
-                          </a>
+                            <a
+                              href="/plans/update/8fa7eb32-99d7-4b49-8332-9ecedd6d51ae"
+                              onClick={[Function]}
+                            >
+                              TwoTwoOne_01 IRS 2019-07-10
+                            </a>
+                          </Link>
                         </td>
                         <td
                           className="listview-th"
@@ -1135,11 +1153,12 @@ exports[`components/InterventionPlan/PlanDefinitionList renders plan definition 
                         className="listview-th"
                         items={
                           Array [
-                            <a
-                              href="#"
+                            <Link
+                              replace={false}
+                              to="/plans/update/f0558ad1-396d-4d97-9fff-c46cf92b6ce6"
                             >
                               A1 - TwoTwoTwo_03 - 2019-07-18
-                            </a>,
+                            </Link>,
                             "FI",
                             "active",
                             "2019-07-18",
@@ -1150,12 +1169,18 @@ exports[`components/InterventionPlan/PlanDefinitionList renders plan definition 
                           className="listview-th"
                           key="0"
                         >
-                          <a
-                            href="#"
+                          <Link
                             key="f0558ad1-396d-4d97-9fff-c46cf92b6ce6"
+                            replace={false}
+                            to="/plans/update/f0558ad1-396d-4d97-9fff-c46cf92b6ce6"
                           >
-                            A1 - TwoTwoTwo_03 - 2019-07-18
-                          </a>
+                            <a
+                              href="/plans/update/f0558ad1-396d-4d97-9fff-c46cf92b6ce6"
+                              onClick={[Function]}
+                            >
+                              A1 - TwoTwoTwo_03 - 2019-07-18
+                            </a>
+                          </Link>
                         </td>
                         <td
                           className="listview-th"
@@ -1186,11 +1211,12 @@ exports[`components/InterventionPlan/PlanDefinitionList renders plan definition 
                         className="listview-th"
                         items={
                           Array [
-                            <a
-                              href="#"
+                            <Link
+                              replace={false}
+                              to="/plans/update/0e85c238-39c1-4cea-a926-3d89f0c98429"
                             >
                               A Test By Mosh
-                            </a>,
+                            </Link>,
                             "FI",
                             "draft",
                             "2019-05-19",
@@ -1201,12 +1227,18 @@ exports[`components/InterventionPlan/PlanDefinitionList renders plan definition 
                           className="listview-th"
                           key="0"
                         >
-                          <a
-                            href="#"
+                          <Link
                             key="0e85c238-39c1-4cea-a926-3d89f0c98429"
+                            replace={false}
+                            to="/plans/update/0e85c238-39c1-4cea-a926-3d89f0c98429"
                           >
-                            A Test By Mosh
-                          </a>
+                            <a
+                              href="/plans/update/0e85c238-39c1-4cea-a926-3d89f0c98429"
+                              onClick={[Function]}
+                            >
+                              A Test By Mosh
+                            </a>
+                          </Link>
                         </td>
                         <td
                           className="listview-th"

--- a/src/containers/pages/InterventionPlan/PlanDefinitionList/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/pages/InterventionPlan/PlanDefinitionList/tests/__snapshots__/index.test.tsx.snap
@@ -393,6 +393,12 @@ exports[`components/InterventionPlan/PlanDefinitionList renders plan definition 
             Object {
               "code": "35968df5-f335-44ae-8ae5-25804caa2d86",
             },
+            Object {
+              "code": "3952",
+            },
+            Object {
+              "code": "ac7ba751-35e8-4b46-9e53-3cbaad193697",
+            },
           ],
           "name": "TwoTwoOne_01_IRS_2019-07-10",
           "serverVersion": 1563303151426,

--- a/src/containers/pages/InterventionPlan/UpdatePlan/index.tsx
+++ b/src/containers/pages/InterventionPlan/UpdatePlan/index.tsx
@@ -19,6 +19,7 @@ import {
 import { OpenSRPService } from '../../../../services/opensrp';
 import planDefinitionReducer, {
   addPlanDefinition,
+  getPlanDefinitionById,
   reducerName as planDefinitionReducerName,
 } from '../../../../store/ducks/opensrp/PlanDefinition';
 import PlanForm, { propsForUpdatingPlans } from '../../../forms/PlanForm';
@@ -124,26 +125,25 @@ export { UpdatePlan };
 /** Connect the component to the store */
 
 /** interface to describe props from mapStateToProps */
-// interface DispatchedStateProps {
-//   plans: PlanDefinition[];
-// }
+interface DispatchedStateProps {
+  plan: PlanDefinition | null;
+}
 
 // /** map state to props */
-// const mapStateToProps = (state: Partial<Store>): DispatchedStateProps => {
-//   const planDefinitionsArray = getPlanDefinitionsArray(state);
+const mapStateToProps = (state: Partial<Store>, ownProps: any): DispatchedStateProps => {
+  const planObj = getPlanDefinitionById(state, ownProps.match.params.id);
+  return {
+    plan: planObj,
+  };
+};
 
-//   return {
-//     plans: planDefinitionsArray,
-//   };
-// };
+/** map dispatch to props */
+const mapDispatchToProps = { fetchPlan: addPlanDefinition };
 
-// /** map dispatch to props */
-// const mapDispatchToProps = { fetchPlans: fetchPlanDefinitions };
+/** Connected ActiveFI component */
+const ConnectedUpdatePlan = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(UpdatePlan);
 
-// /** Connected ActiveFI component */
-// const ConnectedPlanDefinitionList = connect(
-//   mapStateToProps,
-//   mapDispatchToProps
-// )(PlanDefinitionList);
-
-// export default ConnectedPlanDefinitionList;
+export default ConnectedUpdatePlan;

--- a/src/containers/pages/InterventionPlan/UpdatePlan/index.tsx
+++ b/src/containers/pages/InterventionPlan/UpdatePlan/index.tsx
@@ -1,0 +1,105 @@
+import reducerRegistry from '@onaio/redux-reducer-registry';
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import { Col, Row } from 'reactstrap';
+import HeaderBreadcrumb from '../../../../components/page/HeaderBreadcrumb/HeaderBreadcrumb';
+import { PlanDefinition } from '../../../../configs/settings';
+import { HOME, HOME_URL, NEW_PLAN_URL, PLAN_LIST_URL, PLANS } from '../../../../constants';
+import { OpenSRPService } from '../../../../services/opensrp';
+import planDefinitionReducer, {
+  addPlanDefinition,
+  reducerName as planDefinitionReducerName,
+} from '../../../../store/ducks/opensrp/PlanDefinition';
+import PlanForm, { propsForUpdatingPlans } from '../../../forms/PlanForm';
+import { getPlanFormValues } from '../../../forms/PlanForm/helpers';
+
+/** register the plan definitions reducer */
+reducerRegistry.register(planDefinitionReducerName, planDefinitionReducer);
+
+/** UpdatePlanProps interface */
+interface UpdatePlanProps {
+  fetchPlan: typeof addPlanDefinition;
+  plan: PlanDefinition | null;
+  service: typeof OpenSRPService;
+}
+
+/** Component used to update Plan Definition objects */
+const UpdatePlan = (props: UpdatePlanProps) => {
+  const { plan } = props;
+
+  const pageTitle: string = 'Update Plan';
+
+  const breadcrumbProps = {
+    currentPage: {
+      label: pageTitle,
+      url: `${NEW_PLAN_URL}`,
+    },
+    pages: [
+      {
+        label: HOME,
+        url: HOME_URL,
+      },
+      {
+        label: PLANS,
+        url: PLAN_LIST_URL,
+      },
+    ],
+  };
+
+  const planFormProps = {
+    ...propsForUpdatingPlans,
+    ...(plan && { initialValues: getPlanFormValues(plan) }),
+  };
+
+  return (
+    <div>
+      <Helmet>
+        <title>{pageTitle}</title>
+      </Helmet>
+      <HeaderBreadcrumb {...breadcrumbProps} />
+      <h3 className="mb-3 page-title">{pageTitle}</h3>
+      <Row>
+        <Col md={8}>
+          <PlanForm {...planFormProps} />
+        </Col>
+      </Row>
+    </div>
+  );
+};
+
+const defaultProps: UpdatePlanProps = {
+  fetchPlan: addPlanDefinition,
+  plan: null,
+  service: OpenSRPService,
+};
+
+UpdatePlan.defaultProps = defaultProps;
+
+export { UpdatePlan };
+
+/** Connect the component to the store */
+
+/** interface to describe props from mapStateToProps */
+// interface DispatchedStateProps {
+//   plans: PlanDefinition[];
+// }
+
+// /** map state to props */
+// const mapStateToProps = (state: Partial<Store>): DispatchedStateProps => {
+//   const planDefinitionsArray = getPlanDefinitionsArray(state);
+
+//   return {
+//     plans: planDefinitionsArray,
+//   };
+// };
+
+// /** map dispatch to props */
+// const mapDispatchToProps = { fetchPlans: fetchPlanDefinitions };
+
+// /** Connected ActiveFI component */
+// const ConnectedPlanDefinitionList = connect(
+//   mapStateToProps,
+//   mapDispatchToProps
+// )(PlanDefinitionList);
+
+// export default ConnectedPlanDefinitionList;

--- a/src/containers/pages/InterventionPlan/UpdatePlan/index.tsx
+++ b/src/containers/pages/InterventionPlan/UpdatePlan/index.tsx
@@ -8,14 +8,7 @@ import { Store } from 'redux';
 import HeaderBreadcrumb from '../../../../components/page/HeaderBreadcrumb/HeaderBreadcrumb';
 import Loading from '../../../../components/page/Loading';
 import { PlanDefinition } from '../../../../configs/settings';
-import {
-  HOME,
-  HOME_URL,
-  NEW_PLAN_URL,
-  PLAN_LIST_URL,
-  PLAN_UPDATE_URL,
-  PLANS,
-} from '../../../../constants';
+import { HOME, HOME_URL, NEW_PLAN_URL, PLAN_LIST_URL, PLANS } from '../../../../constants';
 import { OpenSRPService } from '../../../../services/opensrp';
 import planDefinitionReducer, {
   addPlanDefinition,

--- a/src/containers/pages/InterventionPlan/UpdatePlan/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/pages/InterventionPlan/UpdatePlan/tests/__snapshots__/index.test.tsx.snap
@@ -85,17 +85,12 @@ Object {
   "disabledActivityFields": Array [
     "actionReason",
     "goalPriority",
-    "timingPeriodStart",
-    "timingPeriodEnd",
   ],
   "disabledFields": Array [
     "interventionType",
     "fiReason",
     "fiStatus",
     "identifier",
-    "start",
-    "date",
-    "end",
     "name",
     "caseNum",
     "opensrpEventId",

--- a/src/containers/pages/InterventionPlan/UpdatePlan/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/pages/InterventionPlan/UpdatePlan/tests/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,163 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/InterventionPlan/UpdatePlan renders plan definition list correctly: Breadcrumb 1`] = `
+<Breadcrumb
+  aria-label="breadcrumb"
+  className="reveal-breadcrumb"
+  listTag="ol"
+  tag="nav"
+>
+  <nav
+    aria-label="breadcrumb"
+    className="reveal-breadcrumb"
+  >
+    <ol
+      className="breadcrumb"
+    >
+      <BreadcrumbItem
+        key="0"
+        tag="li"
+      >
+        <li
+          className="breadcrumb-item"
+        >
+          <Link
+            key="0"
+            replace={false}
+            to="/"
+          >
+            <a
+              href="/"
+              onClick={[Function]}
+            >
+              Home
+            </a>
+          </Link>
+        </li>
+      </BreadcrumbItem>
+      <BreadcrumbItem
+        key="1"
+        tag="li"
+      >
+        <li
+          className="breadcrumb-item"
+        >
+          <Link
+            key="1"
+            replace={false}
+            to="/plans/list"
+          >
+            <a
+              href="/plans/list"
+              onClick={[Function]}
+            >
+              Manage Plans
+            </a>
+          </Link>
+        </li>
+      </BreadcrumbItem>
+      <BreadcrumbItem
+        active={true}
+        tag="li"
+      >
+        <li
+          aria-current="page"
+          className="active breadcrumb-item"
+        >
+          Update Plan: TwoTwoOne_01 IRS 2019-07-10
+        </li>
+      </BreadcrumbItem>
+    </ol>
+  </nav>
+</Breadcrumb>
+`;
+
+exports[`components/InterventionPlan/UpdatePlan renders plan definition list correctly: Page title 1`] = `
+<h3
+  className="mb-3 page-title"
+>
+  Update Plan: TwoTwoOne_01 IRS 2019-07-10
+</h3>
+`;
+
+exports[`components/InterventionPlan/UpdatePlan renders plan definition list correctly: PlanForm 1`] = `
+Object {
+  "disabledActivityFields": Array [
+    "actionReason",
+    "goalPriority",
+    "timingPeriodStart",
+    "timingPeriodEnd",
+  ],
+  "disabledFields": Array [
+    "interventionType",
+    "fiReason",
+    "fiStatus",
+    "identifier",
+    "start",
+    "date",
+    "end",
+    "name",
+    "caseNum",
+    "opensrpEventId",
+    "jurisdictions",
+  ],
+  "initialValues": Object {
+    "activities": Array [
+      Object {
+        "actionCode": "BCC",
+        "actionDescription": "Perform BCC for the operational area",
+        "actionIdentifier": "3f2eef38-38fe-4108-abb3-4e896b880302",
+        "actionReason": "Routine",
+        "actionTitle": "Perform BCC",
+        "goalDescription": "Complete BCC for the operational area",
+        "goalDue": 2019-07-10T00:00:00.000Z,
+        "goalPriority": "medium-priority",
+        "goalValue": 1,
+        "timingPeriodEnd": 2019-07-30T00:00:00.000Z,
+        "timingPeriodStart": 2019-07-10T00:00:00.000Z,
+      },
+      Object {
+        "actionCode": "IRS",
+        "actionDescription": "Visit each structure in the operational area and attempt to spray",
+        "actionIdentifier": "95a5a00f-a411-4fe5-bd9c-460a856239c9",
+        "actionReason": "Routine",
+        "actionTitle": "Spray Structures",
+        "goalDescription": "Spray 90 % of structures in the operational area",
+        "goalDue": 2019-07-30T00:00:00.000Z,
+        "goalPriority": "medium-priority",
+        "goalValue": 90,
+        "timingPeriodEnd": 2019-07-30T00:00:00.000Z,
+        "timingPeriodStart": 2019-07-10T00:00:00.000Z,
+      },
+    ],
+    "caseNum": "",
+    "date": 2019-07-10T00:00:00.000Z,
+    "end": 2019-07-30T00:00:00.000Z,
+    "fiReason": undefined,
+    "fiStatus": undefined,
+    "identifier": "8fa7eb32-99d7-4b49-8332-9ecedd6d51ae",
+    "interventionType": "IRS",
+    "jurisdictions": Array [
+      Object {
+        "id": "35968df5-f335-44ae-8ae5-25804caa2d86",
+        "name": "35968df5-f335-44ae-8ae5-25804caa2d86",
+      },
+      Object {
+        "id": "3952",
+        "name": "3952",
+      },
+      Object {
+        "id": "ac7ba751-35e8-4b46-9e53-3cbaad193697",
+        "name": "ac7ba751-35e8-4b46-9e53-3cbaad193697",
+      },
+    ],
+    "name": "TwoTwoOne_01_IRS_2019-07-10",
+    "opensrpEventId": undefined,
+    "start": 2019-07-10T00:00:00.000Z,
+    "status": "active",
+    "title": "TwoTwoOne_01 IRS 2019-07-10",
+    "version": "1",
+  },
+  "redirectAfterAction": "/plans/list",
+}
+`;

--- a/src/containers/pages/InterventionPlan/UpdatePlan/tests/index.test.tsx
+++ b/src/containers/pages/InterventionPlan/UpdatePlan/tests/index.test.tsx
@@ -1,0 +1,60 @@
+import { mount, shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import { createBrowserHistory } from 'history';
+import React from 'react';
+import { Router } from 'react-router';
+import { UpdatePlan } from '..';
+import { PlanDefinition } from '../../../../../configs/settings';
+import { PLAN_UPDATE_URL } from '../../../../../constants';
+import * as fixtures from '../../../../../store/ducks/opensrp/PlanDefinition/tests/fixtures';
+
+/* tslint:disable-next-line no-var-requires */
+const fetch = require('jest-fetch-mock');
+
+const history = createBrowserHistory();
+
+describe('components/InterventionPlan/UpdatePlan', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  function getProps() {
+    const mock: any = jest.fn();
+    const serviceMock: any = jest.fn(async () => []);
+    return {
+      fetchPlan: mock,
+      history,
+      location: mock,
+      match: {
+        isExact: true,
+        params: { id: fixtures.plans[1].identifier },
+        path: `${PLAN_UPDATE_URL}/:id`,
+        url: `${PLAN_UPDATE_URL}/${fixtures.plans[1].identifier}`,
+      },
+      plan: fixtures.plans[1] as PlanDefinition,
+      service: serviceMock,
+    };
+  }
+
+  it('renders without crashing', () => {
+    fetch.mockResponseOnce(JSON.stringify(fixtures.plans[1]));
+    shallow(
+      <Router history={history}>
+        <UpdatePlan {...getProps()} />
+      </Router>
+    );
+  });
+
+  it('renders plan definition list correctly', () => {
+    fetch.mockResponseOnce(JSON.stringify(fixtures.plans[1]));
+    const wrapper = mount(
+      <Router history={history}>
+        <UpdatePlan {...getProps()} />
+      </Router>
+    );
+    expect(toJson(wrapper.find('Breadcrumb'))).toMatchSnapshot('Breadcrumb');
+    expect(toJson(wrapper.find('h3.page-title'))).toMatchSnapshot('Page title');
+    expect(wrapper.find('PlanForm').props()).toMatchSnapshot('PlanForm');
+    wrapper.unmount();
+  });
+});

--- a/src/store/ducks/opensrp/PlanDefinition/index.ts
+++ b/src/store/ducks/opensrp/PlanDefinition/index.ts
@@ -17,22 +17,32 @@ export const PLAN_DEFINITIONS_FETCHED =
 export const REMOVE_PLAN_DEFINITIONS =
   'reveal/reducer/opensrp/PlanDefinition/REMOVE_PLAN_DEFINITIONS';
 
+/** PLAN_DEFINITION_FETCHED action type */
+export const ADD_PLAN_DEFINITION = 'reveal/reducer/opensrp/PlanDefinition/ADD_PLAN_DEFINITION';
+
 /** interface for fetch PlanDefinitions action */
 interface FetchPlanDefinitionsAction extends AnyAction {
   planDefinitionsById: { [key: string]: PlanDefinition };
   type: typeof PLAN_DEFINITIONS_FETCHED;
 }
 
-/** interface for fetch PlanDefinitions action */
+/** interface for removing PlanDefinitions action */
 interface RemovePlanDefinitionsAction extends AnyAction {
   planDefinitionsById: { [key: string]: PlanDefinition };
   type: typeof REMOVE_PLAN_DEFINITIONS;
+}
+
+/** interface for adding a single PlanDefinitions action */
+interface AddPlanDefinitionAction extends AnyAction {
+  planObj: PlanDefinition;
+  type: typeof ADD_PLAN_DEFINITION;
 }
 
 /** Create type for PlanDefinition reducer actions */
 export type PlanDefinitionActionTypes =
   | FetchPlanDefinitionsAction
   | RemovePlanDefinitionsAction
+  | AddPlanDefinitionAction
   | AnyAction;
 
 // action creators
@@ -52,6 +62,15 @@ export const fetchPlanDefinitions = (
 export const removePlanDefinitions = () => ({
   planDefinitionsById: {},
   type: REMOVE_PLAN_DEFINITIONS,
+});
+
+/**
+ * Add one Plan Definition action creator
+ * @param {PlanDefinition} planObj - the plan definition object
+ */
+export const addPlanDefinition = (planObj: PlanDefinition): AddPlanDefinitionAction => ({
+  planObj,
+  type: ADD_PLAN_DEFINITION,
 });
 
 // the reducer
@@ -84,8 +103,20 @@ export default function reducer(
         });
       }
       return state;
+    case ADD_PLAN_DEFINITION:
+      if (action.planObj as PlanDefinition) {
+        return SeamlessImmutable({
+          ...state,
+          planDefinitionsById: {
+            ...state.planDefinitionsById,
+            [action.planObj.identifier as string]: action.planObj,
+          },
+        });
+      }
+      return state;
     case REMOVE_PLAN_DEFINITIONS:
       return SeamlessImmutable({
+        ...state,
         planDefinitionsById: action.planDefinitionsById,
       });
     default:

--- a/src/store/ducks/opensrp/PlanDefinition/tests/index.test.ts
+++ b/src/store/ducks/opensrp/PlanDefinition/tests/index.test.ts
@@ -93,8 +93,18 @@ describe('reducers/opensrp/PlanDefinition', () => {
     store.dispatch(addPlanDefinition(fixtures.plans[2] as PlanDefinition));
     // we should have it in the store
     expect(getPlanDefinitionsArray(store.getState())).toEqual([fixtures.plans[2]]);
+
     // fetch one more plan definition objects
     store.dispatch(addPlanDefinition(fixtures.plans[3] as PlanDefinition));
+    // we should now have a total of three plan definition objects in the store
+    expect(getPlanDefinitionsArray(store.getState())).toEqual([
+      fixtures.plans[2],
+      fixtures.plans[3],
+    ]);
+
+    // add an existing plan again
+    store.dispatch(addPlanDefinition(fixtures.plans[2] as PlanDefinition));
+    // nothing should have changed in the store
     // we should now have a total of three plan definition objects in the store
     expect(getPlanDefinitionsArray(store.getState())).toEqual([
       fixtures.plans[2],

--- a/src/store/ducks/opensrp/PlanDefinition/tests/index.test.ts
+++ b/src/store/ducks/opensrp/PlanDefinition/tests/index.test.ts
@@ -5,6 +5,7 @@ import { PlanDefinition } from '../../../../../configs/settings';
 import store from '../../../../index';
 import { InterventionType } from '../../../plans';
 import reducer, {
+  addPlanDefinition,
   fetchPlanDefinitions,
   getPlanDefinitionById,
   getPlanDefinitionsArray,
@@ -80,6 +81,23 @@ describe('reducers/opensrp/PlanDefinition', () => {
     expect(getPlanDefinitionsArray(store.getState())).toEqual([
       fixtures.plans[0],
       fixtures.plans[1],
+      fixtures.plans[3],
+    ]);
+  });
+
+  it('You can add one plan definition object to the store', () => {
+    // reset
+    store.dispatch(removePlanDefinitions());
+
+    // add one plan definition objects
+    store.dispatch(addPlanDefinition(fixtures.plans[2] as PlanDefinition));
+    // we should have it in the store
+    expect(getPlanDefinitionsArray(store.getState())).toEqual([fixtures.plans[2]]);
+    // fetch one more plan definition objects
+    store.dispatch(addPlanDefinition(fixtures.plans[3] as PlanDefinition));
+    // we should now have a total of three plan definition objects in the store
+    expect(getPlanDefinitionsArray(store.getState())).toEqual([
+      fixtures.plans[2],
       fixtures.plans[3],
     ]);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4729,7 +4729,7 @@ data-urls@^1.0.0, data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-date-fns@^1.27.2, date-fns@^1.30.1:
+date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4729,7 +4729,7 @@ data-urls@^1.0.0, data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-date-fns@^1.27.2:
+date-fns@^1.27.2, date-fns@^1.30.1:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==


### PR DESCRIPTION
This PR:

- Fixes #297 
- Adds a function that translates a plan to values for PlanForm aka `getPlanFormValues`
- Implements a way to add a single plan definition object to the redux store
- Fixes #337 and Fixes #335 via #354