### PR TITLE
394 handle partially selected jurisdictions

### DIFF
--- a/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
+++ b/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
@@ -1942,26 +1942,22 @@ class IrsPlan extends React.Component<
       }
     };
 
+    const headerCheckboxIsChecked = isFocusJurisdictionTopLevel
+      ? newPlan &&
+        newPlan.plan_jurisdictions_ids &&
+        newPlan.plan_jurisdictions_ids.length === filteredJurisdictionIds.length
+      : !!focusJurisdictionId && this.getIsJurisdictionPartiallySelected(focusJurisdictionId);
+
     const columns = [
       {
-        Header: () => {
-          const isChecked = isFocusJurisdictionTopLevel
-            ? newPlan &&
-              newPlan.plan_jurisdictions_ids &&
-              newPlan.plan_jurisdictions_ids.length === filteredJurisdictionIds.length
-            : !!focusJurisdictionId &&
-              newPlan &&
-              newPlan.plan_jurisdictions_ids &&
-              newPlan.plan_jurisdictions_ids.includes(focusJurisdictionId);
-          return (
-            <Input
-              checked={isChecked}
-              className="plan-jurisdiction-select-all-checkbox"
-              onChange={onToggleAllCheckboxChange}
-              type="checkbox"
-            />
-          );
-        },
+        Header: () => (
+          <Input
+            checked={headerCheckboxIsChecked}
+            className="plan-jurisdiction-select-all-checkbox"
+            onChange={onToggleAllCheckboxChange}
+            type="checkbox"
+          />
+        ),
         columns: [
           {
             Header: '',

--- a/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
+++ b/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
@@ -1113,18 +1113,10 @@ class IrsPlan extends React.Component<
 
       // loop through all geographic_levels
       const geoGraphicLevels = this.getGeographicLevelsFromJurisdictions(filteredJurisdictions);
-      if (
-        typeof clickedFeatureJurisdiction.geographic_level !== 'undefined' &&
-        country &&
-        country.tilesets
-      ) {
+      if (country && country.tilesets) {
         const Map = window.maps.find((e: mbMap) => (e as GisidaMap)._container.id === MAP_ID);
 
-        for (
-          let g = clickedFeatureJurisdiction.geographic_level;
-          g < geoGraphicLevels.length;
-          g += 1
-        ) {
+        for (let g = 1; g < geoGraphicLevels.length; g += 1) {
           // Define stops per geographic_level
           const jurisdictionsByLevelArray = filteredJurisdictions.filter(
             j => j.geographic_level === g

--- a/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
+++ b/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
@@ -238,16 +238,20 @@ class IrsPlan extends React.Component<
 
     await supersetService(SUPERSET_JURISDICTIONS_DATA_SLICE, otherJurisdictionSupersetParams).then(
       (jurisdictionResults: FlexObject[] = []) => {
-        const jurisdictionsArray: Jurisdiction[] = jurisdictionResults.map(j => {
-          const { id, parent_id, name, geographic_level } = j;
-          const jurisdiction: Jurisdiction = {
-            geographic_level: geographic_level || 0,
-            jurisdiction_id: id,
-            name: name || null,
-            parent_id: parent_id || null,
-          };
-          return jurisdiction;
-        });
+        const jurisdictionsArray: Jurisdiction[] = jurisdictionResults
+          .map(j => {
+            const { id, parent_id, name, geographic_level } = j;
+            const jurisdiction: Jurisdiction = {
+              geographic_level: geographic_level || 0,
+              jurisdiction_id: id,
+              name: name || null,
+              parent_id: parent_id || null,
+            };
+            return jurisdiction;
+          })
+          .sort((a, b) =>
+            a.geographic_level && b.geographic_level ? b.geographic_level - a.geographic_level : 0
+          );
         // initialize Finalized Plan
         if (
           !isNewPlan &&

--- a/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
+++ b/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
@@ -1373,10 +1373,10 @@ class IrsPlan extends React.Component<
     jurisdictions: Jurisdiction[],
     tileset: FlexObject | undefined
   ) {
-    const { childrenByParentId, newPlan } = this.state;
+    const { childrenByParentId } = this.state;
     const uniqueKeys: string[] = [];
     const selectionStyle = {
-      default: 0.33,
+      default: 0.3,
       property: (tileset && tileset.idField) || 'jurisdiction_id',
       stops: [] as Array<[string, number]>,
       type: 'categorical',
@@ -1384,18 +1384,17 @@ class IrsPlan extends React.Component<
 
     for (const j of jurisdictions) {
       // keys in stops must be unique
-      if (!uniqueKeys.includes(j.jurisdiction_id)) {
+      if (!uniqueKeys.includes(j.jurisdiction_id) && selectedIds.includes(j.jurisdiction_id)) {
         uniqueKeys.push(j.jurisdiction_id);
         const selectedChildren =
           (childrenByParentId[j.jurisdiction_id] &&
             childrenByParentId[j.jurisdiction_id].filter(c => selectedIds.includes(c))) ||
           [];
-        const opacity = !selectedIds.includes(j.jurisdiction_id)
-          ? 0.33
-          : childrenByParentId[j.jurisdiction_id] &&
-            selectedChildren.length !== childrenByParentId[j.jurisdiction_id].length
-          ? 0.7
-          : 0.9;
+        const opacity =
+          childrenByParentId[j.jurisdiction_id] &&
+          selectedChildren.length !== childrenByParentId[j.jurisdiction_id].length
+            ? 0.6
+            : 0.9;
 
         selectionStyle.stops.push([j.jurisdiction_id, opacity]);
       }


### PR DESCRIPTION
Fixes #394 
Fixes #390

- [x] Drastically improve performance of  `getDecendantJurisdictionIds`
- [x] Use `childrenByParentId` from state to determine selection status
- [x] Style Admin Jurisdiction fill layers according to their selection status