### PR TITLE
Filter current plan from SingleActiveFI dropdown

### DIFF
--- a/src/containers/pages/FocusInvestigation/map/active/index.tsx
+++ b/src/containers/pages/FocusInvestigation/map/active/index.tsx
@@ -231,6 +231,10 @@ class SingleActiveFIMap extends React.Component<
     if (!jurisdiction || !plan) {
       return <Loading />;
     }
+
+    /** filter out this plan form plans by focusArea */
+    const otherPlansByFocusArea = plansByFocusArea.filter(localPlan => localPlan.id !== plan.id);
+
     const homePage = {
       label: HOME,
       url: HOME_URL,
@@ -327,7 +331,7 @@ class SingleActiveFIMap extends React.Component<
             <Col xs="4">
               <SelectComponent
                 placeholder={PLAN_SELECT_PLACEHOLDER}
-                plansArray={plansByFocusArea}
+                plansArray={otherPlansByFocusArea}
               />
             </Col>
           </Row>

--- a/src/containers/pages/FocusInvestigation/map/active/tests/index.test.tsx
+++ b/src/containers/pages/FocusInvestigation/map/active/tests/index.test.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router';
+import SelectComponent from '../../../../../../components/SelectPlan';
 import { FIReasons } from '../../../../../../configs/settings';
 import { FI_SINGLE_URL } from '../../../../../../constants';
 import { wrapFeatureCollection } from '../../../../../../helpers/utils';
@@ -158,6 +159,10 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
 
     // structures
     expect((singleActiveWrapperProps as MapSingleFIProps).structures).toBeNull();
+
+    // does not render the current plan under other plans select dropdown
+    const otherPlansSelectProps = wrapper.find(SelectComponent).props();
+    expect(otherPlansSelectProps.plansArray).toEqual([]);
 
     wrapper.unmount();
   });


### PR DESCRIPTION
fixes #584 

excludes the active plan from the `other plans in this area dropdown` 