### PR TITLE
Add IRS indicators Legend to IRS reports

### DIFF
--- a/src/components/AssignTeamPopover/tests/index.test.tsx
+++ b/src/components/AssignTeamPopover/tests/index.test.tsx
@@ -1,5 +1,4 @@
-import { mount, shallow } from 'enzyme';
-import toJson from 'enzyme-to-json';
+import { shallow } from 'enzyme';
 import React from 'react';
 import AssignTeamPopover, { AssignTeamPopoverProps } from '..';
 

--- a/src/components/formatting/IRSIndicatorLegend/index.tsx
+++ b/src/components/formatting/IRSIndicatorLegend/index.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Table } from 'reactstrap';
+import {
+  IndicatorThresholdItem,
+  IndicatorThresholds,
+  indicatorThresholdsNA,
+} from '../../../configs/settings';
+import { percentage } from '../../../helpers/utils';
+
+interface Props {
+  indicatorThresholds: IndicatorThresholds;
+}
+
+const defaultProps: Props = {
+  indicatorThresholds: indicatorThresholdsNA,
+};
+
+const IRSIndicatorLegend = (props: Props) => {
+  const { indicatorThresholds } = props;
+
+  return (
+    <div>
+      <h5 className="mt-4 mb-3">IRS Conditional Formatting</h5>
+      <div className="row">
+        <div className="col-3">
+          <Table className="text-center">
+            <tbody>
+              {Object.values(indicatorThresholds)
+                .sort((a: IndicatorThresholdItem, b: IndicatorThresholdItem) =>
+                  a.value > b.value ? 1 : -1
+                )
+                .map((item, index) => {
+                  return (
+                    <tr key={index} style={{ background: item.color }}>
+                      <td>{item.name}</td>
+                      <td>>=</td>
+                      <td>{percentage(item.value)}</td>
+                    </tr>
+                  );
+                })}
+            </tbody>
+          </Table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+IRSIndicatorLegend.defaultProps = defaultProps;
+
+export default IRSIndicatorLegend;

--- a/src/components/formatting/IRSIndicatorLegend/index.tsx
+++ b/src/components/formatting/IRSIndicatorLegend/index.tsx
@@ -37,12 +37,11 @@ const IRSIndicatorLegend = (props: Props) => {
                         <td>{item.name}</td>
                         <td>
                           {index === 0
-                            ? '<'
+                            ? `< ${percentage(item.value)}`
                             : `${percentage(indicatorItems[index - 1].value)} - ${percentage(
                                 item.value
                               )}`}
                         </td>
-                        <td>{percentage(item.value)}</td>
                       </tr>
                     );
                   })}

