### PR TITLE
Fix IRS Map when loading no structures

### DIFF
--- a/src/containers/pages/IRS/Map/helpers.ts
+++ b/src/containers/pages/IRS/Map/helpers.ts
@@ -32,7 +32,11 @@ export const structuresLayerBuilder = (
   indicatorStops: string[][] = defaultIndicatorStops
 ) => {
   const structuresLayers: FlexObject[] = [];
-  const layerType = structures.features[0].geometry && structures.features[0].geometry.type;
+  const layerType =
+    structures.features &&
+    structures.features[0] &&
+    structures.features[0].geometry &&
+    structures.features[0].geometry.type;
   const structuresPopup: FlexObject = {
     body: `<div>
           <p class="heading">{{structure_type}}</p>

--- a/src/containers/pages/IRS/Map/helpers.ts
+++ b/src/containers/pages/IRS/Map/helpers.ts
@@ -76,7 +76,7 @@ export const structuresLayerBuilder = (
       visible: true,
     };
     structuresLayers.push(structureCircleLayer);
-  } else {
+  } else if (layerType) {
     // build fill / line layers if structures are polygons
     const structuresFillLayer = {
       ...fillLayerConfig,

--- a/src/containers/pages/IRS/Map/tests/index.test.tsx
+++ b/src/containers/pages/IRS/Map/tests/index.test.tsx
@@ -102,6 +102,38 @@ describe('components/IRS Reports/IRSReportingMap', () => {
     );
   });
 
+  it('renders without structures', () => {
+    const mock: any = jest.fn();
+    const props = {
+      focusArea: getGenericJurisdictionByJurisdictionId(
+        store.getState(),
+        'zm-focusAreas',
+        '0dc2d15b-be1d-45d3-93d8-043a3a916f30'
+      ),
+      history,
+      jurisdiction: getJurisdictionById(store.getState(), '0dc2d15b-be1d-45d3-93d8-043a3a916f30'),
+      location: mock,
+      match: {
+        isExact: true,
+        params: {
+          jurisdictionId: '0dc2d15b-be1d-45d3-93d8-043a3a916f30',
+          planId: (plans[0] as IRSPlan).plan_id,
+        },
+        path: `${INTERVENTION_IRS_URL}/:planId/:jurisdictionId/${MAP}`,
+        url: `${INTERVENTION_IRS_URL}/${
+          (plans[0] as IRSPlan).plan_id
+        }/0dc2d15b-be1d-45d3-93d8-043a3a916f30/${MAP}`,
+      },
+      plan: plans[0] as IRSPlan,
+      structures: {} as StructureFeatureCollection,
+    };
+    shallow(
+      <Router history={history}>
+        <IRSReportingMap {...props} />
+      </Router>
+    );
+  });
+
   it('renders correctly', async () => {
     fetch.mockResponseOnce(JSON.stringify({}));
     const mock: any = jest.fn();


### PR DESCRIPTION
Fixes a bug occurring when an IRS Map tries to build layers without structures

Fix: #470 