### PR TITLE
Add default circle layer for FI structures point features

### DIFF
--- a/src/containers/pages/FocusInvestigation/map/active/tests/fixtures.ts
+++ b/src/containers/pages/FocusInvestigation/map/active/tests/fixtures.ts
@@ -46,3 +46,248 @@ export const existingState = {
     },
   },
 };
+
+// tslint:disable object-literal-sort-keys
+export const structures = [
+  {
+    id: '90ac3202-6e7c-449b-8555-9640d4804035',
+    jurisdiction_id: '450fc15b-5bd2-468a-927a-49cb10d3bcac',
+    geojson: {
+      id: '90ac3202-6e7c-449b-8555-9640d4804035',
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [98.420925756882, 17.1019111524589],
+      },
+      properties: {
+        uid: 'a',
+        code: 'null',
+        name: 'b',
+        type: 'Feature',
+        status: 'Pending Review',
+        version: 0,
+        server_version: 1570616378990,
+        jurisdiction_id: '450fc15b-5bd2-468a-927a-49cb10d3bcac',
+        geographic_level: 0,
+        effective_end_data: null,
+        effective_start_date: null,
+      },
+    },
+  },
+  {
+    id: '85ecfa3f-146f-4f98-a06b-cd8c939c0bbb',
+    jurisdiction_id: '450fc15b-5bd2-468a-927a-49cb10d3bcac',
+    geojson: {
+      id: '85ecfa3f-146f-4f98-a06b-cd8c939c0bbb',
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [98.4202760925857, 17.10324421982],
+      },
+      properties: {
+        uid: 'a',
+        code: 'null',
+        name: 'b',
+        type: 'Feature',
+        status: 'Pending Review',
+        version: 0,
+        server_version: 1566453083059,
+        jurisdiction_id: '450fc15b-5bd2-468a-927a-49cb10d3bcac',
+        geographic_level: 0,
+        effective_end_data: null,
+        effective_start_date: null,
+      },
+    },
+  },
+  {
+    id: '580edf9d-1b91-48d9-aedd-6d675af42bc9',
+    jurisdiction_id: '450fc15b-5bd2-468a-927a-49cb10d3bcac',
+    geojson: {
+      id: '580edf9d-1b91-48d9-aedd-6d675af42bc9',
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [98.4198805975802, 17.1023527881308],
+      },
+      properties: {
+        uid: 'a',
+        code: 'null',
+        name: 'b',
+        type: 'Feature',
+        status: 'Pending Review',
+        version: 0,
+        server_version: 1566453219298,
+        jurisdiction_id: '450fc15b-5bd2-468a-927a-49cb10d3bcac',
+        geographic_level: 0,
+        effective_end_data: null,
+        effective_start_date: null,
+      },
+    },
+  },
+  {
+    id: '630a4bae-4122-4a1f-94d1-0d92fe7a74c8',
+    jurisdiction_id: '450fc15b-5bd2-468a-927a-49cb10d3bcac',
+    geojson: {
+      id: '630a4bae-4122-4a1f-94d1-0d92fe7a74c8',
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [98.4164667269838, 17.1049454034914],
+      },
+      properties: {
+        uid: 'a',
+        code: 'null',
+        name: 'b',
+        type: 'Feature',
+        status: 'Pending Review',
+        version: 0,
+        server_version: 1566453617330,
+        jurisdiction_id: '450fc15b-5bd2-468a-927a-49cb10d3bcac',
+        geographic_level: 0,
+        effective_end_date: null,
+        effective_start_date: null,
+      },
+    },
+  },
+  {
+    id: '29392be5-34d5-46cc-b8ae-c53c25362ef5',
+    jurisdiction_id: '450fc15b-5bd2-468a-927a-49cb10d3bcac',
+    geojson: {
+      id: '29392be5-34d5-46cc-b8ae-c53c25362ef5',
+      type: 'Feature',
+      geometry: {
+        type: 'MultiPolygon',
+        coordinates: [
+          [
+            [
+              [98.4197601, 17.1046228],
+              [98.419819, 17.1046009],
+              [98.4197911, 17.1045323],
+              [98.4197322, 17.1045542],
+              [98.4197601, 17.1046228],
+            ],
+          ],
+        ],
+      },
+      properties: {
+        uid: 'a',
+        code: 'null',
+        name: 'b',
+        type: 'Feature',
+        status: 'Active',
+        version: 0,
+        server_version: 1565908631340,
+        jurisdiction_id: '450fc15b-5bd2-468a-927a-49cb10d3bcac',
+        geographic_level: 6,
+        effective_end_data: null,
+        effective_start_date: null,
+      },
+    },
+  },
+  {
+    id: '752acb0c-e340-403a-979c-4ccb095f7eb3',
+    jurisdiction_id: '450fc15b-5bd2-468a-927a-49cb10d3bcac',
+    geojson: {
+      id: '752acb0c-e340-403a-979c-4ccb095f7eb3',
+      type: 'Feature',
+      geometry: {
+        type: 'MultiPolygon',
+        coordinates: [
+          [
+            [
+              [98.4205088, 17.1020634],
+              [98.4205677, 17.1020415],
+              [98.4205398, 17.1019729],
+              [98.4204809, 17.1019948],
+              [98.4205088, 17.1020634],
+            ],
+          ],
+        ],
+      },
+      properties: {
+        uid: 'a',
+        code: 'null',
+        name: 'b',
+        type: 'Feature',
+        status: 'Active',
+        version: 0,
+        server_version: 1565908631308,
+        jurisdiction_id: '450fc15b-5bd2-468a-927a-49cb10d3bcac',
+        geographic_level: 6,
+        effective_end_data: null,
+        effective_start_date: null,
+      },
+    },
+  },
+  {
+    id: '96bf681a-2438-42f7-9d88-f742ecb8734f',
+    jurisdiction_id: '450fc15b-5bd2-468a-927a-49cb10d3bcac',
+    geojson: {
+      id: '96bf681a-2438-42f7-9d88-f742ecb8734f',
+      type: 'Feature',
+      geometry: {
+        type: 'MultiPolygon',
+        coordinates: [
+          [
+            [
+              [98.4200517, 17.1038184],
+              [98.4201106, 17.1037965],
+              [98.4200827, 17.1037279],
+              [98.4200238, 17.1037497],
+              [98.4200517, 17.1038184],
+            ],
+          ],
+        ],
+      },
+      properties: {
+        uid: 'a',
+        code: 'null',
+        name: 'b',
+        type: 'Feature',
+        status: 'Active',
+        version: 0,
+        server_version: 1565908631380,
+        jurisdiction_id: '450fc15b-5bd2-468a-927a-49cb10d3bcac',
+        geographic_level: 6,
+        effective_end_data: null,
+        effective_start_date: null,
+      },
+    },
+  },
+  {
+    id: '1e98bd77-8fd5-44d6-937e-d620fa7b6c33',
+    jurisdiction_id: '450fc15b-5bd2-468a-927a-49cb10d3bcac',
+    geojson: {
+      id: '1e98bd77-8fd5-44d6-937e-d620fa7b6c33',
+      type: 'Feature',
+      geometry: {
+        type: 'MultiPolygon',
+        coordinates: [
+          [
+            [
+              [98.4210954, 17.1028532],
+              [98.4211784, 17.1028411],
+              [98.4211667, 17.1027678],
+              [98.4210836, 17.10278],
+              [98.4210954, 17.1028532],
+            ],
+          ],
+        ],
+      },
+      properties: {
+        uid: 'a',
+        code: 'null',
+        name: 'b',
+        type: 'Feature',
+        status: 'Active',
+        version: 0,
+        server_version: 1565908631279,
+        jurisdiction_id: '450fc15b-5bd2-468a-927a-49cb10d3bcac',
+        geographic_level: 6,
+        effective_end_data: null,
+        effective_start_date: null,
+      },
+    },
+  },
+];
+// tslint:enable object-literal-sort-keys

