### PR TITLE
Remove indicatorRowItem Reference

### DIFF
--- a/src/configs/settings.ts
+++ b/src/configs/settings.ts
@@ -36,7 +36,7 @@ import {
   OPENSRP_OAUTH_STATE,
   OPENSRP_USER_URL,
 } from './env';
-import { IndicatorRows, JurisdictionTypes } from './types';
+import { JurisdictionTypes } from './types';
 
 /** Interfaces */
 

--- a/src/configs/types.ts
+++ b/src/configs/types.ts
@@ -1,7 +1,6 @@
 import {
   adminLayerColors,
   GREEN_THRESHOLD,
-  IndicatorRowItem,
   JurisdictionLevels,
   ORANGE_THRESHOLD,
   YELLOW_THRESHOLD,
@@ -14,9 +13,6 @@ export type ORANGE_THRESHOLD = typeof ORANGE_THRESHOLD;
 
 // admin layer color type
 export type adminLayerColorsType = typeof adminLayerColors[number];
-
-// indicator row type
-export type IndicatorRows = IndicatorRowItem[];
 
 // jurisdiction types
 export type JurisdictionTypes = typeof JurisdictionLevels[number];


### PR DESCRIPTION
@DavisRayM it looks like a type was added to the types.ts file referencing `IndicatorRowItem` which is no longer in settings.ts. It doesn't look like there are any references to these types, am I missing something or are these okay to remove?