### PR TITLE
Fix for mark plan as complete error

### DIFF
--- a/src/containers/forms/PractitionerForm/UserIdSelect/index.tsx
+++ b/src/containers/forms/PractitionerForm/UserIdSelect/index.tsx
@@ -102,10 +102,18 @@ export const UserIdSelect: React.FC<Props> = props => {
     setOpenMRSUsers(unMatchedUsers);
   };
 
-  const options = openMRSUsers.map((user: OpenMRSUser) => ({
-    label: user.display,
-    value: user.uuid,
-  }));
+  const options = React.useMemo(() => {
+    return openMRSUsers
+      .map((user: OpenMRSUser) => ({
+        label: user.display,
+        value: user.uuid,
+      }))
+      .sort((userA, userB) => {
+        const userALabel = userA.label;
+        const userBLabel = userB.label;
+        return userALabel === userBLabel ? 0 : userALabel > userBLabel ? 1 : -1;
+      });
+  }, [openMRSUsers]);
 
   return (
     <Select

--- a/src/containers/pages/FocusInvestigation/map/planCompletion/index.tsx
+++ b/src/containers/pages/FocusInvestigation/map/planCompletion/index.tsx
@@ -67,7 +67,8 @@ export class PlanCompletion extends React.Component<
     const service = new serviceClass(`${OPENSRP_PLANS}`);
 
     // get the plan as it exists in the OpenSRP Server
-    await service.read(planToconfirm.plan_id).then((planPayload: PlanPayload) => {
+    await service.read(planToconfirm.plan_id).then((fullPayload: PlanPayload[]) => {
+      const planPayload = fullPayload[0];
       if (planPayload && JSON.stringify(planPayload) !== '{}') {
         // set the plan status to complete
         const thePlan: PlanPayload = {

--- a/src/containers/pages/FocusInvestigation/map/planCompletion/tests/index.test.tsx
+++ b/src/containers/pages/FocusInvestigation/map/planCompletion/tests/index.test.tsx
@@ -169,7 +169,7 @@ describe('@containers/pages/map/planCompletion/', () => {
 
     const expectedCalledUrl =
       'https://reveal-stage.smartregister.org/opensrp/rest/plans/10f9e9fa-ce34-4b27-a961-72fab5206ab6';
-    fetch.once(JSON.stringify(plansListResponse[0])).once(JSON.stringify(updateResponse));
+    fetch.once(JSON.stringify([plansListResponse[0]])).once(JSON.stringify(updateResponse));
 
     const discoWrapper = mount(
       <Provider store={store}>

--- a/src/containers/pages/PractitionerViews/CreateEditPractitioner/index.tsx
+++ b/src/containers/pages/PractitionerViews/CreateEditPractitioner/index.tsx
@@ -1,6 +1,7 @@
 /** Edit / New Practitioner View page:
  * displays form that's used to create a new practitioner or update openSRP api
  */
+import { capitalize } from 'lodash';
 import React, { useEffect } from 'react';
 import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
@@ -65,7 +66,7 @@ const CreateEditPractitionerView = (props: PropsTypes) => {
   };
   const breadcrumbProps: BreadCrumbProps = {
     currentPage: {
-      label: editing ? `${EDIT} ${PRACTITIONER}` : `${NEW} ${PRACTITIONER}`,
+      label: editing ? `${EDIT} ${PRACTITIONER}` : `${capitalize(NEW as string)} ${PRACTITIONER}`,
       url: editing
         ? `${EDIT_PRACTITIONER_URL}/${practitioner!.identifier}`
         : CREATE_PRACTITIONER_URL,


### PR DESCRIPTION
closes #616 

Refactors type of received response during 'get' request to `'rest/plans/<identifier>`, Fixes the payload to `PUT` accordingly.