### PR TITLE
Focus Investigation pages cleanup

### DIFF
--- a/src/containers/pages/FocusInvestigation/map/active/index.tsx
+++ b/src/containers/pages/FocusInvestigation/map/active/index.tsx
@@ -21,6 +21,7 @@ import {
   SUPERSET_STRUCTURES_SLICE,
   SUPERSET_TASKS_SLICE,
 } from '../../../../../configs/env';
+import { FIReasons } from '../../../../../configs/settings';
 import {
   CASE_TRIGGERED,
   END_DATE,
@@ -417,13 +418,17 @@ const mapStateToProps = (state: Partial<Store>, ownProps: any) => {
   if (plan) {
     jurisdiction = getJurisdictionById(state, plan.jurisdiction_id);
     goals = getGoalsByPlanAndJurisdiction(state, plan.plan_id, plan.jurisdiction_id);
-    plansByFocusArea = getPlansArray(
-      state,
-      InterventionType.FI,
-      [PlanStatus.ACTIVE, PlanStatus.COMPLETE],
-      null,
-      [plan.jurisdiction_id]
-    );
+    FIReasons.forEach(reason => {
+      const plans = getPlansArray(
+        state,
+        InterventionType.FI,
+        [PlanStatus.ACTIVE, PlanStatus.COMPLETE],
+        reason,
+        [plan.jurisdiction_id]
+      );
+      plansByFocusArea = plansByFocusArea.concat(plans);
+    });
+    plansByFocusArea.sort((a: Plan, b: Plan) => Date.parse(b.plan_date) - Date.parse(a.plan_date));
   }
 
   if (plan && jurisdiction && (goals && goals.length > 1)) {

--- a/src/containers/pages/FocusInvestigation/map/active/tests/index.test.tsx
+++ b/src/containers/pages/FocusInvestigation/map/active/tests/index.test.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router';
+import { FIReasons } from '../../../../../../configs/settings';
 import { FI_SINGLE_URL } from '../../../../../../constants';
 import { wrapFeatureCollection } from '../../../../../../helpers/utils';
 import store from '../../../../../../store';
@@ -304,17 +305,23 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
         </Router>
       </Provider>
     );
-    expect(getPlansArrayMock).toBeCalledTimes(2);
+    expect(getPlansArrayMock).toBeCalledTimes(FIReasons.length + 1);
 
     // define expected results
     const plansArrayExpected1 = [
       existingState,
       'FI',
       ['active', 'complete'],
-      null,
+      FIReasons[0],
       ['450fc15b-5bd2-468a-927a-49cb10d3bcac'],
     ];
-    const plansArrayExpected2 = [existingState, 'FI', ['active', 'complete']];
+    const plansArrayExpected2 = [
+      existingState,
+      'FI',
+      ['active', 'complete'],
+      'Case Triggered',
+      ['450fc15b-5bd2-468a-927a-49cb10d3bcac'],
+    ];
     const planByIdExpected = [existingState, 'ed2b4b7c-3388-53d9-b9f6-6a19d1ffde1f'];
     const goalPlanJurisdictionexpected = [
       existingState,

--- a/src/containers/pages/FocusInvestigation/single/index.tsx
+++ b/src/containers/pages/FocusInvestigation/single/index.tsx
@@ -417,21 +417,7 @@ class SingleFI extends React.Component<RouteComponentProps<RouteParams> & Single
           </Col>
         </Row>
         <hr />
-        <Form inline={true} onSubmit={this.handleSubmit}>
-          <FormGroup className="mb-2 mr-sm-2 mb-sm-0">
-            <Input
-              type="text"
-              name="search"
-              id="exampleEmail"
-              placeholder="Search active focus investigations"
-            />
-          </FormGroup>
-          <Button outline={true} color="success">
-            Search
-          </Button>
-        </Form>
         <h4 className="mb-4">{CURRENT_FOCUS_INVESTIGATION}</h4>
-        <hr />
         {currentRoutineReactivePlans}
         <h4 className="mb-4 complete">{COMPLETE_FOCUS_INVESTIGATION}</h4>
         <hr />

--- a/src/containers/pages/FocusInvestigation/single/index.tsx
+++ b/src/containers/pages/FocusInvestigation/single/index.tsx
@@ -481,14 +481,14 @@ const mapStateToProps = (state: Partial<Store>, ownProps: any): DispatchedStateP
     currentReactivePlansArray: getPlansArray(
       state,
       InterventionType.FI,
-      [PlanStatus.ACTIVE, PlanStatus.DRAFT],
+      [PlanStatus.ACTIVE],
       CASE_TRIGGERED,
       jurisdictionId
     ),
     currentRoutinePlansArray: getPlansArray(
       state,
       InterventionType.FI,
-      [PlanStatus.ACTIVE, PlanStatus.DRAFT],
+      [PlanStatus.ACTIVE],
       ROUTINE,
       jurisdictionId
     ),

--- a/src/containers/pages/FocusInvestigation/single/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/pages/FocusInvestigation/single/tests/__snapshots__/index.test.tsx.snap
@@ -1016,59 +1016,11 @@ exports[`containers/pages/SingleFI It works with the Redux store 1`] = `
             </div>
           </Row>
           <hr />
-          <Form
-            inline={true}
-            onSubmit={[Function]}
-            tag="form"
-          >
-            <form
-              className="form-inline"
-              onSubmit={[Function]}
-            >
-              <FormGroup
-                className="mb-2 mr-sm-2 mb-sm-0"
-                tag="div"
-              >
-                <div
-                  className="mb-2 mr-sm-2 mb-sm-0 form-group"
-                >
-                  <Input
-                    id="exampleEmail"
-                    name="search"
-                    placeholder="Search active focus investigations"
-                    type="text"
-                  >
-                    <input
-                      className="form-control"
-                      id="exampleEmail"
-                      name="search"
-                      placeholder="Search active focus investigations"
-                      type="text"
-                    />
-                  </Input>
-                </div>
-              </FormGroup>
-              <Button
-                color="success"
-                outline={true}
-                tag="button"
-              >
-                <button
-                  aria-label={null}
-                  className="btn btn-outline-success"
-                  onClick={[Function]}
-                >
-                  Search
-                </button>
-              </Button>
-            </form>
-          </Form>
           <h4
             className="mb-4"
           >
             Current Focus Investigations
           </h4>
-          <hr />
           <div
             key="ed2b4b7c-3388-53d9-b9f6-6a19d1ffde1f"
           >
@@ -6194,59 +6146,11 @@ exports[`containers/pages/SingleFI renders SingleFI correctly 1`] = `
         </div>
       </Row>
       <hr />
-      <Form
-        inline={true}
-        onSubmit={[Function]}
-        tag="form"
-      >
-        <form
-          className="form-inline"
-          onSubmit={[Function]}
-        >
-          <FormGroup
-            className="mb-2 mr-sm-2 mb-sm-0"
-            tag="div"
-          >
-            <div
-              className="mb-2 mr-sm-2 mb-sm-0 form-group"
-            >
-              <Input
-                id="exampleEmail"
-                name="search"
-                placeholder="Search active focus investigations"
-                type="text"
-              >
-                <input
-                  className="form-control"
-                  id="exampleEmail"
-                  name="search"
-                  placeholder="Search active focus investigations"
-                  type="text"
-                />
-              </Input>
-            </div>
-          </FormGroup>
-          <Button
-            color="success"
-            outline={true}
-            tag="button"
-          >
-            <button
-              aria-label={null}
-              className="btn btn-outline-success"
-              onClick={[Function]}
-            >
-              Search
-            </button>
-          </Button>
-        </form>
-      </Form>
       <h4
         className="mb-4"
       >
         Current Focus Investigations
       </h4>
-      <hr />
       <div
         key="plan-id-2"
       >


### PR DESCRIPTION
For #578 and #579 

This PR:
* Filters the plans rendered in the FI reporting map dropdown select
* Removes draft plans from the FA page
* Removes the search input from the FA page