### PR TITLE
Exclude src/index.tsx from the coverage report

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,12 @@
     "lint-js": "eslint 'src/**/*.{js,jsx}'",
     "lint-ts": "tslint -c tslint.json 'src/**/*.{ts,tsx}'"
   },
+  "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx}",
+      "!src/index.tsx"
+    ]
+  },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"


### PR DESCRIPTION
# Changes proposed in this PR

- Exclude `src/index.tsx` from the coverage report

Closes #671 