### PR TITLE
Do not use GA HOC if GA code is not provided

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -9,8 +9,11 @@ import { Route, Switch } from 'react-router';
 import { toast } from 'react-toastify';
 import { Col, Container, Row } from 'reactstrap';
 import Loading from '../components/page/Loading';
-import WithGATracker, { initGoogleAnalytics } from '../components/page/WithGATracker';
-import { TOAST_AUTO_CLOSE_DELAY, WEBSITE_NAME } from '../configs/env';
+import WithGATracker, {
+  initGoogleAnalytics,
+  TrackingOptions,
+} from '../components/page/WithGATracker';
+import { GA_CODE, GA_ENV, TOAST_AUTO_CLOSE_DELAY, WEBSITE_NAME } from '../configs/env';
 import { DISABLE_LOGIN_PROTECTION, OPENSRP_LOGOUT_URL, OPENSRP_OAUTH_STATE } from '../configs/env';
 import { providers } from '../configs/settings';
 import {
@@ -71,7 +74,11 @@ library.add(faExternalLinkSquareAlt);
 toast.configure({
   autoClose: TOAST_AUTO_CLOSE_DELAY /** defines how long a toast remains visible on screen */,
 });
-initGoogleAnalytics();
+
+const trackingOptions: TrackingOptions = initGoogleAnalytics({
+  GA_CODE,
+  GA_ENV,
+} as TrackingOptions);
 
 import store from '../store';
 import { getOauthProviderState } from '../store/selectors';
@@ -93,7 +100,7 @@ class App extends Component {
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path="/"
-                  component={WithGATracker(Home)}
+                  component={WithGATracker(Home, trackingOptions)}
                 />
                 {/* Active IRS Plans list view */}
                 <ConnectedPrivateRoute
@@ -101,192 +108,192 @@ class App extends Component {
                   exact={true}
                   path={INTERVENTION_IRS_URL}
                   ConnectedOrgTeamView={true}
-                  component={WithGATracker(IrsPlans)}
+                  component={WithGATracker(IrsPlans, trackingOptions)}
                 />
                 {/* Draft IRS Plans list view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={INTERVENTION_IRS_DRAFTS_URL}
-                  component={WithGATracker(IrsPlans)}
+                  component={WithGATracker(IrsPlans, trackingOptions)}
                 />
                 {/* New IRS Plan form view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={NEW_IRS_PLAN_URL}
-                  component={WithGATracker(NewIRSPlan)}
+                  component={WithGATracker(NewIRSPlan, trackingOptions)}
                 />
                 {/* Draft IRS Plan Jurisdiction Selection view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${DRAFT_IRS_PLAN_URL}/:id`}
-                  component={WithGATracker(IrsPlan)}
+                  component={WithGATracker(IrsPlan, trackingOptions)}
                 />
                 {/* Draft IRS Plan Team Assignment view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${ACTIVE_IRS_PLAN_URL}/:id`}
-                  component={WithGATracker(IrsPlan)}
+                  component={WithGATracker(IrsPlan, trackingOptions)}
                 />
                 {/* IRS Reporting plan table view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={REPORT_IRS_PLAN_URL}
-                  component={WithGATracker(ConnectedIRSPlansList)}
+                  component={WithGATracker(ConnectedIRSPlansList, trackingOptions)}
                 />
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${REPORT_IRS_PLAN_URL}/:planId`}
-                  component={WithGATracker(ConnectedJurisdictionReport)}
+                  component={WithGATracker(ConnectedJurisdictionReport, trackingOptions)}
                 />
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${REPORT_IRS_PLAN_URL}/:planId/:jurisdictionId`}
-                  component={WithGATracker(ConnectedJurisdictionReport)}
+                  component={WithGATracker(ConnectedJurisdictionReport, trackingOptions)}
                 />
                 {/* IRS Reporting Map view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${REPORT_IRS_PLAN_URL}/:planId/:jurisdictionId/${MAP}`}
-                  component={WithGATracker(ConnectedIRSReportingMap)}
+                  component={WithGATracker(ConnectedIRSReportingMap, trackingOptions)}
                 />
                 {/* IRS Assignment views */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${ASSIGN_PLAN_URL}`}
-                  component={WithGATracker(ConnectedIRSAssignmentPlansList)}
+                  component={WithGATracker(ConnectedIRSAssignmentPlansList, trackingOptions)}
                 />
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${ASSIGN_PLAN_URL}/:id`}
-                  component={WithGATracker(IrsPlan)}
+                  component={WithGATracker(IrsPlan, trackingOptions)}
                 />
                 {/* Focus Investigation Reporting list view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={FI_URL}
-                  component={WithGATracker(ActiveFocusInvestigation)}
+                  component={WithGATracker(ActiveFocusInvestigation, trackingOptions)}
                 />
                 {/* Focus Area detail view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${FI_FILTER_URL}/:jurisdiction_parent_id/:plan_id?`}
-                  component={WithGATracker(ActiveFocusInvestigation)}
+                  component={WithGATracker(ActiveFocusInvestigation, trackingOptions)}
                 />
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${FI_SINGLE_URL}/:id`}
-                  component={WithGATracker(SingleFI)}
+                  component={WithGATracker(SingleFI, trackingOptions)}
                 />
                 {/* Focus Investigation completion confirmation view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${PLAN_COMPLETION_URL}/:id`}
-                  component={WithGATracker(ConnectedPlanCompletion)}
+                  component={WithGATracker(ConnectedPlanCompletion, trackingOptions)}
                 />
                 {/* Focus Investigation Reporting map view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${FI_SINGLE_MAP_URL}/:id/`}
-                  component={WithGATracker(SingleActiveFIMap)}
+                  component={WithGATracker(SingleActiveFIMap, trackingOptions)}
                 />
                 {/* Focus Investigation Reporting map view (with goal layers) */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${FI_SINGLE_MAP_URL}/:id/:goalId`}
-                  component={WithGATracker(SingleActiveFIMap)}
+                  component={WithGATracker(SingleActiveFIMap, trackingOptions)}
                 />
                 {/* New Focus Investigation Plan form view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={NEW_PLAN_URL}
-                  component={WithGATracker(NewPlan)}
+                  component={WithGATracker(NewPlan, trackingOptions)}
                 />
                 {/* Edit Focus Investigation Plan form view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${PLAN_UPDATE_URL}/:id`}
-                  component={WithGATracker(ConnectedUpdatePlan)}
+                  component={WithGATracker(ConnectedUpdatePlan, trackingOptions)}
                 />
                 {/* Manage Plans list view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={PLAN_LIST_URL}
-                  component={WithGATracker(ConnectedPlanDefinitionList)}
+                  component={WithGATracker(ConnectedPlanDefinitionList, trackingOptions)}
                 />
                 {/** Organization list view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={ORGANIZATIONS_LIST_URL}
-                  component={WithGATracker(ConnectedOrgsListView)}
+                  component={WithGATracker(ConnectedOrgsListView, trackingOptions)}
                 />
                 {/** organization create view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={CREATE_ORGANIZATION_URL}
-                  component={WithGATracker(ConnectedCreateEditOrgView)}
+                  component={WithGATracker(ConnectedCreateEditOrgView, trackingOptions)}
                 />
                 {/** Organization edit view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${EDIT_ORGANIZATION_URL}/:id`}
-                  component={WithGATracker(ConnectedCreateEditOrgView)}
+                  component={WithGATracker(ConnectedCreateEditOrgView, trackingOptions)}
                 />
                 {/* single organization view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${SINGLE_ORGANIZATION_URL}/:id`}
-                  component={WithGATracker(ConnectedSingleOrgView)}
+                  component={WithGATracker(ConnectedSingleOrgView, trackingOptions)}
                 />
                 {/* single organization view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${SINGLE_ORGANIZATION_URL}/:id`}
-                  component={WithGATracker(ConnectedSingleOrgView)}
+                  component={WithGATracker(ConnectedSingleOrgView, trackingOptions)}
                 />
                 {/* Practitioner listing page */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={PRACTITIONERS_LIST_URL}
-                  component={WithGATracker(ConnectedPractitionersListView)}
+                  component={WithGATracker(ConnectedPractitionersListView, trackingOptions)}
                 />
                 {/** practitioner create view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={CREATE_PRACTITIONER_URL}
-                  component={WithGATracker(ConnectedCreateEditPractitionerView)}
+                  component={WithGATracker(ConnectedCreateEditPractitionerView, trackingOptions)}
                 />
                 {/** Practitioner edit view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${EDIT_PRACTITIONER_URL}/:id`}
-                  component={WithGATracker(ConnectedCreateEditPractitionerView)}
+                  component={WithGATracker(ConnectedCreateEditPractitionerView, trackingOptions)}
                 />
                 {/** Assign practitioners to organization view */}
                 />
@@ -294,7 +301,7 @@ class App extends Component {
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${ASSIGN_PRACTITIONERS_URL}/:id`}
-                  component={WithGATracker(ConnectedAssignPractitioner)}
+                  component={WithGATracker(ConnectedAssignPractitioner, trackingOptions)}
                 />
                 {/* tslint:disable jsx-no-lambda */}
                 <Route

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -9,7 +9,7 @@ import { Route, Switch } from 'react-router';
 import { toast } from 'react-toastify';
 import { Col, Container, Row } from 'reactstrap';
 import Loading from '../components/page/Loading';
-import WithGATracker from '../components/page/WithGATracker';
+import WithGATracker, { initGoogleAnalytics } from '../components/page/WithGATracker';
 import { TOAST_AUTO_CLOSE_DELAY, WEBSITE_NAME } from '../configs/env';
 import { DISABLE_LOGIN_PROTECTION, OPENSRP_LOGOUT_URL, OPENSRP_OAUTH_STATE } from '../configs/env';
 import { providers } from '../configs/settings';
@@ -71,6 +71,7 @@ library.add(faExternalLinkSquareAlt);
 toast.configure({
   autoClose: TOAST_AUTO_CLOSE_DELAY /** defines how long a toast remains visible on screen */,
 });
+initGoogleAnalytics();
 
 import store from '../store';
 import { getOauthProviderState } from '../store/selectors';

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -9,11 +9,8 @@ import { Route, Switch } from 'react-router';
 import { toast } from 'react-toastify';
 import { Col, Container, Row } from 'reactstrap';
 import Loading from '../components/page/Loading';
-import WithGATracker, {
-  initGoogleAnalytics,
-  TrackingOptions,
-} from '../components/page/WithGATracker';
-import { GA_CODE, GA_ENV, TOAST_AUTO_CLOSE_DELAY, WEBSITE_NAME } from '../configs/env';
+import WithGATracker, { initGoogleAnalytics } from '../components/page/WithGATracker';
+import { TOAST_AUTO_CLOSE_DELAY, WEBSITE_NAME } from '../configs/env';
 import { DISABLE_LOGIN_PROTECTION, OPENSRP_LOGOUT_URL, OPENSRP_OAUTH_STATE } from '../configs/env';
 import { providers } from '../configs/settings';
 import {
@@ -74,11 +71,7 @@ library.add(faExternalLinkSquareAlt);
 toast.configure({
   autoClose: TOAST_AUTO_CLOSE_DELAY /** defines how long a toast remains visible on screen */,
 });
-
-const trackingOptions: TrackingOptions = initGoogleAnalytics({
-  GA_CODE,
-  GA_ENV,
-} as TrackingOptions);
+initGoogleAnalytics();
 
 import store from '../store';
 import { getOauthProviderState } from '../store/selectors';
@@ -100,7 +93,7 @@ class App extends Component {
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path="/"
-                  component={WithGATracker(Home, trackingOptions)}
+                  component={WithGATracker(Home)}
                 />
                 {/* Active IRS Plans list view */}
                 <ConnectedPrivateRoute
@@ -108,192 +101,192 @@ class App extends Component {
                   exact={true}
                   path={INTERVENTION_IRS_URL}
                   ConnectedOrgTeamView={true}
-                  component={WithGATracker(IrsPlans, trackingOptions)}
+                  component={WithGATracker(IrsPlans)}
                 />
                 {/* Draft IRS Plans list view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={INTERVENTION_IRS_DRAFTS_URL}
-                  component={WithGATracker(IrsPlans, trackingOptions)}
+                  component={WithGATracker(IrsPlans)}
                 />
                 {/* New IRS Plan form view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={NEW_IRS_PLAN_URL}
-                  component={WithGATracker(NewIRSPlan, trackingOptions)}
+                  component={WithGATracker(NewIRSPlan)}
                 />
                 {/* Draft IRS Plan Jurisdiction Selection view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${DRAFT_IRS_PLAN_URL}/:id`}
-                  component={WithGATracker(IrsPlan, trackingOptions)}
+                  component={WithGATracker(IrsPlan)}
                 />
                 {/* Draft IRS Plan Team Assignment view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${ACTIVE_IRS_PLAN_URL}/:id`}
-                  component={WithGATracker(IrsPlan, trackingOptions)}
+                  component={WithGATracker(IrsPlan)}
                 />
                 {/* IRS Reporting plan table view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={REPORT_IRS_PLAN_URL}
-                  component={WithGATracker(ConnectedIRSPlansList, trackingOptions)}
+                  component={WithGATracker(ConnectedIRSPlansList)}
                 />
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${REPORT_IRS_PLAN_URL}/:planId`}
-                  component={WithGATracker(ConnectedJurisdictionReport, trackingOptions)}
+                  component={WithGATracker(ConnectedJurisdictionReport)}
                 />
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${REPORT_IRS_PLAN_URL}/:planId/:jurisdictionId`}
-                  component={WithGATracker(ConnectedJurisdictionReport, trackingOptions)}
+                  component={WithGATracker(ConnectedJurisdictionReport)}
                 />
                 {/* IRS Reporting Map view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${REPORT_IRS_PLAN_URL}/:planId/:jurisdictionId/${MAP}`}
-                  component={WithGATracker(ConnectedIRSReportingMap, trackingOptions)}
+                  component={WithGATracker(ConnectedIRSReportingMap)}
                 />
                 {/* IRS Assignment views */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${ASSIGN_PLAN_URL}`}
-                  component={WithGATracker(ConnectedIRSAssignmentPlansList, trackingOptions)}
+                  component={WithGATracker(ConnectedIRSAssignmentPlansList)}
                 />
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${ASSIGN_PLAN_URL}/:id`}
-                  component={WithGATracker(IrsPlan, trackingOptions)}
+                  component={WithGATracker(IrsPlan)}
                 />
                 {/* Focus Investigation Reporting list view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={FI_URL}
-                  component={WithGATracker(ActiveFocusInvestigation, trackingOptions)}
+                  component={WithGATracker(ActiveFocusInvestigation)}
                 />
                 {/* Focus Area detail view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${FI_FILTER_URL}/:jurisdiction_parent_id/:plan_id?`}
-                  component={WithGATracker(ActiveFocusInvestigation, trackingOptions)}
+                  component={WithGATracker(ActiveFocusInvestigation)}
                 />
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${FI_SINGLE_URL}/:id`}
-                  component={WithGATracker(SingleFI, trackingOptions)}
+                  component={WithGATracker(SingleFI)}
                 />
                 {/* Focus Investigation completion confirmation view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${PLAN_COMPLETION_URL}/:id`}
-                  component={WithGATracker(ConnectedPlanCompletion, trackingOptions)}
+                  component={WithGATracker(ConnectedPlanCompletion)}
                 />
                 {/* Focus Investigation Reporting map view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${FI_SINGLE_MAP_URL}/:id/`}
-                  component={WithGATracker(SingleActiveFIMap, trackingOptions)}
+                  component={WithGATracker(SingleActiveFIMap)}
                 />
                 {/* Focus Investigation Reporting map view (with goal layers) */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${FI_SINGLE_MAP_URL}/:id/:goalId`}
-                  component={WithGATracker(SingleActiveFIMap, trackingOptions)}
+                  component={WithGATracker(SingleActiveFIMap)}
                 />
                 {/* New Focus Investigation Plan form view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={NEW_PLAN_URL}
-                  component={WithGATracker(NewPlan, trackingOptions)}
+                  component={WithGATracker(NewPlan)}
                 />
                 {/* Edit Focus Investigation Plan form view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${PLAN_UPDATE_URL}/:id`}
-                  component={WithGATracker(ConnectedUpdatePlan, trackingOptions)}
+                  component={WithGATracker(ConnectedUpdatePlan)}
                 />
                 {/* Manage Plans list view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={PLAN_LIST_URL}
-                  component={WithGATracker(ConnectedPlanDefinitionList, trackingOptions)}
+                  component={WithGATracker(ConnectedPlanDefinitionList)}
                 />
                 {/** Organization list view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={ORGANIZATIONS_LIST_URL}
-                  component={WithGATracker(ConnectedOrgsListView, trackingOptions)}
+                  component={WithGATracker(ConnectedOrgsListView)}
                 />
                 {/** organization create view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={CREATE_ORGANIZATION_URL}
-                  component={WithGATracker(ConnectedCreateEditOrgView, trackingOptions)}
+                  component={WithGATracker(ConnectedCreateEditOrgView)}
                 />
                 {/** Organization edit view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${EDIT_ORGANIZATION_URL}/:id`}
-                  component={WithGATracker(ConnectedCreateEditOrgView, trackingOptions)}
+                  component={WithGATracker(ConnectedCreateEditOrgView)}
                 />
                 {/* single organization view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${SINGLE_ORGANIZATION_URL}/:id`}
-                  component={WithGATracker(ConnectedSingleOrgView, trackingOptions)}
+                  component={WithGATracker(ConnectedSingleOrgView)}
                 />
                 {/* single organization view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${SINGLE_ORGANIZATION_URL}/:id`}
-                  component={WithGATracker(ConnectedSingleOrgView, trackingOptions)}
+                  component={WithGATracker(ConnectedSingleOrgView)}
                 />
                 {/* Practitioner listing page */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={PRACTITIONERS_LIST_URL}
-                  component={WithGATracker(ConnectedPractitionersListView, trackingOptions)}
+                  component={WithGATracker(ConnectedPractitionersListView)}
                 />
                 {/** practitioner create view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={CREATE_PRACTITIONER_URL}
-                  component={WithGATracker(ConnectedCreateEditPractitionerView, trackingOptions)}
+                  component={WithGATracker(ConnectedCreateEditPractitionerView)}
                 />
                 {/** Practitioner edit view */}
                 <ConnectedPrivateRoute
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${EDIT_PRACTITIONER_URL}/:id`}
-                  component={WithGATracker(ConnectedCreateEditPractitionerView, trackingOptions)}
+                  component={WithGATracker(ConnectedCreateEditPractitionerView)}
                 />
                 {/** Assign practitioners to organization view */}
                 />
@@ -301,7 +294,7 @@ class App extends Component {
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${ASSIGN_PRACTITIONERS_URL}/:id`}
-                  component={WithGATracker(ConnectedAssignPractitioner, trackingOptions)}
+                  component={WithGATracker(ConnectedAssignPractitioner)}
                 />
                 {/* tslint:disable jsx-no-lambda */}
                 <Route

--- a/src/App/tests/__snapshots__/App.test.tsx.snap
+++ b/src/App/tests/__snapshots__/App.test.tsx.snap
@@ -915,7 +915,7 @@ exports[`App renders App correctly 1`] = `
                               path="/"
                               render={[Function]}
                             >
-                              <HOC
+                              <WithGATrackerHOC
                                 computedMatch={
                                   Object {
                                     "isExact": true,
@@ -1206,7 +1206,7 @@ exports[`App renders App correctly 1`] = `
                                     </Row>
                                   </div>
                                 </Home>
-                              </HOC>
+                              </WithGATrackerHOC>
                             </Route>
                           </PrivateRoute>
                         </Connect(PrivateRoute)>

--- a/src/components/page/WithGATracker/index.tsx
+++ b/src/components/page/WithGATracker/index.tsx
@@ -12,9 +12,16 @@ let username = (getUser(store.getState()) || {}).username || '';
 
 /**
  * helper function to get the Google Analytics tracking code
- * @param options tracking options for the page view
+ * @param {FlexObject|undefined} options tracking options for the page view
+ * @returns {string}
  */
-export const getGaCode = (options: FlexObject = {}) => (options && options.GA_CODE) || GA_CODE;
+export const getGaCode = (options: FlexObject | undefined) => {
+  const gaCode =
+    (options && !!!options.GA_CODE && options.GA_CODE) ||
+    ((!options || !!options.GA_CODE) && GA_CODE) ||
+    '';
+  return gaCode;
+};
 
 /**
  * helper function to set the Google Analytics dimension for username

--- a/src/components/page/WithGATracker/index.tsx
+++ b/src/components/page/WithGATracker/index.tsx
@@ -43,12 +43,15 @@ export const getGAusername = (): string => username;
  * @param {string} page the url string of the page view being tracked
  * @param {FlexObject} options tracking options for the page view
  */
-export const trackPage = (page: string, options: FlexObject = {}): void => {
-  GoogleAnalytics.set({
-    page,
-    ...options,
-  });
-  GoogleAnalytics.pageview(page);
+export const trackPage = (page: string, options?: FlexObject): void => {
+  const gaCode = getGaCode(options);
+  if (gaCode && gaCode.length) {
+    GoogleAnalytics.set({
+      page,
+      ...options,
+    });
+    GoogleAnalytics.pageview(page);
+  }
 };
 
 /**

--- a/src/components/page/WithGATracker/index.tsx
+++ b/src/components/page/WithGATracker/index.tsx
@@ -73,7 +73,7 @@ const WithGATracker = (WrappedComponent: any, options: FlexObject = {}) => {
     return WrappedComponent;
   }
 
-  const HOC = class extends Component<Props> {
+  const WithGATrackerHOC = class extends Component<Props> {
     public componentDidMount() {
       // update the username dimension
       const user = (getUser(store.getState()) || {}) as FlexObject;
@@ -106,7 +106,7 @@ const WithGATracker = (WrappedComponent: any, options: FlexObject = {}) => {
     }
   };
 
-  return HOC;
+  return WithGATrackerHOC;
 };
 
 export default WithGATracker;

--- a/src/components/page/WithGATracker/index.tsx
+++ b/src/components/page/WithGATracker/index.tsx
@@ -3,6 +3,7 @@ import { getUser } from '@onaio/session-reducer';
 import React, { Component } from 'react';
 import GoogleAnalytics from 'react-ga';
 import { RouteComponentProps } from 'react-router';
+import * as env from '../../../configs/env';
 import { TEST } from '../../../constants';
 import { FlexObject, RouteParams } from '../../../helpers/utils';
 import store from '../../../store';
@@ -17,6 +18,11 @@ export interface TrackingOptions {
   GA_CODE: string;
   GA_ENV?: string;
 }
+
+const defaultTrackingOptions: TrackingOptions = {
+  GA_CODE: env.GA_CODE || '',
+  GA_ENV: env.GA_ENV || TEST,
+};
 
 /**
  * helper function to set the Google Analytics dimension for username
@@ -38,7 +44,10 @@ export const getGAusername = (): string => username;
  * @param {string} page the url string of the page view being tracked
  * @param {FlexObject} options tracking options for the page view
  */
-export const trackPage = (page: string, options: TrackingOptions): void => {
+export const trackPage = (
+  page: string,
+  options: TrackingOptions = defaultTrackingOptions
+): void => {
   const { GA_CODE } = options;
   if (GA_CODE && GA_CODE.length) {
     GoogleAnalytics.set({
@@ -54,7 +63,9 @@ export const trackPage = (page: string, options: TrackingOptions): void => {
  * @param {TrackingOptions} options tracking options for the page view
  * @returns {TrackingOptions}
  */
-export const initGoogleAnalytics = (options: TrackingOptions): TrackingOptions => {
+export const initGoogleAnalytics = (
+  options: TrackingOptions = defaultTrackingOptions
+): TrackingOptions => {
   const { GA_CODE, GA_ENV } = options;
   if (GA_CODE && GA_CODE.length) {
     GoogleAnalytics.initialize(GA_CODE, {
@@ -65,7 +76,7 @@ export const initGoogleAnalytics = (options: TrackingOptions): TrackingOptions =
       username,
     });
   }
-  return options;
+  return { ...options };
 };
 
 /**
@@ -74,7 +85,10 @@ export const initGoogleAnalytics = (options: TrackingOptions): TrackingOptions =
  * @param {TrackingOptions} options tracking options for the page view
  * @returns HOC rendering the WrappedComponent
  */
-const WithGATracker = (WrappedComponent: any, options: TrackingOptions) => {
+const WithGATracker = (
+  WrappedComponent: any,
+  options: TrackingOptions = defaultTrackingOptions
+) => {
   const { GA_CODE } = options;
   if (!GA_CODE || !GA_CODE.length) {
     return WrappedComponent;

--- a/src/components/page/WithGATracker/index.tsx
+++ b/src/components/page/WithGATracker/index.tsx
@@ -11,6 +11,12 @@ type Props = RouteComponentProps<RouteParams>;
 let username = (getUser(store.getState()) || {}).username || '';
 
 /**
+ * helper function to get the Google Analytics tracking code
+ * @param options tracking options for the page view
+ */
+export const getGaCode = (options: FlexObject = {}) => (options && options.GA_CODE) || GA_CODE;
+
+/**
  * helper function to set the Google Analytics dimension for username
  * @param {FlexObject} user user object returned from session store
  */

--- a/src/components/page/WithGATracker/index.tsx
+++ b/src/components/page/WithGATracker/index.tsx
@@ -77,7 +77,7 @@ export const initGoogleAnalytics = (options?: FlexObject) => {
  * @param {FlexObject} options tracking options for the page view
  * @returns HOC rendering the WrappedComponent
  */
-const WithGATracker = (WrappedComponent: any, options: FlexObject = {}) => {
+const WithGATracker = (WrappedComponent: any, options?: FlexObject) => {
   const gaCode = getGaCode(options);
   if (!gaCode || !gaCode.length) {
     return WrappedComponent;
@@ -106,7 +106,7 @@ const WithGATracker = (WrappedComponent: any, options: FlexObject = {}) => {
 
         // track the page view here only if component didn't un/remount and the URL has updated
         if (currentPage !== nextPage) {
-          trackPage(nextPage);
+          trackPage(nextPage, options);
         }
       }
     }

--- a/src/components/page/WithGATracker/index.tsx
+++ b/src/components/page/WithGATracker/index.tsx
@@ -44,15 +44,22 @@ export const trackPage = (page: string, options: FlexObject = {}): void => {
   GoogleAnalytics.pageview(page);
 };
 
-if (GA_CODE.length) {
-  GoogleAnalytics.initialize(GA_CODE, {
-    testMode: GA_ENV === 'test',
-  });
-  GoogleAnalytics.set({
-    env: GA_ENV,
-    username,
-  });
-}
+/**
+ * helper function to initialize GoogleAnalytics
+ * @param {FlexObject} options tracking options for the page view
+ */
+export const initGoogleAnalytics = (options: FlexObject = {}) => {
+  const gaCode = getGaCode(options);
+  if (gaCode && gaCode.length) {
+    GoogleAnalytics.initialize(GA_CODE, {
+      testMode: GA_ENV === 'test',
+    });
+    GoogleAnalytics.set({
+      env: GA_ENV,
+      username,
+    });
+  }
+};
 
 /**
  * Higher Order Component (HOC) which handles Google Analytics page view tracking

--- a/src/components/page/WithGATracker/index.tsx
+++ b/src/components/page/WithGATracker/index.tsx
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import GoogleAnalytics from 'react-ga';
 import { RouteComponentProps } from 'react-router';
 import * as env from '../../../configs/env';
-import { TEST } from '../../../constants';
+import { GA_ENV_TEST } from '../../../constants';
 import { FlexObject, RouteParams } from '../../../helpers/utils';
 import store from '../../../store';
 
@@ -21,7 +21,7 @@ export interface TrackingOptions {
 
 const defaultTrackingOptions: TrackingOptions = {
   GA_CODE: env.GA_CODE || '',
-  GA_ENV: env.GA_ENV || TEST,
+  GA_ENV: env.GA_ENV || GA_ENV_TEST,
 };
 
 /**
@@ -69,10 +69,10 @@ export const initGoogleAnalytics = (
   const { GA_CODE, GA_ENV } = options;
   if (GA_CODE && GA_CODE.length) {
     GoogleAnalytics.initialize(GA_CODE, {
-      testMode: GA_ENV === TEST,
+      testMode: GA_ENV === GA_ENV_TEST,
     });
     GoogleAnalytics.set({
-      env: GA_ENV || TEST,
+      env: GA_ENV || GA_ENV_TEST,
       username,
     });
   }

--- a/src/components/page/WithGATracker/index.tsx
+++ b/src/components/page/WithGATracker/index.tsx
@@ -61,7 +61,8 @@ if (GA_CODE.length) {
  * @returns HOC rendering the WrappedComponent
  */
 const WithGATracker = (WrappedComponent: any, options: FlexObject = {}) => {
-  if (!GA_CODE.length) {
+  const gaCode = getGaCode(options);
+  if (!gaCode || !gaCode.length) {
     return WrappedComponent;
   }
 

--- a/src/components/page/WithGATracker/index.tsx
+++ b/src/components/page/WithGATracker/index.tsx
@@ -55,7 +55,7 @@ export const trackPage = (page: string, options: FlexObject = {}): void => {
  * helper function to initialize GoogleAnalytics
  * @param {FlexObject} options tracking options for the page view
  */
-export const initGoogleAnalytics = (options: FlexObject = {}) => {
+export const initGoogleAnalytics = (options?: FlexObject) => {
   const gaCode = getGaCode(options);
   if (gaCode && gaCode.length) {
     GoogleAnalytics.initialize(GA_CODE, {

--- a/src/components/page/WithGATracker/index.tsx
+++ b/src/components/page/WithGATracker/index.tsx
@@ -20,7 +20,10 @@ export interface TrackingOptions {
   GA_ENV?: string;
 }
 
-const defaultTrackingOptions: TrackingOptions = {
+/**
+ * Default tracking options using global envs
+ */
+export const defaultTrackingOptions: TrackingOptions = {
   GA_CODE: env.GA_CODE || '',
   GA_ENV: env.GA_ENV || GA_ENV_TEST,
 };

--- a/src/components/page/WithGATracker/index.tsx
+++ b/src/components/page/WithGATracker/index.tsx
@@ -3,7 +3,7 @@ import { getUser } from '@onaio/session-reducer';
 import React, { Component } from 'react';
 import GoogleAnalytics from 'react-ga';
 import { RouteComponentProps } from 'react-router';
-import { GA_CODE, GA_ENV } from '../../../configs/env';
+import { TEST } from '../../../constants';
 import { FlexObject, RouteParams } from '../../../helpers/utils';
 import store from '../../../store';
 
@@ -11,17 +11,12 @@ type Props = RouteComponentProps<RouteParams>;
 let username = (getUser(store.getState()) || {}).username || '';
 
 /**
- * helper function to get the Google Analytics tracking code
- * @param {FlexObject|undefined} options tracking options for the page view
- * @returns {string}
+ * Interface defining the options param passed into tracking methods
  */
-export const getGaCode = (options: FlexObject | undefined) => {
-  const gaCode =
-    (options && !!!options.GA_CODE && options.GA_CODE) ||
-    ((!options || !!options.GA_CODE) && GA_CODE) ||
-    '';
-  return gaCode;
-};
+export interface TrackingOptions {
+  GA_CODE: string;
+  GA_ENV?: string;
+}
 
 /**
  * helper function to set the Google Analytics dimension for username
@@ -43,9 +38,9 @@ export const getGAusername = (): string => username;
  * @param {string} page the url string of the page view being tracked
  * @param {FlexObject} options tracking options for the page view
  */
-export const trackPage = (page: string, options?: FlexObject): void => {
-  const gaCode = getGaCode(options);
-  if (gaCode && gaCode.length) {
+export const trackPage = (page: string, options: TrackingOptions): void => {
+  const { GA_CODE } = options;
+  if (GA_CODE && GA_CODE.length) {
     GoogleAnalytics.set({
       page,
       ...options,
@@ -56,30 +51,32 @@ export const trackPage = (page: string, options?: FlexObject): void => {
 
 /**
  * helper function to initialize GoogleAnalytics
- * @param {FlexObject} options tracking options for the page view
+ * @param {TrackingOptions} options tracking options for the page view
+ * @returns {TrackingOptions}
  */
-export const initGoogleAnalytics = (options?: FlexObject) => {
-  const gaCode = getGaCode(options);
-  if (gaCode && gaCode.length) {
+export const initGoogleAnalytics = (options: TrackingOptions): TrackingOptions => {
+  const { GA_CODE, GA_ENV } = options;
+  if (GA_CODE && GA_CODE.length) {
     GoogleAnalytics.initialize(GA_CODE, {
-      testMode: GA_ENV === 'test',
+      testMode: GA_ENV === TEST,
     });
     GoogleAnalytics.set({
-      env: GA_ENV,
+      env: GA_ENV || TEST,
       username,
     });
   }
+  return options;
 };
 
 /**
  * Higher Order Component (HOC) which handles Google Analytics page view tracking
  * @param {any} WrappedComponent the component to be wrapped by the HOC component
- * @param {FlexObject} options tracking options for the page view
+ * @param {TrackingOptions} options tracking options for the page view
  * @returns HOC rendering the WrappedComponent
  */
-const WithGATracker = (WrappedComponent: any, options?: FlexObject) => {
-  const gaCode = getGaCode(options);
-  if (!gaCode || !gaCode.length) {
+const WithGATracker = (WrappedComponent: any, options: TrackingOptions) => {
+  const { GA_CODE } = options;
+  if (!GA_CODE || !GA_CODE.length) {
     return WrappedComponent;
   }
 

--- a/src/components/page/WithGATracker/index.tsx
+++ b/src/components/page/WithGATracker/index.tsx
@@ -55,6 +55,10 @@ if (GA_CODE.length) {
  * @returns HOC rendering the WrappedComponent
  */
 const WithGATracker = (WrappedComponent: any, options: FlexObject = {}) => {
+  if (!GA_CODE.length) {
+    return WrappedComponent;
+  }
+
   const HOC = class extends Component<Props> {
     public componentDidMount() {
       // update the username dimension

--- a/src/components/page/WithGATracker/index.tsx
+++ b/src/components/page/WithGATracker/index.tsx
@@ -4,6 +4,7 @@ import React, { Component } from 'react';
 import GoogleAnalytics from 'react-ga';
 import { RouteComponentProps } from 'react-router';
 import * as env from '../../../configs/env';
+import { ConnectedFlexComponent, FlexComponent } from '../../../configs/types';
 import { GA_ENV_TEST } from '../../../constants';
 import { RouteParams } from '../../../helpers/utils';
 import store from '../../../store';
@@ -81,12 +82,12 @@ export const initGoogleAnalytics = (
 
 /**
  * Higher Order Component (HOC) which handles Google Analytics page view tracking
- * @param {any} WrappedComponent the component to be wrapped by the HOC component
+ * @param {FlexComponent | ConnectedFlexComponent} WrappedComponent the component to be wrapped by the HOC component
  * @param {TrackingOptions} options tracking options for the page view
  * @returns HOC rendering the WrappedComponent
  */
 const WithGATracker = (
-  WrappedComponent: any,
+  WrappedComponent: FlexComponent | ConnectedFlexComponent,
   options: TrackingOptions = defaultTrackingOptions
 ) => {
   const { GA_CODE } = options;

--- a/src/components/page/WithGATracker/index.tsx
+++ b/src/components/page/WithGATracker/index.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable react/prop-types */
-import { getUser } from '@onaio/session-reducer';
+import { getUser, User } from '@onaio/session-reducer';
 import React, { Component } from 'react';
 import GoogleAnalytics from 'react-ga';
 import { RouteComponentProps } from 'react-router';
 import * as env from '../../../configs/env';
 import { GA_ENV_TEST } from '../../../constants';
-import { FlexObject, RouteParams } from '../../../helpers/utils';
+import { RouteParams } from '../../../helpers/utils';
 import store from '../../../store';
 
 type Props = RouteComponentProps<RouteParams>;
@@ -26,9 +26,9 @@ const defaultTrackingOptions: TrackingOptions = {
 
 /**
  * helper function to set the Google Analytics dimension for username
- * @param {FlexObject} user user object returned from session store
+ * @param {User} user user object returned from session store
  */
-export const setGAusername = (user: FlexObject): void => {
+export const setGAusername = (user: User): void => {
   username = user.username || '';
   GoogleAnalytics.set({ username });
 };
@@ -97,7 +97,7 @@ const WithGATracker = (
   const WithGATrackerHOC = class extends Component<Props> {
     public componentDidMount() {
       // update the username dimension
-      const user = (getUser(store.getState()) || {}) as FlexObject;
+      const user: User = (getUser(store.getState()) || {}) as User;
       if (user.username && getGAusername() !== user.username) {
         setGAusername(user);
       }

--- a/src/components/page/WithGATracker/tests/index.test.tsx
+++ b/src/components/page/WithGATracker/tests/index.test.tsx
@@ -15,7 +15,6 @@ import {
 } from '..';
 import App from '../../../../App/App';
 import { NEW_IRS_PLAN_URL, PLAN_LIST_URL } from '../../../../constants';
-import { FlexObject } from '../../../../helpers/utils';
 import store from '../../../../store';
 
 jest.mock('../../../../configs/env');

--- a/src/components/page/WithGATracker/tests/index.test.tsx
+++ b/src/components/page/WithGATracker/tests/index.test.tsx
@@ -71,7 +71,7 @@ describe('components/WithGATracker', () => {
 
   it('tracks pageviews when navigating to different pages', () => {
     GoogleAnalytics.pageview = jest.fn();
-    mount(
+    const wrapper = mount(
       <Provider store={store}>
         <ConnectedRouter history={history}>
           <App />
@@ -81,5 +81,6 @@ describe('components/WithGATracker', () => {
     expect(GoogleAnalytics.pageview).toBeCalledWith('/');
     history.push(PLAN_LIST_URL);
     expect(GoogleAnalytics.pageview).toBeCalledWith(PLAN_LIST_URL);
+    wrapper.unmount();
   });
 });

--- a/src/components/page/WithGATracker/tests/index.test.tsx
+++ b/src/components/page/WithGATracker/tests/index.test.tsx
@@ -57,6 +57,7 @@ describe('components/WithGATracker', () => {
       </Provider>
     );
     expect(wrapper.find('App').length).toEqual(1);
+    expect(wrapper.find('WithGATrackerHOC').length).toEqual(1);
     wrapper.unmount();
   });
 

--- a/src/components/page/WithGATracker/tests/index.test.tsx
+++ b/src/components/page/WithGATracker/tests/index.test.tsx
@@ -87,7 +87,7 @@ describe('components/WithGATracker', () => {
 
   it('tracks nothing when no GA Code is provided', () => {
     GoogleAnalytics.pageview = jest.fn();
-    const gaOptions: TrackingOptions = initGoogleAnalytics({ GA_CODE: '' }) as TrackingOptions;
+    const gaOptions: TrackingOptions = initGoogleAnalytics({ GA_CODE: '' } as TrackingOptions);
     trackPage('/', gaOptions);
     trackPage(NEW_IRS_PLAN_URL, gaOptions);
     expect(GoogleAnalytics.pageview).not.toBeCalled();

--- a/src/components/page/WithGATracker/tests/index.test.tsx
+++ b/src/components/page/WithGATracker/tests/index.test.tsx
@@ -5,7 +5,14 @@ import { createBrowserHistory } from 'history';
 import React from 'react';
 import GoogleAnalytics from 'react-ga';
 import { Provider } from 'react-redux';
-import { getGAusername, initGoogleAnalytics, setGAusername, TrackingOptions, trackPage } from '..';
+import {
+  defaultTrackingOptions,
+  getGAusername,
+  initGoogleAnalytics,
+  setGAusername,
+  TrackingOptions,
+  trackPage,
+} from '..';
 import App from '../../../../App/App';
 import { NEW_IRS_PLAN_URL, PLAN_LIST_URL } from '../../../../constants';
 import { FlexObject } from '../../../../helpers/utils';
@@ -63,7 +70,7 @@ describe('components/WithGATracker', () => {
 
   it('GoogleAnalytics.pageview is called with the correct arguments', () => {
     GoogleAnalytics.pageview = jest.fn();
-    const trackingOptions: TrackingOptions = { GA_CODE: '12345', GA_ENV: 'test' };
+    const trackingOptions: TrackingOptions = { ...defaultTrackingOptions };
     trackPage('/', trackingOptions);
     expect(GoogleAnalytics.pageview).toBeCalledWith('/');
     trackPage(PLAN_LIST_URL, trackingOptions);

--- a/src/components/page/WithGATracker/tests/index.test.tsx
+++ b/src/components/page/WithGATracker/tests/index.test.tsx
@@ -50,8 +50,8 @@ describe('components/WithGATracker', () => {
 
   it('gets and sets the username dimension', () => {
     expect(getGAusername()).toBe('');
-    setGAusername({ username: 'Conor' });
-    expect(getGAusername()).toBe('Conor');
+    setGAusername({ username: 'suppaD3v4life', name: 'Conor' });
+    expect(getGAusername()).toBe('suppaD3v4life');
   });
 
   it('renders components correctly when wrapped with HOC', () => {

--- a/src/components/page/WithGATracker/tests/index.test.tsx
+++ b/src/components/page/WithGATracker/tests/index.test.tsx
@@ -1,14 +1,14 @@
 import { authenticateUser } from '@onaio/session-reducer';
 import { ConnectedRouter } from 'connected-react-router';
 import { mount } from 'enzyme';
-import toJson from 'enzyme-to-json';
 import { createBrowserHistory } from 'history';
 import React from 'react';
 import GoogleAnalytics from 'react-ga';
 import { Provider } from 'react-redux';
-import { getGAusername, setGAusername, trackPage } from '..';
+import { getGAusername, initGoogleAnalytics, setGAusername, trackPage } from '..';
 import App from '../../../../App/App';
-import { PLAN_LIST_URL } from '../../../../constants';
+import { NEW_IRS_PLAN_URL, PLAN_LIST_URL } from '../../../../constants';
+import { FlexObject } from '../../../../helpers/utils';
 import store from '../../../../store';
 
 jest.mock('../../../../configs/env');
@@ -82,5 +82,14 @@ describe('components/WithGATracker', () => {
     history.push(PLAN_LIST_URL);
     expect(GoogleAnalytics.pageview).toBeCalledWith(PLAN_LIST_URL);
     wrapper.unmount();
+  });
+
+  it('tracks nothing when no GA Code is provided', () => {
+    GoogleAnalytics.pageview = jest.fn();
+    const gaOptions: FlexObject = { GA_CODE: '' };
+    initGoogleAnalytics(gaOptions);
+    trackPage('/', gaOptions);
+    trackPage(NEW_IRS_PLAN_URL, gaOptions);
+    expect(GoogleAnalytics.pageview).not.toBeCalled();
   });
 });

--- a/src/components/page/WithGATracker/tests/index.test.tsx
+++ b/src/components/page/WithGATracker/tests/index.test.tsx
@@ -5,7 +5,7 @@ import { createBrowserHistory } from 'history';
 import React from 'react';
 import GoogleAnalytics from 'react-ga';
 import { Provider } from 'react-redux';
-import { getGAusername, initGoogleAnalytics, setGAusername, trackPage } from '..';
+import { getGAusername, initGoogleAnalytics, setGAusername, TrackingOptions, trackPage } from '..';
 import App from '../../../../App/App';
 import { NEW_IRS_PLAN_URL, PLAN_LIST_URL } from '../../../../constants';
 import { FlexObject } from '../../../../helpers/utils';
@@ -63,9 +63,10 @@ describe('components/WithGATracker', () => {
 
   it('GoogleAnalytics.pageview is called with the correct arguments', () => {
     GoogleAnalytics.pageview = jest.fn();
-    trackPage('/');
+    const trackingOptions: TrackingOptions = { GA_CODE: '12345', GA_ENV: 'test' };
+    trackPage('/', trackingOptions);
     expect(GoogleAnalytics.pageview).toBeCalledWith('/');
-    trackPage(PLAN_LIST_URL);
+    trackPage(PLAN_LIST_URL, trackingOptions);
     expect(GoogleAnalytics.pageview).toBeCalledWith(PLAN_LIST_URL);
   });
 
@@ -86,8 +87,7 @@ describe('components/WithGATracker', () => {
 
   it('tracks nothing when no GA Code is provided', () => {
     GoogleAnalytics.pageview = jest.fn();
-    const gaOptions: FlexObject = { GA_CODE: '' };
-    initGoogleAnalytics(gaOptions);
+    const gaOptions: TrackingOptions = initGoogleAnalytics({ GA_CODE: '' }) as TrackingOptions;
     trackPage('/', gaOptions);
     trackPage(NEW_IRS_PLAN_URL, gaOptions);
     expect(GoogleAnalytics.pageview).not.toBeCalled();

--- a/src/configs/types.ts
+++ b/src/configs/types.ts
@@ -1,3 +1,5 @@
+import { ComponentType } from 'react';
+import { ConnectedComponentClass } from 'react-redux';
 import {
   adminLayerColors,
   GREEN_THRESHOLD,
@@ -30,3 +32,6 @@ export type ADMN0_PCODE =
   | 'Lop Buri'
   | 'Oddar Meanchey Province'
   | 'Lusaka';
+
+export type FlexComponent<T> = ComponentType | ComponentType<T>;
+export type ConnectedFlexComponent = ConnectedComponentClass<FlexComponent<any>, any>;

--- a/src/configs/types.ts
+++ b/src/configs/types.ts
@@ -33,5 +33,5 @@ export type ADMN0_PCODE =
   | 'Oddar Meanchey Province'
   | 'Lusaka';
 
-export type FlexComponent<T> = ComponentType | ComponentType<T>;
+export type FlexComponent<T = {}> = ComponentType<T>;
 export type ConnectedFlexComponent = ConnectedComponentClass<FlexComponent<any>, any>;

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -41,7 +41,7 @@ export const BLOOD_SCREENING_ACTIVITY_CODE = 'bloodScreening';
 export const BEDNET_DISTRIBUTION_ACTIVITY_CODE = 'bednetDistribution';
 export const LARVAL_DIPPING_ACTIVITY_CODE = 'larvalDipping';
 export const MOSQUITO_COLLECTION_ACTIVITY_CODE = 'mosquitoCollection';
-export const TEST = 'test';
+export const GA_ENV_TEST = 'test';
 
 // internal urls
 export const LOGIN_URL = '/login';

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -41,6 +41,7 @@ export const BLOOD_SCREENING_ACTIVITY_CODE = 'bloodScreening';
 export const BEDNET_DISTRIBUTION_ACTIVITY_CODE = 'bednetDistribution';
 export const LARVAL_DIPPING_ACTIVITY_CODE = 'larvalDipping';
 export const MOSQUITO_COLLECTION_ACTIVITY_CODE = 'mosquitoCollection';
+export const TEST = 'test';
 
 // internal urls
 export const LOGIN_URL = '/login';


### PR DESCRIPTION
This PR:
* adds a simple conditional to disallow the WithGATracking component from mounting the HOC.
* adds simple conditions to disallow GA Tracking helper methods from tracking without a GA Code
* adds a utility function to extract the GA Code from the WithGATracking `options` param if provided, even if the code is an empty string
* adds tests to make sure page tracking is not happening in the absence of a GA_CODE
* references the GA_CODE and GA_ENV from options only
* adds `FlexComponent` and `ConnectedFlexComponent` to `types.ts`
* adds correct typings for WithGATracking

This PR addresses:
* Point C from https://github.com/onaio/reveal-frontend/issues/641
* Point 3 from https://github.com/onaio/reveal-frontend/issues/637#issuecomment-578252808