### PR TITLE
547 plans reducer getter

### DIFF
--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -376,7 +376,7 @@ export const fetchPlanRecords = (planList: PlanRecordResponse[] = []): FetchPlan
 
 // selectors
 
-/** getPlansById - get plansById by intervention type
+/** getPlansById - get plansById
  * @param {Partial<Store>} state - the redux store
  * @param {InterventionType} intervention - the intervention type
  * @param {string[]} statusList - the plan statuses
@@ -384,7 +384,7 @@ export const fetchPlanRecords = (planList: PlanRecordResponse[] = []): FetchPlan
  */
 export function getPlansById(
   state: Partial<Store>,
-  intervention: InterventionType = InterventionType.FI,
+  intervention: InterventionType | null = null,
   statusList: string[] = [PlanStatus.ACTIVE],
   reason: string | null = null
 ): { [key: string]: Plan } {
@@ -392,13 +392,13 @@ export function getPlansById(
   return pickBy(
     plansById,
     (plan: Plan) =>
-      plan.plan_intervention_type === intervention &&
+      (intervention ? plan.plan_intervention_type === intervention : true) &&
       (statusList.length ? statusList.includes(plan.plan_status) : true) &&
       (reason ? plan.plan_fi_reason === reason : true)
   );
 }
 
-/** getPlansArray - get an array of Plans by intervention type
+/** getPlansArray - get an array of Plans
  * @param {Partial<Store>} state - the redux store
  * @param {InterventionType} intervention - the intervention type
  * @param {string[]} statusList - a list of the desired the plan statuses
@@ -408,7 +408,7 @@ export function getPlansById(
  */
 export function getPlansArray(
   state: Partial<Store>,
-  intervention: InterventionType = InterventionType.FI,
+  intervention: InterventionType | null = null,
   statusList: string[] = [],
   reason: string | null = null,
   jurisdictions: string[] = [],
@@ -416,7 +416,7 @@ export function getPlansArray(
 ): Plan[] {
   return values((state as any)[reducerName].plansById).filter(
     (plan: Plan) =>
-      plan.plan_intervention_type === intervention &&
+      (intervention ? plan.plan_intervention_type === intervention : true) &&
       (statusList.length ? statusList.includes(plan.plan_status) : true) &&
       (reason ? plan.plan_fi_reason === reason : true) &&
       (jurisdictions.length ? jurisdictions.includes(plan.jurisdiction_id) : true) &&

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -472,7 +472,7 @@ export function getPlanRecordsById(
   );
 }
 
-/** getPlanRecordsArray - get an array of PlanRecords by intervention type
+/** getPlanRecordsArray - get an array of PlanRecords
  * @param {Partial<Store>} state - the redux store
  * @param {InterventionType} intervention - the intervention type
  * @param {string[]} status - the plan statuses
@@ -480,13 +480,13 @@ export function getPlanRecordsById(
  */
 export function getPlanRecordsArray(
   state: Partial<Store>,
-  intervention: InterventionType = InterventionType.FI,
+  intervention: InterventionType | null = null,
   statusList: string[] = [PlanStatus.ACTIVE],
   reason: string | null = null
 ): PlanRecord[] {
   return values((state as any)[reducerName].planRecordsById).filter(
     (plan: PlanRecord) =>
-      plan.plan_intervention_type === intervention &&
+      (intervention ? plan.plan_intervention_type === intervention : true) &&
       (statusList.length ? statusList.includes(plan.plan_status) : true) &&
       (reason ? plan.plan_fi_reason === reason : true)
   );

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -450,7 +450,7 @@ export function getPlanById(state: Partial<Store>, id: string): Plan | null {
   return get((state as any)[reducerName].plansById, id) || null;
 }
 
-/** getPlanRecordsById - get planRecordsById by intervention type
+/** getPlanRecordsById - get planRecordsById
  * @param {Partial<Store>} state - the redux store
  * @param {InterventionType} intervention - the intervention type
  * @param {string[]} statusList - the plan statuses
@@ -458,7 +458,7 @@ export function getPlanById(state: Partial<Store>, id: string): Plan | null {
  */
 export function getPlanRecordsById(
   state: Partial<Store>,
-  intervention: InterventionType = InterventionType.FI,
+  intervention: InterventionType | null = null,
   statusList: string[] = [PlanStatus.ACTIVE],
   reason: string | null = null
 ): { [key: string]: PlanRecord } {
@@ -466,7 +466,7 @@ export function getPlanRecordsById(
   return pickBy(
     planRecordsById,
     (plan: PlanRecord) =>
-      plan.plan_intervention_type === intervention &&
+      (intervention ? plan.plan_intervention_type === intervention : true) &&
       (statusList.length ? statusList.includes(plan.plan_status) : true) &&
       (reason ? plan.plan_fi_reason === reason : true)
   );

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -427,7 +427,7 @@ export function getPlansArray(
   );
 }
 
-/** getPlansIdArray - get an array of Plan ids by intervention type
+/** getPlansIdArray - get an array of Plan ids
  * @param {Partial<Store>} state - the redux store
  * @param {InterventionType} intervention - the intervention type
  * @param {string[]} statusList - the plan statuses
@@ -435,7 +435,7 @@ export function getPlansArray(
  */
 export function getPlansIdArray(
   state: Partial<Store>,
-  intervention: InterventionType = InterventionType.FI,
+  intervention: InterventionType | null = null,
   statusList: string[] = [PlanStatus.ACTIVE],
   reason: string | null = null
 ): string[] {

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -500,7 +500,7 @@ export function getPlanRecordsArray(
  */
 export function getPlanRecordsIdArray(
   state: Partial<Store>,
-  intervention: InterventionType = InterventionType.FI,
+  intervention: InterventionType | null = null,
   statusList: string[] = [PlanStatus.ACTIVE],
   reason: string | null = null
 ): string[] {

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -74,7 +74,10 @@ describe('reducers/plans', () => {
     expect(getPlansById(store.getState(), InterventionType.FI, [], null)).toEqual(fiPlans);
     expect(getPlansById(store.getState(), InterventionType.IRS, [], null)).toEqual(irsPlans);
 
-    expect(getPlansIdArray(store.getState())).toEqual(['ed2b4b7c-3388-53d9-b9f6-6a19d1ffde1f']);
+    expect(getPlansIdArray(store.getState())).toEqual([
+      'ed2b4b7c-3388-53d9-b9f6-6a19d1ffde1f',
+      'plan-id-2',
+    ]);
     expect(getPlansIdArray(store.getState(), InterventionType.IRS)).toEqual(['plan-id-2']);
 
     expect(getPlansArray(store.getState(), InterventionType.FI, [], null)).toEqual(values(fiPlans));

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -222,21 +222,21 @@ describe('reducers/plans', () => {
 
   it('resets plansById records', () => {
     store.dispatch(removePlansAction);
-    let numberOfPlansInStore = getPlansArray(store.getState(), undefined, []).length;
+    let numberOfPlansInStore = getPlansArray(store.getState(), null, []).length;
     expect(numberOfPlansInStore).toEqual(0);
 
     store.dispatch(fetchPlans([fixtures.plan3] as any));
-    numberOfPlansInStore = getPlansArray(store.getState(), undefined, []).length;
+    numberOfPlansInStore = getPlansArray(store.getState(), null, []).length;
     expect(numberOfPlansInStore).toEqual(1);
 
     store.dispatch(removePlansAction);
-    numberOfPlansInStore = getPlansArray(store.getState(), undefined, []).length;
+    numberOfPlansInStore = getPlansArray(store.getState(), null, []).length;
     expect(numberOfPlansInStore).toEqual(0);
   });
 
   it('Concatenates new plans to existing plans after fetching', () => {
     store.dispatch(removePlansAction);
-    let numberOfPlansInStore = getPlansArray(store.getState(), undefined, []).length;
+    let numberOfPlansInStore = getPlansArray(store.getState(), null, []).length;
     expect(numberOfPlansInStore).toEqual(0);
     store.dispatch(fetchPlans([fixtures.plan3] as any));
     let plan3FromStore = getPlanById(store.getState(), '1502e539');

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -179,7 +179,7 @@ describe('reducers/plans', () => {
 
     const fiRecordPlanIds = keys(fiPlanRecords);
     const irsRecordPlansIds = keys(irsPlanRecords);
-    expect(getPlanRecordsIdArray(store.getState())).toEqual(fiRecordPlanIds);
+    expect(getPlanRecordsIdArray(store.getState(), InterventionType.FI)).toEqual(fiRecordPlanIds);
     expect(getPlanRecordsIdArray(store.getState(), InterventionType.IRS)).toEqual(
       irsRecordPlansIds
     );

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -174,7 +174,7 @@ describe('reducers/plans', () => {
       allPlanRecords,
       (e: PlanRecord) => e.plan_intervention_type === InterventionType.IRS
     );
-    expect(getPlanRecordsById(store.getState())).toEqual(fiPlanRecords);
+    expect(getPlanRecordsById(store.getState(), InterventionType.FI)).toEqual(fiPlanRecords);
     expect(getPlanRecordsById(store.getState(), InterventionType.IRS)).toEqual(irsPlanRecords);
 
     const fiRecordPlanIds = keys(fiPlanRecords);

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -186,15 +186,14 @@ describe('reducers/plans', () => {
 
     const fiPlanRecordsArray = values(fiPlanRecords);
     const irsPlanRecordsArray = values(irsPlanRecords);
-    expect(getPlanRecordsArray(store.getState())).toEqual(fiPlanRecordsArray);
+    expect(getPlanRecordsArray(store.getState(), InterventionType.FI)).toEqual(fiPlanRecordsArray);
     expect(getPlanRecordsArray(store.getState(), InterventionType.IRS)).toEqual(
       irsPlanRecordsArray
     );
 
-    const planRecordsArray = [
-      ...getPlanRecordsArray(store.getState()),
-      ...getPlanRecordsArray(store.getState(), InterventionType.IRS),
-    ].sort((a: PlanRecord, b: PlanRecord) => Date.parse(b.plan_date) - Date.parse(a.plan_date));
+    const planRecordsArray = [...getPlanRecordsArray(store.getState())].sort(
+      (a: PlanRecord, b: PlanRecord) => Date.parse(a.plan_date) - Date.parse(b.plan_date)
+    );
     expect(planRecordsArray).toEqual(fixtures.sortedPlanRecordArray);
 
     const planId = '6c7904b2-c556-4004-a9b9-114617832954';

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -192,7 +192,7 @@ describe('reducers/plans', () => {
     );
 
     const planRecordsArray = [...getPlanRecordsArray(store.getState())].sort(
-      (a: PlanRecord, b: PlanRecord) => Date.parse(a.plan_date) - Date.parse(b.plan_date)
+      (a: PlanRecord, b: PlanRecord) => Date.parse(b.plan_date) - Date.parse(a.plan_date)
     );
     expect(planRecordsArray).toEqual(fixtures.sortedPlanRecordArray);
 


### PR DESCRIPTION
closes #547 

__previously__: 
plans selectors had `FI` as the default value for intervention type filter

__now__:
Plan selectors do not filter against any intervention type be default,