### PR TITLE
Assign page fix

### DIFF
--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -223,6 +223,8 @@ export const NO_PRACTITIONERS_ADDED_YET = 'No Practitioners Added yet';
 export type NO_PRACTITIONERS_ADDED_YET = typeof NO_PRACTITIONERS_ADDED_YET;
 export const PLAN_SELECT_PLACEHOLDER = 'Other plans in this area';
 export type PLAN_SELECT_PLACEHOLDER = typeof PLAN_SELECT_PLACEHOLDER;
+export const ASSIGN_PLANS = 'Assign Plans';
+export type ASSIGN_PLANS = typeof ASSIGN_PLANS;
 
 // TODO ? - do the below 2 belong here or in a settings file
 export const ORGANIZATION_LABEL = TEAM;

--- a/src/containers/pages/IRS/assignments/index.tsx
+++ b/src/containers/pages/IRS/assignments/index.tsx
@@ -9,10 +9,11 @@ import { Store } from 'redux';
 import HeaderBreadcrumb from '../../../../components/page/HeaderBreadcrumb/HeaderBreadcrumb';
 import Loading from '../../../../components/page/Loading';
 import {
+  ASSIGN,
   ASSIGN_PLAN_URL,
+  ASSIGN_PLANS,
   HOME,
   HOME_URL,
-  IRS_PLANS,
   NO_PLANS_LOADED_MESSAGE,
   REPORT_IRS_PLAN_URL,
 } from '../../../../constants';
@@ -46,7 +47,7 @@ const IRSAssignmentPlansList = (props: PlanAssignmentsListProps) => {
   const { fetchPlans, plans } = props;
   const [loading, setLoading] = useState<boolean>(plans.length < 1);
 
-  const pageTitle: string = IRS_PLANS;
+  const pageTitle: string = `${ASSIGN_PLANS}`;
 
   const breadcrumbProps = {
     currentPage: {

--- a/src/containers/pages/IRS/assignments/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/pages/IRS/assignments/tests/__snapshots__/index.test.tsx.snap
@@ -22,7 +22,7 @@ Array [
     aria-current="page"
     className="active breadcrumb-item"
   >
-    IRS Plans
+    Assign Plans
   </li>,
 ]
 `;
@@ -31,7 +31,7 @@ exports[`components/IRS Reports/IRSPlansList renders plan definition list correc
 <h3
   className="mt-3 mb-3 page-title"
 >
-  IRS Plans
+  Assign Plans
 </h3>
 `;
 

--- a/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
+++ b/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
@@ -683,14 +683,13 @@ class IrsPlan extends React.Component<
           target: getGisidaMapById(MAP_ID),
         };
         this.onDrillUpClick(fauxE, this.state.country, filteredJurisdictions);
-
-        // update drilldown table
-        this.onResetDrilldownTableHierarchy(clickedTableCrumb.id);
       }
+      // update drilldown table
+      this.onResetDrilldownTableHierarchy(e.currentTarget.id);
     }
   };
   /** onResetDrilldownTableHierarchy - function for resetting drilldown table hierachy baseline
-   * @param {string|null} Id - the id of the highest level parent_idto show in the table, or null to reset completely
+   * @param {string|null} Id - the id of the highest level parent_id to show in the table, or null to reset completely
    */
   private onResetDrilldownTableHierarchy(Id: string | null) {
     const id = Id !== 'null' ? Id : null;

--- a/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
+++ b/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
@@ -503,16 +503,9 @@ class IrsPlan extends React.Component<
 
     const planHeaderRow = (
       <Row>
-        {isFinalizedPlan && (
-          <Col xs="8" className="page-title-col">
-            <h2 className="page-title">IRS: {pageLabel}</h2>
-          </Col>
-        )}
-        {!isFinalizedPlan && (
-          <Col xs="8" className="page-title-col">
-            <h2 className="page-title">IRS: {pageLabel}</h2>
-          </Col>
-        )}
+        <Col xs="8" className="page-title-col">
+          <h2 className="page-title">IRS: {pageLabel}</h2>
+        </Col>
 
         <Col xs="4" className="save-plan-buttons-column">
           {!isFinalizedPlan && (

--- a/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
+++ b/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../../../../configs/env';
 import {
   ASSIGN_PLAN_URL,
+  ASSIGN_PLANS,
   DRAFT,
   HOME,
   HOME_URL,
@@ -185,6 +186,7 @@ interface IrsPlanState {
   filteredJurisdictionIds: string[];
   focusJurisdictionId: string | null;
   gisidaWrapperProps: GisidaProps | null;
+  isAssignView: boolean;
   isBuildingGisidaProps: boolean;
   isLoadingGeoms: boolean;
   isLoadingJurisdictions: boolean;
@@ -212,6 +214,7 @@ class IrsPlan extends React.Component<
       filteredJurisdictionIds: [],
       focusJurisdictionId: null,
       gisidaWrapperProps: null,
+      isAssignView: props.match.url.includes(ASSIGN_PLAN_URL),
       isBuildingGisidaProps: false,
       isLoadingGeoms: false,
       isLoadingJurisdictions: true,
@@ -490,6 +493,8 @@ class IrsPlan extends React.Component<
       (newPlan && newPlan.plan_title) ||
       NEW_PLAN;
 
+    const displayedPageLabel = this.state.isAssignView ? pageLabel : `IRS: ${pageLabel}`;
+
     const breadCrumbProps = this.getBreadCrumbProps(this.props, pageLabel);
 
     const { planTableProps } = this.state;
@@ -504,7 +509,7 @@ class IrsPlan extends React.Component<
     const planHeaderRow = (
       <Row>
         <Col xs="8" className="page-title-col">
-          <h2 className="page-title">IRS: {pageLabel}</h2>
+          <h2 className="page-title">{displayedPageLabel}</h2>
         </Col>
 
         <Col xs="4" className="save-plan-buttons-column">
@@ -563,7 +568,7 @@ class IrsPlan extends React.Component<
     return (
       <div className="mb-5">
         <Helmet>
-          <title>IRS: {pageLabel}</title>
+          <title>{displayedPageLabel}</title>
         </Helmet>
         <HeaderBreadcrumbs {...breadCrumbProps} />
         {planHeaderRow}
@@ -2022,7 +2027,7 @@ class IrsPlan extends React.Component<
       url: HOME_URL,
     };
     const basePage = {
-      label: IRS_TITLE,
+      label: this.state.isAssignView ? ASSIGN_PLANS : IRS_TITLE,
       url: isDraftPlan ? INTERVENTION_IRS_URL : ASSIGN_PLAN_URL,
     };
     const urlPathAppend =


### PR DESCRIPTION
Includes fixes for the assign Page as proposed in #556 closes #556 
Changes:
- Refactors so that displayed text on pages tiltles and document titles align with the page's purposes
- Refactor so that one can now drill up in the `drilldown` by clicking the `tableCrumbs`