### PR TITLE
Move type definitions out of settings.ts

### DIFF
--- a/src/configs/settings.ts
+++ b/src/configs/settings.ts
@@ -35,6 +35,7 @@ import {
   OPENSRP_OAUTH_STATE,
   OPENSRP_USER_URL,
 } from './env';
+import { IndicatorRows, JurisdictionTypes } from './types';
 
 /** Interfaces */
 
@@ -579,11 +580,8 @@ export const FIClassifications: Classification[] = [
 
 // thresholds
 export const GREEN_THRESHOLD = 0.9;
-export type GREEN_THRESHOLD = typeof GREEN_THRESHOLD;
 export const YELLOW_THRESHOLD = 0.2;
-export type YELLOW_THRESHOLD = typeof YELLOW_THRESHOLD;
 export const ORANGE_THRESHOLD = 0.8;
-export type ORANGE_THRESHOLD = typeof ORANGE_THRESHOLD;
 
 // 1-3-7 thresholds
 export const ONE = 0;
@@ -711,7 +709,6 @@ export const symbolLayerConfig = {
 
 /** Default colors layer fill colors per administrative level */
 export const adminLayerColors = ['black', 'red', 'orange', 'yellow', 'green'];
-export type adminLayerColorsType = typeof adminLayerColors[number];
 
 /** interface describing threshold configs for IRS report indicators */
 export interface IndicatorThresholds {
@@ -804,7 +801,6 @@ export interface ADMN3 extends ADMN2 {
 
 export const baseTilesetGeographicLevel: number = 1; // this tells the Jurisdiction Selection map at which geographic level to start rendering administrative fill layers
 export const JurisdictionLevels = ['administrative', 'operational'] as const;
-export type JurisdictionTypes = typeof JurisdictionLevels[number];
 export interface Tileset {
   idField: string; // the feature property corresponding with jurisdiction_id (for joining)
   jurisdictionType: JurisdictionTypes; // Admin or OA/FA/SA
@@ -979,20 +975,6 @@ export const LusakaAdmin0: JurisdictionsByCountry = {
   jurisdictionIds: [],
   tilesets: [],
 };
-
-/** ISO 3166-alpha-2 admin codes */
-export type ADMN0_PCODE =
-  | 'TH'
-  | 'ZM'
-  | 'NA'
-  | 'BW'
-  | 'Chadiza'
-  | 'Sinda'
-  | 'Katete'
-  | 'Siavonga'
-  | 'Lop Buri'
-  | 'Oddar Meanchey Province'
-  | 'Lusaka';
 
 /** dictionary of JurisdictionsByCountry by country code */
 export const CountriesAdmin0 = {

--- a/src/configs/settings.ts
+++ b/src/configs/settings.ts
@@ -14,6 +14,13 @@
 import { Providers } from '@onaio/gatekeeper';
 import { Expression, LngLatBoundsLike } from 'mapbox-gl';
 import {
+  ActionReasonType,
+  GoalPriorityType,
+  PlanActionCodesType,
+  PlanActivities,
+  UseContextCodesType,
+} from '../containers/forms/PlanForm/types';
+import {
   DOMAIN_NAME,
   ENABLE_ONADATA_OAUTH,
   ENABLE_OPENSRP_OAUTH,
@@ -29,7 +36,7 @@ import {
   OPENSRP_USER_URL,
 } from './env';
 
-/** Interfaces and Types */
+/** Interfaces */
 
 /** Interface for a Focus Investigation Classification */
 export interface Classification {
@@ -106,19 +113,15 @@ export const locationHierarchy: LocationItem[] = [
 /** Focus investigation configs */
 /** Allowed FI Status values */
 export const FIStatuses = ['A1', 'A2', 'B1', 'B2'] as const;
-export type FIStatusType = typeof FIStatuses[number];
 
 /** Allowed FI Status values */
 export const FIReasons = ['Routine', 'Case Triggered'] as const;
-export type FIReasonType = typeof FIReasons[number];
 
 /** Allowed goal priority values */
 export const goalPriorities = ['low-priority', 'medium-priority', 'high-priority'] as const;
-export type GoalPriorityType = typeof goalPriorities[number];
 
 /** Allowed action Reason values */
 export const actionReasons = ['Investigation', 'Routine'] as const;
-export type ActionReasonType = typeof actionReasons[number];
 
 /** Allowed useContext Code values */
 export const useContextCodes = [
@@ -129,7 +132,6 @@ export const useContextCodes = [
   'caseNum',
   'taskGenerationStatus',
 ] as const;
-export type UseContextCodesType = typeof useContextCodes[number];
 
 /** Plan activity code values */
 export const PlanActionCodes = [
@@ -142,11 +144,9 @@ export const PlanActionCodes = [
   'Larval Dipping',
   'Mosquito Collection',
 ] as const;
-export type PlanActionCodesType = typeof PlanActionCodes[number];
 
 /** Allowed taskGenerationStatus values */
 export const taskGenerationStatuses = ['True', 'False'] as const;
-export type taskGenerationStatusType = typeof taskGenerationStatuses[number];
 
 /** Plan Action Timing Period */
 export interface PlanActionTimingPeriod {
@@ -217,10 +217,6 @@ export const PlanActivityTitles = [
   'BCC',
   'IRS',
 ] as const;
-export type PlanActivityTitlesType = typeof PlanActivityTitles[number];
-
-/** type to describe plan activities */
-export type PlanActivities = { [K in PlanActivityTitlesType]: PlanActivity };
 
 /** default plan activities */
 export const planActivities: PlanActivities = {

--- a/src/configs/types.ts
+++ b/src/configs/types.ts
@@ -1,0 +1,36 @@
+import {
+  adminLayerColors,
+  GREEN_THRESHOLD,
+  IndicatorRowItem,
+  JurisdictionLevels,
+  ORANGE_THRESHOLD,
+  YELLOW_THRESHOLD,
+} from './settings';
+
+// threshold types
+export type GREEN_THRESHOLD = typeof GREEN_THRESHOLD;
+export type YELLOW_THRESHOLD = typeof YELLOW_THRESHOLD;
+export type ORANGE_THRESHOLD = typeof ORANGE_THRESHOLD;
+
+// admin layer color type
+export type adminLayerColorsType = typeof adminLayerColors[number];
+
+// indicator row type
+export type IndicatorRows = IndicatorRowItem[];
+
+// jurisdiction types
+export type JurisdictionTypes = typeof JurisdictionLevels[number];
+
+/** ISO 3166-alpha-2 admin codes */
+export type ADMN0_PCODE =
+  | 'TH'
+  | 'ZM'
+  | 'NA'
+  | 'BW'
+  | 'Chadiza'
+  | 'Sinda'
+  | 'Katete'
+  | 'Siavonga'
+  | 'Lop Buri'
+  | 'Oddar Meanchey Province'
+  | 'Lusaka';

--- a/src/containers/forms/PlanForm/helpers.ts
+++ b/src/containers/forms/PlanForm/helpers.ts
@@ -14,31 +14,33 @@ import {
 } from '../../../configs/env';
 import {
   actionReasons,
-  ActionReasonType,
   FIClassifications,
   FIReasons,
-  FIReasonType,
-  FIStatusType,
   goalPriorities,
-  GoalPriorityType,
   PlanAction,
   PlanActionCodes,
-  PlanActionCodesType,
   planActivities,
   PlanActivity,
-  PlanActivityTitlesType,
   PlanDefinition,
   PlanGoal,
   PlanGoalDetail,
   PlanGoaldetailQuantity,
   PlanGoalTarget,
   taskGenerationStatuses,
-  taskGenerationStatusType,
   UseContext,
 } from '../../../configs/settings';
 import { DATE, IS, NAME, REQUIRED } from '../../../constants';
 import { generateNameSpacedUUID } from '../../../helpers/utils';
 import { InterventionType, PlanStatus } from '../../../store/ducks/plans';
+import {
+  ActionReasonType,
+  FIReasonType,
+  FIStatusType,
+  GoalPriorityType,
+  PlanActionCodesType,
+  PlanActivityTitlesType,
+  taskGenerationStatusType,
+} from './types';
 
 /** separate FI and IRS activities */
 export const FIActivities = omit(planActivities, ['IRS']);

--- a/src/containers/forms/PlanForm/tests/fixtures.ts
+++ b/src/containers/forms/PlanForm/tests/fixtures.ts
@@ -2,9 +2,9 @@ import { parseISO } from 'date-fns';
 import moment from 'moment';
 import { FormEvent } from 'react';
 import { DEFAULT_ACTIVITY_DURATION_DAYS, DEFAULT_TIME } from '../../../../configs/env';
-import { PlanActivities } from '../../../../configs/settings';
 import { InterventionType, PlanStatus } from '../../../../store/ducks/plans';
 import { PlanActivityFormFields, PlanFormFields } from '../helpers';
+import { PlanActivities } from '../types';
 
 const goalDue = moment()
   .add(DEFAULT_ACTIVITY_DURATION_DAYS, 'days')

--- a/src/containers/forms/PlanForm/types.ts
+++ b/src/containers/forms/PlanForm/types.ts
@@ -1,0 +1,38 @@
+import {
+  actionReasons,
+  FIReasons,
+  FIStatuses,
+  goalPriorities,
+  PlanActionCodes,
+  PlanActivity,
+  PlanActivityTitles,
+  taskGenerationStatuses,
+  useContextCodes,
+} from '../../../configs/settings';
+
+/** FI Status type */
+export type FIStatusType = typeof FIStatuses[number];
+
+/** FI Reason type */
+export type FIReasonType = typeof FIReasons[number];
+
+/** Goal priority type */
+export type GoalPriorityType = typeof goalPriorities[number];
+
+/** Action reason type */
+export type ActionReasonType = typeof actionReasons[number];
+
+/** Use context codes type */
+export type UseContextCodesType = typeof useContextCodes[number];
+
+/** Plan action codes type */
+export type PlanActionCodesType = typeof PlanActionCodes[number];
+
+/** Task generation status type */
+export type taskGenerationStatusType = typeof taskGenerationStatuses[number];
+
+/** Plan activity title type */
+export type PlanActivityTitlesType = typeof PlanActivityTitles[number];
+
+/** Plan activities type */
+export type PlanActivities = { [K in PlanActivityTitlesType]: PlanActivity };

--- a/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
+++ b/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
@@ -40,7 +40,6 @@ import {
 } from '../../../../../helpers/utils';
 import {
   adminLayerColors,
-  ADMN0_PCODE,
   baseTilesetGeographicLevel,
   CountriesAdmin0,
   deselectedJurisdictionOpacity,
@@ -49,7 +48,6 @@ import {
   JurisdictionLevels,
   JurisdictionsByCountry,
   jurisdictionSelectionTooltipHint,
-  JurisdictionTypes,
   lineLayerConfig,
   partiallySelectedJurisdictionOpacity,
   Tileset,
@@ -87,6 +85,7 @@ import HeaderBreadcrumbs, {
 } from '../../../../../components/page/HeaderBreadcrumb/HeaderBreadcrumb';
 import Loading from '../../../../../components/page/Loading';
 
+import { ADMN0_PCODE, JurisdictionTypes } from '../../../../../configs/types';
 import './../../../../../styles/css/drill-down-table.css';
 import './style.css';
 


### PR DESCRIPTION
Moves type definitions out of settings.ts into a separate types.ts file adjacent to helpers.ts.

Fix #469 