### PR TITLE
Declare typescript as package in server/package.json

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,8 @@
     "express-session": "^1.17.0",
     "helmet": "^3.21.2",
     "request": "^2.88.0",
-    "session-file-store": "^1.3.1"
+    "session-file-store": "^1.3.1",
+    "typescript": "^3.7.5"
   },
   "devDependencies": {
     "@types/cookie-parser": "^1.4.2",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -2086,6 +2086,11 @@ type-is@~1.6.17, type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
+typescript@^3.7.5:
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
+  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+
 uid-safe@~2.1.5:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/uid-safe/-/uid-safe-2.1.5.tgz#2b3d5c7240e8fc2e58f8aa269e5ee49c0857bd3a"


### PR DESCRIPTION
I thought this would remove the need to have a task that installs typescript in ansible-express.
Aslo the role can now be used for non-typescript apps without installing surplus packages.