### PR TITLE
Update IRS Map Circle SIzes

### DIFF
--- a/src/containers/pages/IRS/Map/helpers.ts
+++ b/src/containers/pages/IRS/Map/helpers.ts
@@ -128,7 +128,7 @@ export const structuresLayerBuilder = (
     paint: {
       ...circleLayerConfig.paint,
       'circle-color': structureStatusColors,
-      'circle-radius': ['interpolate', ['linear'], ['zoom'], 13, 2, 14, 4, 16, 8, 20, 12],
+      'circle-radius': ['interpolate', ['exponential', 2], ['zoom'], 15.75, 2.5, 20.8, 50],
       'circle-stroke-color': structureStatusColors,
       'circle-stroke-opacity': 1,
     },

--- a/src/containers/pages/IRS/Map/tests/index.test.tsx
+++ b/src/containers/pages/IRS/Map/tests/index.test.tsx
@@ -369,7 +369,7 @@ describe('components/IRS Reports/IRSReportingMap', () => {
         paint: {
           ...circleLayerConfig.paint,
           'circle-color': structureStatusColors,
-          'circle-radius': ['interpolate', ['linear'], ['zoom'], 13, 2, 14, 4, 16, 8, 20, 12],
+          'circle-radius': ['interpolate', ['exponential', 2], ['zoom'], 15.75, 2.5, 20.8, 50],
           'circle-stroke-color': structureStatusColors,
           'circle-stroke-opacity': 1,
         },


### PR DESCRIPTION
@mberg This PR uses the right scaling to zoom the circles correctly based on the buildings

cc @kahama94 @KipSigei - something to note when using an expression like this to set a `circle-radius`, is that because that controls the radius it doesn't necessarily scale "correctly" when it's a linear scale. Switching to an exponential scale helps the circles scale their surface area more than the actual radius. Note - when actually encoding data to the surface area, we should be using the expressions first developed in UG Atlas, this approach is only valid because the circle size is purely aesthetic here. 