--- a/src/containers/pages/FocusInvestigation/map/active/tests/index.test.tsx
+++ b/src/containers/pages/FocusInvestigation/map/active/tests/index.test.tsx
@@ -19,7 +19,7 @@ import * as structureDucks from '../../../../../../store/ducks/structures';
 import * as tasksDucks from '../../../../../../store/ducks/tasks';
 import * as fixtures from '../../../../../../store/ducks/tests/fixtures';
 import ConnectedMapSingleFI, { MapSingleFIProps, SingleActiveFIMap } from '../../active/';
-import { existingState } from './fixtures';
+import { existingState, structures } from './fixtures';
 
 jest.mock('../../../../../../components/GisidaWrapper', () => {
   const GisidaWrapperMock = () => <div>I love oov</div>;
@@ -351,5 +351,44 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
     expect(structuresMock).not.toBeCalled();
     expect(currentGoalMock).not.toBeCalled();
     expect(FCMock).not.toBeCalled();
+  });
+
+  it('renders the GisidaWrapper with structures', () => {
+    const mock: any = jest.fn();
+    const supersetServiceMock: any = jest.fn(async () => []);
+    store.dispatch(fetchGoals([fixtures.goal3 as goalDucks.Goal]));
+    store.dispatch(fetchJurisdictions([fixtures.jurisdictions[0]]));
+    store.dispatch(fetchPlans([fixtures.plan1 as Plan]));
+    store.dispatch(fetchTasks(fixtures.tasks));
+    store.dispatch(structureDucks.setStructures(structures as structureDucks.Structure[]));
+
+    const props = {
+      currentGoal: fixtures.goal3,
+      history,
+      location: mock,
+      match: {
+        isExact: true,
+        params: { id: fixtures.plan1.id },
+        path: `${FI_SINGLE_URL}/:id`,
+        url: `${FI_SINGLE_URL}/13`,
+      },
+      pointFeatureCollection: wrapFeatureCollection([fixtures.coloredTasks.task3.geojson]),
+      polygonFeatureCollection: wrapFeatureCollection([fixtures.coloredTasks.task2.geojson]),
+      supersetService: supersetServiceMock,
+    };
+    const wrapper = mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <ConnectedMapSingleFI {...props} />
+        </Router>
+      </Provider>
+    );
+
+    // structures prop
+    const singleActiveWrapperProps = wrapper.find('SingleActiveFIMap').props();
+    expect((singleActiveWrapperProps as MapSingleFIProps).plan).toEqual(fixtures.plan1);
+    expect((singleActiveWrapperProps as MapSingleFIProps).structures).not.toBeNull();
+
+    wrapper.unmount();
   });
 });

--- a/src/helpers/utils.tsx
+++ b/src/helpers/utils.tsx
@@ -52,7 +52,7 @@ export interface RouteParams {
 
 /** Geometry object interface */
 export interface Geometry {
-  coordinates: number[][][] | number[];
+  coordinates: number[][][][] | number[][][] | number[];
   type: string;
 }
 


### PR DESCRIPTION
This PR:
- [x] Adds a default structures circle layer (addressing point C from https://github.com/onaio/reveal-frontend/issues/637#issuecomment-578252808)
- [ ] Adds tests

After Merging:
- [ ] Include in release `v0.3.1`
- [ ] Deploy `v0.3.1` to Thailand Prod without a GA code