### PR TITLE
Small cleanup

### DIFF
--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -333,6 +333,8 @@ export const NEW_PRACTITIONER = 'New Practitioner';
 export type NEW_PRACTITIONER = typeof NEW_PRACTITIONER;
 export const EDIT_PRACTITIONER = 'Edit Practitioner';
 export type EDIT_PRACTITIONER = typeof EDIT_PRACTITIONER;
+export const AS_COMPLETE = 'as complete';
+export type AS_COMPLETE = typeof AS_COMPLETE;
 
 // TODO ? - do the below 2 belong here or in a settings file
 export const ORGANIZATION_LABEL = TEAM;

--- a/src/containers/pages/FocusInvestigation/map/planCompletion/index.css
+++ b/src/containers/pages/FocusInvestigation/map/planCompletion/index.css
@@ -1,0 +1,3 @@
+.plan-name {
+  color: #606060;
+}

--- a/src/containers/pages/FocusInvestigation/map/planCompletion/index.tsx
+++ b/src/containers/pages/FocusInvestigation/map/planCompletion/index.tsx
@@ -7,9 +7,8 @@ import { toast } from 'react-toastify';
 import { Store } from 'redux';
 import Loading from '../../../../../components/page/Loading';
 import {
-  AS,
+  AS_COMPLETE,
   CANCEL,
-  COMPLETE,
   CONFIRM,
   FI_SINGLE_MAP_URL,
   MARK,
@@ -29,6 +28,7 @@ import {
   PlanPayload,
   PlanStatus,
 } from '../../../../../store/ducks/plans';
+import './index.css';
 
 /** Props interface for the plan completion component page */
 export interface PlanCompletionProps {
@@ -110,18 +110,24 @@ export class PlanCompletion extends React.Component<
     return (
       <div id="plan-completion-page-wrapper">
         <Helmet>
-          <title>{`${MARK} ${plan.plan_title} ${AS} ${COMPLETE.toLocaleLowerCase()}`}</title>
+          <title>{`${MARK} ${plan.plan_title} ${AS_COMPLETE}`}</title>
         </Helmet>
         {/** prompt to confirm mark as complete click action */}
-        <h2 className="mb-3 mt-5 page-title">{`${MARK} ${
-          plan.plan_title
-        } ${AS} ${COMPLETE.toLocaleLowerCase()}`}</h2>
+        <h2 className="mb-3 mt-5 page-title">
+          {`${MARK} `}
+          <span className="plan-name">${plan.plan_title}</span>
+          {` ${AS_COMPLETE}`}
+        </h2>
         <hr />
         <div className="card mb-3">
           <div className="card-header">{MARK_AS_COMPLETE}</div>
           <div className="card-body">
             {/* this should be error handlers not links */}
-            <p>{`${MARK} ${plan.plan_title} ${AS} ${COMPLETE.toLocaleLowerCase()}`}</p>
+            <p>
+              {`${MARK} `}
+              <span className="plan-name">${plan.plan_title}</span>
+              {` ${AS_COMPLETE}`}
+            </p>
             <button
               id="complete-plan-cancel-btn"
               onClick={this.cancelClickHandler}

--- a/src/containers/pages/FocusInvestigation/map/planCompletion/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/pages/FocusInvestigation/map/planCompletion/tests/__snapshots__/index.test.tsx.snap
@@ -25,7 +25,14 @@ exports[`@containers/pages/map/planCompletion/ renders correctly 1`] = `
   <h2
     className="mb-3 mt-5 page-title"
   >
-    Mark A1-Tha Luang Village 1 Focus 01 as complete
+    Mark 
+    <span
+      className="plan-name"
+    >
+      $
+      A1-Tha Luang Village 1 Focus 01
+    </span>
+     as complete
   </h2>
   <hr />
   <div
@@ -40,7 +47,14 @@ exports[`@containers/pages/map/planCompletion/ renders correctly 1`] = `
       className="card-body"
     >
       <p>
-        Mark A1-Tha Luang Village 1 Focus 01 as complete
+        Mark 
+        <span
+          className="plan-name"
+        >
+          $
+          A1-Tha Luang Village 1 Focus 01
+        </span>
+         as complete
       </p>
       <button
         className="btn btn-danger"
@@ -66,6 +80,13 @@ exports[`@containers/pages/map/planCompletion/ works with the redux store 1`] = 
 <h2
   className="mb-3 mt-5 page-title"
 >
-  Mark A1-Tha Luang Village 1 Focus 01 as complete
+  Mark 
+  <span
+    className="plan-name"
+  >
+    $
+    A1-Tha Luang Village 1 Focus 01
+  </span>
+   as complete
 </h2>
 `;

--- a/src/containers/pages/FocusInvestigation/map/planCompletion/tests/index.test.tsx
+++ b/src/containers/pages/FocusInvestigation/map/planCompletion/tests/index.test.tsx
@@ -36,20 +36,6 @@ import { payload } from './fixtures';
 
 // tslint:disable-next-line: no-var-requires
 const fetch = require('jest-fetch-mock');
-jest.mock('react-toastify', () => {
-  const mockToast: any = jest.fn();
-  mockToast.TYPE = {
-    DEFAULT: 'default',
-    ERROR: 'error',
-    INFO: 'info',
-    SUCCESS: 'success',
-    WARNING: 'warning',
-  };
-  mockToast.configure = jest.fn();
-  return {
-    toast: mockToast,
-  };
-});
 
 reducerRegistry.register(reducerName, reducer);
 const history = createBrowserHistory();
@@ -257,7 +243,7 @@ describe('@containers/pages/map/planCompletion/', () => {
     discoWrapper.unmount();
   });
 
-  it('growl on plan read error', async () => {
+  it('growl on error when reading plan', async () => {
     store.dispatch(fetchPlans(fixtures.plans as any));
     const mock: any = jest.fn();
     const props = {
@@ -293,7 +279,7 @@ describe('@containers/pages/map/planCompletion/', () => {
     });
   });
 
-  it('growl on no update error', async () => {
+  it('growl on error when updating plan', async () => {
     store.dispatch(fetchPlans(fixtures.plans as any));
     const mock: any = jest.fn();
     const props = {
@@ -330,7 +316,7 @@ describe('@containers/pages/map/planCompletion/', () => {
     });
   });
 
-  it('growl on no plan read error', async () => {
+  it('growl on read if no plan received', async () => {
     store.dispatch(fetchPlans(fixtures.plans as any));
     const mock: any = jest.fn();
     const props = {

--- a/src/containers/pages/OrganizationViews/AssignPractitioners/index.tsx
+++ b/src/containers/pages/OrganizationViews/AssignPractitioners/index.tsx
@@ -228,7 +228,7 @@ const AssignPractitioner = (props: PropsTypes) => {
   };
   const otherPagesInOrder = [
     {
-      label: props.match.params.id,
+      label: organization.name,
       url: `${SINGLE_ORGANIZATION_URL}/${props.match.params.id}`,
     },
   ];

--- a/src/containers/pages/OrganizationViews/AssignPractitioners/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/pages/OrganizationViews/AssignPractitioners/tests/__snapshots__/index.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`src/pages/*/AssignPractitioners Renders correctly: BreadCrumb 1`] = `
               href="/teams/view/d23f7350-d406-11e9-bb65-2a2ae2dbcce4"
               onClick={[Function]}
             >
-              d23f7350-d406-11e9-bb65-2a2ae2dbcce4
+              Takang 1
             </a>
           </Link>
         </li>


### PR DESCRIPTION
closes #
small cleanup for team assignment:
- remove surplus code in tests
- change text for link to single organization view in breadcrumb from the organization identifier to the organization name


- change the text color for plan title in plan completion