### PR TITLE
Remove regex validation on name organizationform.name

### DIFF
--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -349,7 +349,3 @@ export const FI_PLAN_TYPE = 'FI';
 export type FI_PLAN_TYPE = typeof FI_PLAN_TYPE;
 export const IRS_PLAN_TYPE = 'IRS';
 export type IRS_PLAN_TYPE = typeof IRS_PLAN_TYPE;
-
-// error messages
-export const NAME_REGEX_ERROR = 'should include alphanumeric optionally separated by _ or -';
-export type NAME_REGEX_ERROR = typeof NAME_REGEX_ERROR;

--- a/src/containers/forms/OrganizationForm/index.tsx
+++ b/src/containers/forms/OrganizationForm/index.tsx
@@ -8,7 +8,6 @@ import * as Yup from 'yup';
 import {
   ACTIVE,
   NAME,
-  NAME_REGEX_ERROR,
   NO,
   OPENSRP_ORGANIZATION_ENDPOINT,
   ORGANIZATION_LABEL,
@@ -38,9 +37,7 @@ const defaultOrganizationType = {
 export const OrgSchema = Yup.object().shape({
   active: Yup.boolean(),
   identifier: Yup.string(),
-  name: Yup.string()
-    .matches(/^[a-zA-Z0-9]+([_ -]?[a-zA-Z0-9])*$/, NAME_REGEX_ERROR)
-    .required(REQUIRED),
+  name: Yup.string().required(REQUIRED),
 });
 
 /** interface for data fields for team's form */


### PR DESCRIPTION
Removes regex validation that requires an organization name be of the english Alphabet
![organizationbadname](https://user-images.githubusercontent.com/28119869/66849410-80a9af80-ef7f-11e9-98e8-c4eb9a40b696.png)