--- a/src/components/formatting/IRSIndicatorLegend/index.tsx
+++ b/src/components/formatting/IRSIndicatorLegend/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Table } from 'reactstrap';
+import { Col, Row, Table } from 'reactstrap';
 import {
   IndicatorThresholdItem,
   IndicatorThresholds,
@@ -17,30 +17,39 @@ const defaultProps: Props = {
 
 const IRSIndicatorLegend = (props: Props) => {
   const { indicatorThresholds } = props;
+  const indicatorItems = Object.values(indicatorThresholds);
 
   return (
-    <div>
-      <h5 className="mt-4 mb-3">IRS Conditional Formatting</h5>
-      <div className="row">
-        <div className="col-3">
-          <Table className="text-center">
-            <tbody>
-              {Object.values(indicatorThresholds)
-                .sort((a: IndicatorThresholdItem, b: IndicatorThresholdItem) =>
-                  a.value > b.value ? 1 : -1
-                )
-                .map((item, index) => {
-                  return (
-                    <tr key={index} style={{ background: item.color }}>
-                      <td>{item.name}</td>
-                      <td>>=</td>
-                      <td>{percentage(item.value)}</td>
-                    </tr>
-                  );
-                })}
-            </tbody>
-          </Table>
-        </div>
+    <div className="card mt-5 mb-5">
+      <div className="card-header">Conditional formatting rules</div>
+      <div className="card-body">
+        <Row>
+          <Col sm="12" md={{ size: 4, offset: 4 }}>
+            <Table className="text-center">
+              <tbody>
+                {indicatorItems
+                  .sort((a: IndicatorThresholdItem, b: IndicatorThresholdItem) =>
+                    a.value > b.value ? 1 : -1
+                  )
+                  .map((item, index) => {
+                    return (
+                      <tr key={index} style={{ background: item.color }}>
+                        <td>{item.name}</td>
+                        <td>
+                          {index === 0
+                            ? '<'
+                            : `${percentage(indicatorItems[index - 1].value)} - ${percentage(
+                                item.value
+                              )}`}
+                        </td>
+                        <td>{percentage(item.value)}</td>
+                      </tr>
+                    );
+                  })}
+              </tbody>
+            </Table>
+          </Col>
+        </Row>
       </div>
     </div>
   );

--- a/src/components/formatting/IRSIndicatorLegend/index.tsx
+++ b/src/components/formatting/IRSIndicatorLegend/index.tsx
@@ -3,7 +3,7 @@ import { Table } from 'reactstrap';
 import {
   IndicatorThresholdItem,
   IndicatorThresholds,
-  indicatorThresholdsNA,
+  indicatorThresholdsIRS,
 } from '../../../configs/settings';
 import { percentage } from '../../../helpers/utils';
 
@@ -12,7 +12,7 @@ interface Props {
 }
 
 const defaultProps: Props = {
-  indicatorThresholds: indicatorThresholdsNA,
+  indicatorThresholds: indicatorThresholdsIRS,
 };
 
 const IRSIndicatorLegend = (props: Props) => {

--- a/src/components/formatting/IRSIndicatorLegend/tests/__snapshots__/index.test.tsx.snap
+++ b/src/components/formatting/IRSIndicatorLegend/tests/__snapshots__/index.test.tsx.snap
@@ -30,10 +30,7 @@ exports[`/components/formatting/IRSIndicatorLegend renders correctly: indicator 
           Grey
         </td>
         <td>
-          &lt;
-        </td>
-        <td>
-          20%
+          &lt; 20%
         </td>
       </tr>
       <tr
@@ -50,9 +47,6 @@ exports[`/components/formatting/IRSIndicatorLegend renders correctly: indicator 
         <td>
           20% - 75%
         </td>
-        <td>
-          75%
-        </td>
       </tr>
       <tr
         key="2"
@@ -68,9 +62,6 @@ exports[`/components/formatting/IRSIndicatorLegend renders correctly: indicator 
         <td>
           75% - 90%
         </td>
-        <td>
-          90%
-        </td>
       </tr>
       <tr
         key="3"
@@ -85,9 +76,6 @@ exports[`/components/formatting/IRSIndicatorLegend renders correctly: indicator 
         </td>
         <td>
           90% - 100%
-        </td>
-        <td>
-          100%
         </td>
       </tr>
     </tbody>

--- a/src/components/formatting/IRSIndicatorLegend/tests/__snapshots__/index.test.tsx.snap
+++ b/src/components/formatting/IRSIndicatorLegend/tests/__snapshots__/index.test.tsx.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`/components/formatting/IRSIndicatorLegend renders correctly: header 1`] = `
-<h5
-  className="mt-4 mb-3"
+<div
+  className="card-header"
 >
-  IRS Conditional Formatting
-</h5>
+  Conditional formatting rules
+</div>
 `;
 
 exports[`/components/formatting/IRSIndicatorLegend renders correctly: indicator table 1`] = `
@@ -30,7 +30,7 @@ exports[`/components/formatting/IRSIndicatorLegend renders correctly: indicator 
           Grey
         </td>
         <td>
-          &gt;=
+          &lt;
         </td>
         <td>
           20%
@@ -48,7 +48,7 @@ exports[`/components/formatting/IRSIndicatorLegend renders correctly: indicator 
           Red
         </td>
         <td>
-          &gt;=
+          20% - 75%
         </td>
         <td>
           75%
@@ -66,7 +66,7 @@ exports[`/components/formatting/IRSIndicatorLegend renders correctly: indicator 
           Yellow
         </td>
         <td>
-          &gt;=
+          75% - 90%
         </td>
         <td>
           90%
@@ -84,7 +84,7 @@ exports[`/components/formatting/IRSIndicatorLegend renders correctly: indicator 
           Green
         </td>
         <td>
-          &gt;=
+          90% - 100%
         </td>
         <td>
           100%

--- a/src/components/formatting/IRSIndicatorLegend/tests/__snapshots__/index.test.tsx.snap
+++ b/src/components/formatting/IRSIndicatorLegend/tests/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,96 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`/components/formatting/IRSIndicatorLegend renders correctly: header 1`] = `
+<h5
+  className="mt-4 mb-3"
+>
+  IRS Conditional Formatting
+</h5>
+`;
+
+exports[`/components/formatting/IRSIndicatorLegend renders correctly: indicator table 1`] = `
+<Table
+  className="text-center"
+  responsiveTag="div"
+  tag="table"
+>
+  <table
+    className="text-center table"
+  >
+    <tbody>
+      <tr
+        key="0"
+        style={
+          Object {
+            "background": "#dddddd",
+          }
+        }
+      >
+        <td>
+          Grey
+        </td>
+        <td>
+          &gt;=
+        </td>
+        <td>
+          20%
+        </td>
+      </tr>
+      <tr
+        key="1"
+        style={
+          Object {
+            "background": "#FF4136",
+          }
+        }
+      >
+        <td>
+          Red
+        </td>
+        <td>
+          &gt;=
+        </td>
+        <td>
+          75%
+        </td>
+      </tr>
+      <tr
+        key="2"
+        style={
+          Object {
+            "background": "#FFDC00",
+          }
+        }
+      >
+        <td>
+          Yellow
+        </td>
+        <td>
+          &gt;=
+        </td>
+        <td>
+          90%
+        </td>
+      </tr>
+      <tr
+        key="3"
+        style={
+          Object {
+            "background": "#2ECC40",
+          }
+        }
+      >
+        <td>
+          Green
+        </td>
+        <td>
+          &gt;=
+        </td>
+        <td>
+          100%
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Table>
+`;

--- a/src/components/formatting/IRSIndicatorLegend/tests/index.test.tsx
+++ b/src/components/formatting/IRSIndicatorLegend/tests/index.test.tsx
@@ -1,0 +1,15 @@
+import { mount } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import React from 'react';
+import IRSIndicatorLegend from '..';
+import { indicatorThresholdsNA } from '../../../../configs/settings';
+
+describe('/components/formatting/IRSIndicatorLegend', () => {
+  it('renders correctly', () => {
+    const wrapper = mount(<IRSIndicatorLegend />);
+    expect(wrapper.props()).toEqual({ indicatorThresholds: indicatorThresholdsNA });
+    expect(toJson(wrapper.find('h5'))).toMatchSnapshot('header');
+    expect(toJson(wrapper.find('Table'))).toMatchSnapshot('indicator table');
+    wrapper.unmount();
+  });
+});

--- a/src/components/formatting/IRSIndicatorLegend/tests/index.test.tsx
+++ b/src/components/formatting/IRSIndicatorLegend/tests/index.test.tsx
@@ -8,7 +8,7 @@ describe('/components/formatting/IRSIndicatorLegend', () => {
   it('renders correctly', () => {
     const wrapper = mount(<IRSIndicatorLegend />);
     expect(wrapper.props()).toEqual({ indicatorThresholds: indicatorThresholdsIRS });
-    expect(toJson(wrapper.find('h5'))).toMatchSnapshot('header');
+    expect(toJson(wrapper.find('.card-header'))).toMatchSnapshot('header');
     expect(toJson(wrapper.find('Table'))).toMatchSnapshot('indicator table');
     wrapper.unmount();
   });

--- a/src/components/formatting/IRSIndicatorLegend/tests/index.test.tsx
+++ b/src/components/formatting/IRSIndicatorLegend/tests/index.test.tsx
@@ -2,12 +2,12 @@ import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import React from 'react';
 import IRSIndicatorLegend from '..';
-import { indicatorThresholdsNA } from '../../../../configs/settings';
+import { indicatorThresholdsIRS } from '../../../../configs/settings';
 
 describe('/components/formatting/IRSIndicatorLegend', () => {
   it('renders correctly', () => {
     const wrapper = mount(<IRSIndicatorLegend />);
-    expect(wrapper.props()).toEqual({ indicatorThresholds: indicatorThresholdsNA });
+    expect(wrapper.props()).toEqual({ indicatorThresholds: indicatorThresholdsIRS });
     expect(toJson(wrapper.find('h5'))).toMatchSnapshot('header');
     expect(toJson(wrapper.find('Table'))).toMatchSnapshot('indicator table');
     wrapper.unmount();

--- a/src/configs/settings.ts
+++ b/src/configs/settings.ts
@@ -725,8 +725,8 @@ export interface IndicatorThresholds {
   [key: string]: IndicatorThresholdItem;
 }
 
-/** Indicator Thresholds for NA (Namibia) */
-export const indicatorThresholdsNA: IndicatorThresholds = {
+/** IRS Reporting configs */
+export const indicatorThresholdsIRS: IndicatorThresholds = {
   GREEN_THRESHOLD: {
     color: '#2ECC40',
     name: 'Green',
@@ -749,6 +749,7 @@ export const indicatorThresholdsNA: IndicatorThresholds = {
     value: 0.9,
   },
 };
+/** END IRS Reporting configs */
 
 /** interface describing base configs for irs reporting configurations */
 export interface IrsReportingConfig {
@@ -762,34 +763,12 @@ export const irsReportingCongif: {
 } = {
   // Namibia Structures Configs
   [process.env.REACT_APP_SUPERSET_IRS_REPORTING_STRUCTURES_DATA_SLICE_NA as string]: {
-    indicatorThresholds: indicatorThresholdsNA,
+    indicatorThresholds: indicatorThresholdsIRS,
   } as IrsReportingConfig,
 };
 /* tslint:enable:object-literal-sort-keys */
 
 /** END IRS Reporting interfaces */
-
-/** IRS Reporting configs */
-export const indicatorThresholdsIRS = {
-  GREEN_THRESHOLD: {
-    color: '#2ECC40',
-    value: 1,
-  },
-  GREY_THRESHOLD: {
-    color: '#dddddd',
-    value: 0.2,
-  },
-  RED_THRESHOLD: {
-    color: '#FF4136',
-    orEquals: true,
-    value: 0.75,
-  },
-  YELLOW_THRESHOLD: {
-    color: '#FFDC00',
-    value: 0.9,
-  },
-};
-/** END IRS Reporting configs */
 
 /** Interfaces describing administrative hierarchy via ISO 3166 admin codes */
 export interface ADMN0 {

--- a/src/configs/settings.ts
+++ b/src/configs/settings.ts
@@ -13,6 +13,7 @@
  * functions is discouraged and should only be done if there is no other way.
  */
 import { Providers } from '@onaio/gatekeeper';
+import { Color } from 'csstype';
 import { Expression, LngLatBoundsLike } from 'mapbox-gl';
 import {
   ActionReasonType,
@@ -711,32 +712,40 @@ export const symbolLayerConfig = {
 /** Default colors layer fill colors per administrative level */
 export const adminLayerColors = ['black', 'red', 'orange', 'yellow', 'green'];
 
+/** interface describing indicator threshold item */
+export interface IndicatorThresholdItem {
+  color: Color;
+  name: string;
+  orEquals?: boolean;
+  value: number;
+}
+
 /** interface describing threshold configs for IRS report indicators */
 export interface IndicatorThresholds {
-  [key: string]: {
-    color: any;
-    orEquals?: boolean;
-    value: number;
-  };
+  [key: string]: IndicatorThresholdItem;
 }
 
 /** Indicator Thresholds for NA (Namibia) */
 export const indicatorThresholdsNA: IndicatorThresholds = {
   GREEN_THRESHOLD: {
     color: '#2ECC40',
+    name: 'Green',
     value: 1,
   },
   GREY_THRESHOLD: {
     color: '#dddddd',
+    name: 'Grey',
     value: 0.2,
   },
   RED_THRESHOLD: {
     color: '#FF4136',
+    name: 'Red',
     orEquals: true,
     value: 0.75,
   },
   YELLOW_THRESHOLD: {
     color: '#FFDC00',
+    name: 'Yellow',
     value: 0.9,
   },
 };

--- a/src/containers/pages/IRS/JurisdictionsReport/index.tsx
+++ b/src/containers/pages/IRS/JurisdictionsReport/index.tsx
@@ -9,6 +9,7 @@ import { RouteComponentProps } from 'react-router';
 import 'react-table/react-table.css';
 import { Col, Row } from 'reactstrap';
 import { Store } from 'redux';
+import IRSIndicatorLegend from '../../../../components/formatting/IRSIndicatorLegend';
 import IRSTableCell from '../../../../components/IRSTableCell';
 import HeaderBreadcrumb from '../../../../components/page/HeaderBreadcrumb/HeaderBreadcrumb';
 import Loading from '../../../../components/page/Loading';
@@ -231,6 +232,7 @@ const JurisdictionReport = (props: GenericJurisdictionProps & RouteComponentProp
           <div className="irs-report-table">
             <DrillDownTable {...tableProps} />
           </div>
+          <IRSIndicatorLegend />
         </Col>
       </Row>
     </div>

--- a/src/containers/pages/IRS/JurisdictionsReport/tests/index.test.tsx
+++ b/src/containers/pages/IRS/JurisdictionsReport/tests/index.test.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { Router } from 'react-router';
 import { JurisdictionReport } from '../';
+import { indicatorThresholdsIRS } from '../../../../../configs/settings';
 import { REPORT_IRS_PLAN_URL } from '../../../../../constants';
 import store from '../../../../../store';
 import GenericJurisdictionsReducer, {
@@ -137,6 +138,10 @@ describe('components/IRS Reports/JurisdictionReport', () => {
     expect((wrapper.find('DrillDownTable').props() as any).columns).toEqual(
       IRSTableColumns.zambiaJurisdictions2019
     );
+    expect(wrapper.find('IRSIndicatorLegend').length).toEqual(1);
+    expect(wrapper.find('IRSIndicatorLegend').props()).toEqual({
+      indicatorThresholds: indicatorThresholdsIRS,
+    });
     expect(supersetServiceMock.mock.calls).toEqual([
       [
         '13',

--- a/src/containers/pages/IRS/Map/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/pages/IRS/Map/tests/__snapshots__/index.test.tsx.snap
@@ -104,19 +104,23 @@ Array [
       Object {
         "GREEN_THRESHOLD": Object {
           "color": "#2ECC40",
+          "name": "Green",
           "value": 1,
         },
         "GREY_THRESHOLD": Object {
           "color": "#dddddd",
+          "name": "Grey",
           "value": 0.2,
         },
         "RED_THRESHOLD": Object {
           "color": "#FF4136",
+          "name": "Red",
           "orEquals": true,
           "value": 0.75,
         },
         "YELLOW_THRESHOLD": Object {
           "color": "#FFDC00",
+          "name": "Yellow",
           "value": 0.9,
         },
       }
@@ -156,19 +160,23 @@ Array [
       Object {
         "GREEN_THRESHOLD": Object {
           "color": "#2ECC40",
+          "name": "Green",
           "value": 1,
         },
         "GREY_THRESHOLD": Object {
           "color": "#dddddd",
+          "name": "Grey",
           "value": 0.2,
         },
         "RED_THRESHOLD": Object {
           "color": "#FF4136",
+          "name": "Red",
           "orEquals": true,
           "value": 0.75,
         },
         "YELLOW_THRESHOLD": Object {
           "color": "#FFDC00",
+          "name": "Yellow",
           "value": 0.9,
         },
       }
@@ -208,19 +216,23 @@ Array [
       Object {
         "GREEN_THRESHOLD": Object {
           "color": "#2ECC40",
+          "name": "Green",
           "value": 1,
         },
         "GREY_THRESHOLD": Object {
           "color": "#dddddd",
+          "name": "Grey",
           "value": 0.2,
         },
         "RED_THRESHOLD": Object {
           "color": "#FF4136",
+          "name": "Red",
           "orEquals": true,
           "value": 0.75,
         },
         "YELLOW_THRESHOLD": Object {
           "color": "#FFDC00",
+          "name": "Yellow",
           "value": 0.9,
         },
       }
@@ -260,19 +272,23 @@ Array [
       Object {
         "GREEN_THRESHOLD": Object {
           "color": "#2ECC40",
+          "name": "Green",
           "value": 1,
         },
         "GREY_THRESHOLD": Object {
           "color": "#dddddd",
+          "name": "Grey",
           "value": 0.2,
         },
         "RED_THRESHOLD": Object {
           "color": "#FF4136",
+          "name": "Red",
           "orEquals": true,
           "value": 0.75,
         },
         "YELLOW_THRESHOLD": Object {
           "color": "#FFDC00",
+          "name": "Yellow",
           "value": 0.9,
         },
       }

--- a/src/helpers/indicators.tsx
+++ b/src/helpers/indicators.tsx
@@ -6,7 +6,7 @@ import { GREEN, ORANGE, RED, WHITE, YELLOW } from '../colors';
 import {
   GREEN_THRESHOLD,
   IndicatorThresholds,
-  indicatorThresholdsNA,
+  indicatorThresholdsIRS,
   irsReportingCongif,
   ORANGE_THRESHOLD,
   YELLOW_THRESHOLD,
@@ -155,10 +155,10 @@ export function renderClassificationRow(rowObject: FlexObject) {
 }
 
 /** Determines the color of a indicator based on cell.value and threshold configs
- * @param {CellInfo} cell - the ReactTable.Cell being rendered in an indicator drilldown table
+ * @param {CellInfo} cell - the ReactTable.Cell being rendered in an indicator drill-down table
  * @param {IndicatorThresholds} thresholds - the threshold configuration from settings
  * @param {boolean} doMakeDecimal -  determines if the cell value needs to be divided by 100
- * @returns {string} - the value coorisponding the cell.value according to the reporting config
+ * @returns {string} - the value corresponding the cell.value according to the reporting config
  */
 export function getThresholdColor(
   cell: CellInfo,
@@ -216,7 +216,7 @@ export function getThresholdAdherenceIndicator(cell: CellInfo, configId: string)
  */
 export function getIRSThresholdAdherenceIndicator(
   cell: CellInfo,
-  thresholds: IndicatorThresholds | null = indicatorThresholdsNA
+  thresholds: IndicatorThresholds | null = indicatorThresholdsIRS
 ) {
   // determine if cell.value is a number
   const isNumber = !Number.isNaN(Number(cell.value));


### PR DESCRIPTION
Adds a component that explains the colors in IRS reporting tables similar to what was in mSpray - see https://macepa.mspray.onalabs.org/

![irs legend2](https://user-images.githubusercontent.com/372073/67633391-62697b00-f8c0-11e9-8718-b4ef2c5c13de.png)

