### PR TITLE
Only show plans with Active/Complete plan status in ActiveFI

### DIFF
--- a/src/containers/pages/FocusInvestigation/active/index.tsx
+++ b/src/containers/pages/FocusInvestigation/active/index.tsx
@@ -342,13 +342,13 @@ const mapStateToProps = (state: Partial<Store>): DispatchedStateProps => {
   const caseTriggeredPlans = getPlansArray(
     state,
     InterventionType.FI,
-    [PlanStatus.ACTIVE, PlanStatus.DRAFT],
+    [PlanStatus.ACTIVE, PlanStatus.COMPLETE],
     CASE_TRIGGERED
   );
   const routinePlans = getPlansArray(
     state,
     InterventionType.FI,
-    [PlanStatus.ACTIVE, PlanStatus.DRAFT],
+    [PlanStatus.ACTIVE, PlanStatus.COMPLETE],
     ROUTINE
   );
   return {

--- a/src/containers/pages/FocusInvestigation/active/tests/index.test.tsx
+++ b/src/containers/pages/FocusInvestigation/active/tests/index.test.tsx
@@ -17,7 +17,6 @@ import reducer, { fetchPlans, reducerName } from '../../../../../store/ducks/pla
 import * as fixtures from '../../../../../store/ducks/tests/fixtures';
 import ConnectedActiveFocusInvestigation, { ActiveFocusInvestigation } from '../../active';
 reducerRegistry.register(reducerName, reducer);
-import flushPromises from 'flush-promises';
 
 library.add(faExternalLinkSquareAlt);
 const history = createBrowserHistory();
@@ -154,7 +153,6 @@ describe('containers/pages/ActiveFocusInvestigation', () => {
         </Router>
       </Provider>
     );
-    flushPromises();
     const supersetParams = {
       adhoc_filters: [
         {


### PR DESCRIPTION
refactor fiilter arguments passed to the plans selectors

closes #359 .