### PR TITLE
Add Reselect

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "reactstrap": "^7.1.0",
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
+    "reselect": "^4.0.0",
     "seamless-immutable": "^7.1.4",
     "typescript": "^3.3.1",
     "uuid": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "bootstrap": "^4.2.1",
     "client-oauth2": "^4.2.3",
     "connected-react-router": "^6.4.0",
+    "fast_array_intersect": "^1.1.0",
     "formik": "^1.5.8",
     "gisida": "^1.2.5",
     "gisida-react": "^1.2.8",

--- a/src/components/AssignTeamPopover/tests/__snapshots__/index.test.tsx.snap
+++ b/src/components/AssignTeamPopover/tests/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,220 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`/components/AssignTeamPopover renders and passes props correctly 1`] = `
+<Popover
+  isOpen={true}
+  onClick={[Function]}
+  placement="right"
+  placementPrefix="bs-popover"
+  style={
+    Object {
+      "minWidth": "16rem",
+    }
+  }
+  target="plan-assignment-outpost-number-one"
+  toggle={[Function]}
+  trigger="click"
+>
+  <TooltipPopoverWrapper
+    autohide={false}
+    className="popover show"
+    delay={
+      Object {
+        "hide": 250,
+        "show": 0,
+      }
+    }
+    hideArrow={false}
+    innerClassName="popover-inner"
+    isOpen={true}
+    onClick={[Function]}
+    placement="right"
+    placementPrefix="bs-popover"
+    style={
+      Object {
+        "minWidth": "16rem",
+      }
+    }
+    target="plan-assignment-outpost-number-one"
+    toggle={[Function]}
+    trigger="click"
+  >
+    <PopperContent
+      boundariesElement="scrollParent"
+      className="popover show"
+      container="body"
+      fallbackPlacement="flip"
+      flip={true}
+      hideArrow={false}
+      isOpen={true}
+      modifiers={Object {}}
+      offset={0}
+      placement="right"
+      placementPrefix="bs-popover"
+      target="plan-assignment-outpost-number-one"
+    >
+      <Portal
+        containerInfo={
+          <body>
+            <div
+              id="plan-assignment-outpost-number-one"
+            />
+            <div>
+              <div
+                class="popover show bs-popover-right"
+                style="position: absolute; pointer-events: none; opacity: 0;"
+                x-placement="right"
+              >
+                <div
+                  aria-hidden="true"
+                  class="popover-inner"
+                  role="tooltip"
+                  style="min-width: 16rem;"
+                >
+                  <h3
+                    class="popover-header"
+                  >
+                    Select Teams to Assign
+                  </h3>
+                  <div
+                    class="popover-body"
+                  >
+                    <p>
+                      No teams loaded...
+                    </p>
+                  </div>
+                </div>
+                <span
+                  class="arrow"
+                />
+              </div>
+            </div>
+          </body>
+        }
+      >
+        <div>
+          <Popper
+            className="popover show bs-popover-right"
+            component="div"
+            eventsEnabled={true}
+            modifiers={
+              Object {
+                "flip": Object {
+                  "behavior": "flip",
+                  "enabled": true,
+                },
+                "offset": Object {
+                  "offset": 0,
+                },
+                "preventOverflow": Object {
+                  "boundariesElement": "scrollParent",
+                },
+                "update": Object {
+                  "enabled": true,
+                  "fn": [Function],
+                  "order": 950,
+                },
+              }
+            }
+            placement="right"
+            positionFixed={false}
+            x-placement="right"
+          >
+            <div
+              className="popover show bs-popover-right"
+              style={
+                Object {
+                  "opacity": 0,
+                  "pointerEvents": "none",
+                  "position": "absolute",
+                }
+              }
+              x-placement="right"
+            >
+              <div
+                aria-hidden={true}
+                className="popover-inner"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
+                role="tooltip"
+                style={
+                  Object {
+                    "minWidth": "16rem",
+                  }
+                }
+              >
+                <PopoverHeader
+                  tag="h3"
+                >
+                  <h3
+                    className="popover-header"
+                  >
+                    Select Teams to Assign
+                  </h3>
+                </PopoverHeader>
+                <PopoverBody
+                  tag="div"
+                >
+                  <div
+                    className="popover-body"
+                  >
+                    <p>
+                      No teams loaded...
+                    </p>
+                  </div>
+                </PopoverBody>
+              </div>
+              <Arrow
+                className="arrow"
+              >
+                <span
+                  className="arrow"
+                  style={Object {}}
+                />
+              </Arrow>
+            </div>
+          </Popper>
+        </div>
+      </Portal>
+    </PopperContent>
+  </TooltipPopoverWrapper>
+</Popover>
+`;
+
+exports[`/components/AssignTeamPopover renders correctly when organizationsById is not null: button clear props 1`] = `
+Object {
+  "children": "Clear",
+  "color": "default",
+  "onClick": [MockFunction],
+  "outline": true,
+  "size": "xs",
+  "tag": "button",
+}
+`;
+
+exports[`/components/AssignTeamPopover renders correctly when organizationsById is not null: button save props 1`] = `
+Object {
+  "children": "Save",
+  "color": "primary",
+  "onClick": [MockFunction],
+  "size": "xs",
+  "tag": "button",
+}
+`;
+
+exports[`/components/AssignTeamPopover renders correctly when organizationsById is not null: organization select props 1`] = `
+Object {
+  "assignments": Array [],
+  "fetchAssignmentsAction": [Function],
+  "fetchOrganizationsAction": [Function],
+  "jurisdictionId": "outpost-number-one",
+  "name": "plan-assignment-form-outpost-number-one",
+  "organizations": Array [],
+  "planId": "alpha",
+  "resetPlanAssignmentsAction": [Function],
+  "serviceClass": [Function],
+  "value": Array [],
+}
+`;

--- a/src/components/AssignTeamPopover/tests/index.test.tsx
+++ b/src/components/AssignTeamPopover/tests/index.test.tsx
@@ -1,25 +1,90 @@
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
+import EnzymeToJson from 'enzyme-to-json';
 import React from 'react';
+import { Provider } from 'react-redux';
 import AssignTeamPopover, { AssignTeamPopoverProps } from '..';
+import store from '../../../store';
+import { Organization } from '../../../store/ducks/opensrp/organizations';
 
 describe('/components/AssignTeamPopover', () => {
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
+  const mock: any = jest.fn();
+  const props: AssignTeamPopoverProps = {
+    formName: 'plan-assignment-form-outpost-number-one',
+    isActive: true,
+    jurisdictionId: 'outpost-number-one',
+    onClearAssignmentsButtonClick: mock,
+    onSaveAssignmentsButtonClick: mock,
+    onToggle: mock,
+    organizationsById: null,
+    planId: 'alpha',
+    target: 'plan-assignment-outpost-number-one',
+  };
+  const div = document.createElement('div');
+  div.setAttribute('id', 'plan-assignment-outpost-number-one');
+  document.body.appendChild(div);
+
   it('renders without crashing', () => {
-    const mock: any = jest.fn();
-    const props: AssignTeamPopoverProps = {
-      formName: 'plan-assignment-form-outpost-number-one',
-      isActive: true,
-      jurisdictionId: 'outpost-number-one',
-      onClearAssignmentsButtonClick: mock,
-      onSaveAssignmentsButtonClick: mock,
-      onToggle: mock,
-      organizationsById: null,
-      planId: 'alpha',
-      target: 'plan-assignment-outpost-number-one',
-    };
     shallow(<AssignTeamPopover {...props} />);
+  });
+
+  it('renders and passes props correctly', () => {
+    const wrapper = mount(<AssignTeamPopover {...props} />);
+    expect(wrapper.props()).toEqual(props);
+    const tree = EnzymeToJson(wrapper.find('Popover'));
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders correctly when organizationsById is not null', () => {
+    const organization: Organization = {
+      active: true,
+      id: 1,
+      identifier: 'id',
+      name: 'name',
+    };
+    const propsOrganizationsById = {
+      ...props,
+      organizationsById: {
+        1: organization,
+      },
+    };
+    const wrapper = mount(
+      <Provider store={store}>
+        <AssignTeamPopover {...propsOrganizationsById} />
+      </Provider>
+    );
+    expect(wrapper.find('Form').length).toBe(1);
+    expect(wrapper.find('Form').prop('name')).toEqual(props.formName);
+    expect(wrapper.find('FormGroup').length).toBe(2);
+    expect(wrapper.find('OrganizationSelect').length).toBe(1);
+    expect(wrapper.find('OrganizationSelect').props()).toMatchSnapshot('organization select props');
+    expect(wrapper.find('Button').length).toBe(2);
+    expect(
+      wrapper
+        .find('Button')
+        .at(0)
+        .props()
+    ).toMatchSnapshot('button clear props');
+    expect(
+      wrapper
+        .find('Button')
+        .at(0)
+        .text()
+    ).toEqual('Clear');
+    expect(
+      wrapper
+        .find('Button')
+        .at(1)
+        .props()
+    ).toMatchSnapshot('button save props');
+    expect(
+      wrapper
+        .find('Button')
+        .at(1)
+        .text()
+    ).toEqual('Save');
   });
 });

--- a/src/components/DrillDownTableLinkedCell/tests/index.test.tsx
+++ b/src/components/DrillDownTableLinkedCell/tests/index.test.tsx
@@ -1,0 +1,104 @@
+import { mount } from 'enzyme';
+import { createBrowserHistory } from 'history';
+import React from 'react';
+import { Router } from 'react-router-dom';
+import { CellInfo } from 'react-table';
+import DrillDownTableLinkedCell from '..';
+
+const urlPath: string = '/path';
+/* tslint:disable:object-literal-sort-keys */
+
+const cell: CellInfo = {
+  index: 0,
+  viewIndex: 0,
+  pageSize: 20,
+  page: 0,
+  level: 0,
+  nestingPath: [0],
+  column: {
+    Header: '',
+    show: true,
+    minWidth: 90,
+    className: '',
+    style: {},
+    headerClassName: '',
+    headerStyle: {},
+    footerClassName: '',
+    footerStyle: {},
+    filterAll: false,
+    id: 'id',
+  },
+  value: '2019-11-20',
+  resized: [],
+  show: true,
+  width: 90,
+  tdProps: {
+    rest: {},
+  },
+  columnProps: {
+    rest: {},
+  },
+  classes: [],
+  styles: {},
+  pivoted: false,
+  expander: false,
+  isExpanded: false,
+  maxWidth: 4,
+  row: {},
+  rowValues: {},
+  aggregated: false,
+  groupedByPivot: false,
+  subRows: [],
+  original: {},
+};
+/* tslint:disable:object-literal-sort-keys */
+
+/**
+ * Investiate why cellValue = 'some value' fails but
+ * cellValue = cell.value works. Also why should either work if the component expects the value to be
+ * of type Node?
+ */
+const cellValue = cell.value;
+const history = createBrowserHistory();
+
+describe('/components/DrillDownTableLinkedCell', () => {
+  const props = {
+    cell,
+    cellValue,
+    hasChildren: true,
+    urlPath,
+  };
+  const wrapper = mount(
+    <Router history={history}>
+      <DrillDownTableLinkedCell {...props} />
+    </Router>
+  );
+
+  it('receives props correctly', () => {
+    expect(wrapper.find(DrillDownTableLinkedCell).props()).toEqual(props);
+  });
+
+  it('renders correctly if prop hasChildren is true', () => {
+    expect(wrapper.find(DrillDownTableLinkedCell).html()).toEqual(
+      '<div><a href="/path/2019-11-20">2019-11-20</a></div>'
+    );
+    wrapper.unmount();
+  });
+
+  it('renders correctly if prop hasChildren is false', () => {
+    const propsHasChildrenFalse = {
+      ...props,
+      hasChildren: false,
+    };
+    const wrapperHasChildrenFalse = mount(
+      <Router history={history}>
+        <DrillDownTableLinkedCell {...propsHasChildrenFalse} />
+      </Router>
+    );
+
+    expect(wrapperHasChildrenFalse.find(DrillDownTableLinkedCell).html()).toEqual(
+      '<div>2019-11-20</div>'
+    );
+    wrapperHasChildrenFalse.unmount();
+  });
+});

--- a/src/containers/forms/PlanForm/index.tsx
+++ b/src/containers/forms/PlanForm/index.tsx
@@ -16,7 +16,7 @@ import {
 } from 'reactstrap';
 import { format } from 'util';
 import DatePickerWrapper from '../../../components/DatePickerWrapper';
-import FormikEffect, { FormikOnchangeFunc } from '../../../components/FormikEffect';
+import FormikEffect from '../../../components/FormikEffect';
 import {
   DATE_FORMAT,
   DEFAULT_PLAN_DURATION_DAYS,
@@ -943,7 +943,7 @@ const defaultProps: PlanFormProps = {
   cascadingSelect: true,
   disabledActivityFields: [],
   disabledFields: [],
-  formHandler: (curr, next) => void 0,
+  formHandler: (_, __) => void 0,
   initialValues: defaultInitialValues,
   jurisdictionLabel: FOCUS_AREA_HEADER,
   redirectAfterAction: PLAN_LIST_URL,

--- a/src/containers/pages/InterventionPlan/NewPlan/General/index.tsx
+++ b/src/containers/pages/InterventionPlan/NewPlan/General/index.tsx
@@ -12,7 +12,7 @@ import PlanForm, { defaultInitialValues } from '../../../../forms/PlanForm';
 /** Simple component that loads the new plan form and allows you to create a new plan */
 const NewPlan = () => {
   const [formValues, setFormValues] = useState(defaultInitialValues);
-  const formValuesHandler = (curr: any, next: any) => {
+  const formValuesHandler = (_: any, next: any) => {
     setFormValues(next.values);
   };
 

--- a/src/store/ducks/README.md
+++ b/src/store/ducks/README.md
@@ -1,0 +1,93 @@
+# Redux Modules (aka Ducks)
+
+Ducks are modular Redux reducer bundles inspired by [this proposal](https://github.com/erikras/ducks-modular-redux).
+
+## Rules for Reducer Modules
+
+A reducer module:
+
+1. **MUST** export default a function called reducer()
+2. **MUST** export its action creators as functions
+3. **MUST** have action types in the form `reveal/reducer/ACTION_TYPE`
+4. MAY export its action types as UPPER_SNAKE_CASE, if an external reducer needs to listen for them, or if it is a published reusable library
+
+## Selectors
+
+The above proposal does not cover [selectors](https://redux.js.org/introduction/learning-resources/#selectors). Selectors are getters for the redux state. Like getters, selectors encapsulate the structure of the state, and are reusable. Selectors can also compute derived properties.
+
+Generally, we prefer that:
+
+1. Selectors should be included in the reducer module
+2. Selectors should be made using [Reselect](https://github.com/reduxjs/reselect).
+
+### Reselect usage
+
+The following is a mini-tutorial that should serve as an introduction to Reselect usage. [Go here for official documentation](https://github.com/reduxjs/reselect).
+
+Start by creating a basic "base selector". Ideally this base selector should be as simple as possible,
+and should not do any processing or filtering; it should simply be extracting data from the store.
+
+```ts
+export const plansArrayBaseSelector = (state: Registry): Plan[] =>
+  values((state as any)[reducerName].plansById);
+```
+
+If you anticipate that you will need to filter/process the data further by having your selectors take in parameters, then go ahead and create an interface to describe the kind of parameters you are expecting:
+
+```ts
+export interface FancyFilters {
+  interventionType?: InterventionType /** The plan intervention type */;
+  jurisdictionIds?: string[] /** an array of jurisdiction ids */;
+}
+```
+
+Next, create really simple functions that simply extract the params, for example:
+
+```ts
+// these functions are technically also selectors, but they are getting data from `props`. Notice that the
+// first parameter below is unused (it represents the Redux state).
+export const getInterventionType = (_: Registry, props: PlanFilters) => props.interventionType;
+export const getJurisdictionIds = (_: Registry, props: PlanFilters) => props.jurisdictionIds;
+```
+
+Finally, you can now actually use Reselect's `createSelector` to define your memoized selectors:
+
+```ts
+// these selector definitions will result in selector functions that accept two inputs:
+//   1. the state, the global Redux state
+//   2. the props, in this case an object of shape FancyFilters
+export const getPlansArrayByInterventionType = createSelector(
+  [plansArrayBaseSelector, getInterventionType],
+  (plans, interventionType) =>
+    interventionType
+      ? plans.filter(plan => plan.plan_intervention_type === interventionType)
+      : plans
+);
+export const getPlansArrayByJurisdictionIds = createSelector(
+  [plansArrayBaseSelector, getJurisdictionIds],
+  (plans, jurisdictionIds) =>
+    jurisdictionIds
+      ? plans.filter(plan =>
+          jurisdictionIds.length ? jurisdictionIds.includes(plan.jurisdiction_id) : true
+        )
+      : plans
+);
+```
+
+You can compose your selectors by combining them, like so:
+
+```ts
+export const makeComplexSelector = () => {
+  // this is our actual selector definition
+  return createSelector(
+    // the first argument is an array of the selectors that you are combining
+    [getPlansArrayByInterventionType, getPlansArrayByJurisdictionIds],
+    (
+      plans,
+      plans2 // the 2nd argument is a callback function that takes the results of the 1st arguments
+    ) => intersect([plans, plans2], JSON.stringify)
+  );
+};
+```
+
+Note that `makeComplexSelector` above simply returns a selector. This is useful when you want to [create shareable memoized selectors](https://github.com/reduxjs/reselect#sharing-selectors-with-props-across-multiple-component-instances). This is recommended whenever your selectors take in params, like the selectors defined above.

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -588,6 +588,18 @@ export const getPlansArrayByParentJurisdictionId = createSelector(
     )
 );
 
+export const plansArraySelector = createSelector(
+  [
+    getPlansArrayByInterventionType,
+    getPlansArrayByJurisdictionIds,
+    getPlansArrayByStatus,
+    getPlansArrayByReason,
+    getPlansArrayByParentJurisdictionId,
+  ],
+  (plans, plans2, plans3, plans4, plans5) =>
+    intersect([plans, plans2, plans3, plans4, plans5], JSON.stringify)
+);
+
 export const getPlansArrayByInterventionTypeAndJurisdictionId = createSelector(
   [getPlansArrayByInterventionType, getPlansArrayByJurisdictionIds],
   (plans, plans2) => intersect([plans, plans2], JSON.stringify)

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -599,8 +599,3 @@ export const plansArraySelector = createSelector(
   (plans, plans2, plans3, plans4, plans5) =>
     intersect([plans, plans2, plans3, plans4, plans5], JSON.stringify)
 );
-
-export const getPlansArrayByInterventionTypeAndJurisdictionId = createSelector(
-  [getPlansArrayByInterventionType, getPlansArrayByJurisdictionIds],
-  (plans, plans2) => intersect([plans, plans2], JSON.stringify)
-);

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -522,7 +522,7 @@ export function getPlanRecordById(state: Partial<Store>, id: string): PlanRecord
 
 export interface PlanFilters {
   interventionType?: InterventionType;
-  jurisdictionId?: string;
+  jurisdictionIds?: string[];
   parentJurisdictionId?: string;
   reason?: FIReasonType;
   statusList?: string[];
@@ -536,7 +536,7 @@ export const plansArraySelector = (state: Registry): Plan[] =>
 
 export const getInterventionType = (_: Registry, props: PlanFilters) => props.interventionType;
 
-export const getJurisdictionId = (_: Registry, props: PlanFilters) => props.jurisdictionId;
+export const getJurisdictionIds = (_: Registry, props: PlanFilters) => props.jurisdictionIds;
 
 export const getParentJurisdictionId = (_: Registry, props: PlanFilters) =>
   props.parentJurisdictionId;
@@ -554,10 +554,14 @@ export const getPlansArrayByInterventionType = createSelector(
       : plans
 );
 
-export const getPlansArrayByJurisdictionId = createSelector(
-  [plansArraySelector, getJurisdictionId],
-  (plans, jurisdictionId) =>
-    jurisdictionId ? plans.filter(plan => plan.jurisdiction_id === jurisdictionId) : plans
+export const getPlansArrayByJurisdictionIds = createSelector(
+  [plansArraySelector, getJurisdictionIds],
+  (plans, jurisdictionIds) =>
+    jurisdictionIds
+      ? plans.filter(plan =>
+          jurisdictionIds.length ? jurisdictionIds.includes(plan.jurisdiction_id) : true
+        )
+      : plans
 );
 
 export const getPlansArrayByStatus = createSelector(
@@ -584,6 +588,6 @@ export const getPlansArrayByParentJurisdictionId = createSelector(
 );
 
 export const getPlansArrayByInterventionTypeAndJurisdictionId = createSelector(
-  [getPlansArrayByInterventionType, getPlansArrayByJurisdictionId],
+  [getPlansArrayByInterventionType, getPlansArrayByJurisdictionIds],
   (plans, plans2) => plans.filter(value => plans2.includes(value))
 );

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -1,6 +1,7 @@
 import { Registry } from '@onaio/redux-reducer-registry';
 import { get, keyBy, keys, pickBy, values } from 'lodash';
 import { AnyAction, Store } from 'redux';
+import { createSelector } from 'reselect';
 import SeamlessImmutable from 'seamless-immutable';
 import uuidv4 from 'uuid/v4';
 import {
@@ -519,8 +520,36 @@ export function getPlanRecordById(state: Partial<Store>, id: string): PlanRecord
 
 /** RESELECT USAGE STARTS HERE */
 
+export interface PlanFilters {
+  interventionType?: InterventionType;
+  jurisdictionId?: string;
+}
+
 /** plansArraySelector select an array of all plans
  * @param state - the redux store
  */
 export const plansArraySelector = (state: Registry): Plan[] =>
   values((state as any)[reducerName].plansById);
+
+export const getInterventionType = (_: Registry, props: PlanFilters) => props.interventionType;
+
+export const getJurisdictionId = (_: Registry, props: PlanFilters) => props.jurisdictionId;
+
+export const getPlansArrayByInterventionType = createSelector(
+  [plansArraySelector, getInterventionType],
+  (plans, interventionType) =>
+    interventionType
+      ? plans.filter(plan => plan.plan_intervention_type === interventionType)
+      : plans
+);
+
+export const getPlansArrayByJurisdictionId = createSelector(
+  [plansArraySelector, getJurisdictionId],
+  (plans, jurisdictionId) =>
+    jurisdictionId ? plans.filter(plan => plan.jurisdiction_id === jurisdictionId) : plans
+);
+
+export const getPlansArrayByInterventionTypeAndJurisdictionId = createSelector(
+  [getPlansArrayByInterventionType, getPlansArrayByJurisdictionId],
+  (plans, plans2) => plans.filter(value => plans2.includes(value))
+);

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -574,8 +574,8 @@ export const getReason = (_: Registry, props: PlanFilters) => props.reason;
 
 /** getPlansArrayByInterventionType
  * Gets an array of Plan objects filtered by interventionType
- * @param state - the redux store
- * @param props - the plan filters object
+ * @param {Registry} state - the redux store
+ * @param {PlanFilters} props - the plan filters object
  */
 export const getPlansArrayByInterventionType = createSelector(
   [plansArrayBaseSelector, getInterventionType],
@@ -587,8 +587,8 @@ export const getPlansArrayByInterventionType = createSelector(
 
 /** getPlansArrayByJurisdictionIds
  * Gets an array of Plan objects filtered by jurisdictionIds
- * @param state - the redux store
- * @param props - the plan filters object
+ * @param {Registry} state - the redux store
+ * @param {PlanFilters} props - the plan filters object
  */
 export const getPlansArrayByJurisdictionIds = createSelector(
   [plansArrayBaseSelector, getJurisdictionIds],
@@ -602,8 +602,8 @@ export const getPlansArrayByJurisdictionIds = createSelector(
 
 /** getPlansArrayByStatus
  * Gets an array of Plan objects filtered by plan status
- * @param state - the redux store
- * @param props - the plan filters object
+ * @param {Registry} state - the redux store
+ * @param {PlanFilters} props - the plan filters object
  */
 export const getPlansArrayByStatus = createSelector(
   [plansArrayBaseSelector, getStatusList],
@@ -615,8 +615,8 @@ export const getPlansArrayByStatus = createSelector(
 
 /** getPlansArrayByReason
  * Gets an array of Plan objects filtered by FI plan reason
- * @param state - the redux store
- * @param props - the plan filters object
+ * @param {Registry} state - the redux store
+ * @param {PlanFilters} props - the plan filters object
  */
 export const getPlansArrayByReason = createSelector(
   [plansArrayBaseSelector, getReason],
@@ -625,8 +625,8 @@ export const getPlansArrayByReason = createSelector(
 
 /** getPlansArrayByParentJurisdictionId
  * Gets an array of Plan objects filtered by plan jurisdiction parent_id
- * @param state - the redux store
- * @param props - the plan filters object
+ * @param {Registry} state - the redux store
+ * @param {PlanFilters} props - the plan filters object
  */
 export const getPlansArrayByParentJurisdictionId = createSelector(
   [plansArrayBaseSelector, getParentJurisdictionId],
@@ -652,8 +652,8 @@ export const getPlansArrayByParentJurisdictionId = createSelector(
  *
  * This selector is meant to be a memoized replacement for getPlanRecordsArray.
  *
- * @param state - the redux store
- * @param props - the plan filters object
+ * @param {Registry} state - the redux store
+ * @param {PlanFilters} props - the plan filters object
  */
 export const plansArraySelector = createSelector(
   [

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -612,6 +612,11 @@ export const getPlansArrayByStatus = createSelector(
       : plans
 );
 
+/** getPlansArrayByReason
+ * Gets an array of Plan objects filtered by FI plan reason
+ * @param state - the redux store
+ * @param props - the plan filters object
+ */
 export const getPlansArrayByReason = createSelector(
   [plansArrayBaseSelector, getReason],
   (plans, reason) => (reason ? plans.filter(plan => plan.plan_fi_reason === reason) : plans)

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -1,3 +1,4 @@
+import { Registry } from '@onaio/redux-reducer-registry';
 import { get, keyBy, keys, pickBy, values } from 'lodash';
 import { AnyAction, Store } from 'redux';
 import SeamlessImmutable from 'seamless-immutable';
@@ -515,3 +516,11 @@ export function getPlanRecordsIdArray(
 export function getPlanRecordById(state: Partial<Store>, id: string): PlanRecord | null {
   return get((state as any)[reducerName].planRecordsById, id) || null;
 }
+
+/** RESELECT USAGE STARTS HERE */
+
+/** plansArraySelector select an array of all plans
+ * @param state - the redux store
+ */
+export const plansArraySelector = (state: Registry): Plan[] =>
+  values((state as any)[reducerName].plansById);

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -639,6 +639,21 @@ export const getPlansArrayByParentJurisdictionId = createSelector(
     )
 );
 
+/** plansArraySelector
+ * Gets an array of Plan objects filtered by one or all of the following:
+ *    - interventionType
+ *    - jurisdictionIds
+ *    - plan status
+ *    - FI plan reason
+ *    - plan jurisdiction parent_id
+ *
+ * These filter params are all optional and are supplied via the prop parameter.
+ *
+ * This selector is meant to be a memoized replacement for getPlanRecordsArray.
+ *
+ * @param state - the redux store
+ * @param props - the plan filters object
+ */
 export const plansArraySelector = createSelector(
   [
     getPlansArrayByInterventionType,

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -1,4 +1,5 @@
 import { Registry } from '@onaio/redux-reducer-registry';
+import intersect from 'fast_array_intersect';
 import { get, keyBy, keys, pickBy, values } from 'lodash';
 import { AnyAction, Store } from 'redux';
 import { createSelector } from 'reselect';
@@ -531,7 +532,7 @@ export interface PlanFilters {
 /** plansArraySelector select an array of all plans
  * @param state - the redux store
  */
-export const plansArraySelector = (state: Registry): Plan[] =>
+export const plansArrayBaseSelector = (state: Registry): Plan[] =>
   values((state as any)[reducerName].plansById);
 
 export const getInterventionType = (_: Registry, props: PlanFilters) => props.interventionType;
@@ -547,7 +548,7 @@ export const getStatusList = (_: Registry, props: PlanFilters) =>
 export const getReason = (_: Registry, props: PlanFilters) => props.reason;
 
 export const getPlansArrayByInterventionType = createSelector(
-  [plansArraySelector, getInterventionType],
+  [plansArrayBaseSelector, getInterventionType],
   (plans, interventionType) =>
     interventionType
       ? plans.filter(plan => plan.plan_intervention_type === interventionType)
@@ -555,7 +556,7 @@ export const getPlansArrayByInterventionType = createSelector(
 );
 
 export const getPlansArrayByJurisdictionIds = createSelector(
-  [plansArraySelector, getJurisdictionIds],
+  [plansArrayBaseSelector, getJurisdictionIds],
   (plans, jurisdictionIds) =>
     jurisdictionIds
       ? plans.filter(plan =>
@@ -565,18 +566,18 @@ export const getPlansArrayByJurisdictionIds = createSelector(
 );
 
 export const getPlansArrayByStatus = createSelector(
-  [plansArraySelector, getStatusList],
+  [plansArrayBaseSelector, getStatusList],
   (plans, statusList) =>
     plans.filter(plan => (statusList.length ? statusList.includes(plan.plan_status) : true))
 );
 
 export const getPlansArrayByReason = createSelector(
-  [plansArraySelector, getReason],
+  [plansArrayBaseSelector, getReason],
   (plans, reason) => (reason ? plans.filter(plan => plan.plan_fi_reason === reason) : plans)
 );
 
 export const getPlansArrayByParentJurisdictionId = createSelector(
-  [plansArraySelector, getParentJurisdictionId],
+  [plansArrayBaseSelector, getParentJurisdictionId],
   (plans, parentJurisdictionId) =>
     plans.filter(
       plan =>
@@ -589,5 +590,5 @@ export const getPlansArrayByParentJurisdictionId = createSelector(
 
 export const getPlansArrayByInterventionTypeAndJurisdictionId = createSelector(
   [getPlansArrayByInterventionType, getPlansArrayByJurisdictionIds],
-  (plans, plans2) => plans.filter(value => plans2.includes(value))
+  (plans, plans2) => intersect([plans, plans2], JSON.stringify)
 );

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -523,6 +523,7 @@ export function getPlanRecordById(state: Partial<Store>, id: string): PlanRecord
 export interface PlanFilters {
   interventionType?: InterventionType;
   jurisdictionId?: string;
+  statusList?: string[];
 }
 
 /** plansArraySelector select an array of all plans
@@ -534,6 +535,9 @@ export const plansArraySelector = (state: Registry): Plan[] =>
 export const getInterventionType = (_: Registry, props: PlanFilters) => props.interventionType;
 
 export const getJurisdictionId = (_: Registry, props: PlanFilters) => props.jurisdictionId;
+
+export const getStatusList = (_: Registry, props: PlanFilters) =>
+  props.statusList || [PlanStatus.ACTIVE];
 
 export const getPlansArrayByInterventionType = createSelector(
   [plansArraySelector, getInterventionType],
@@ -547,6 +551,12 @@ export const getPlansArrayByJurisdictionId = createSelector(
   [plansArraySelector, getJurisdictionId],
   (plans, jurisdictionId) =>
     jurisdictionId ? plans.filter(plan => plan.jurisdiction_id === jurisdictionId) : plans
+);
+
+export const getPlansArrayByStatus = createSelector(
+  [plansArraySelector, getStatusList],
+  (plans, statusList) =>
+    plans.filter(plan => (statusList.length ? statusList.includes(plan.plan_status) : true))
 );
 
 export const getPlansArrayByInterventionTypeAndJurisdictionId = createSelector(

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -529,21 +529,46 @@ export interface PlanFilters {
   statusList?: string[];
 }
 
-/** plansArraySelector select an array of all plans
+/** plansArrayBaseSelector select an array of all plans
  * @param state - the redux store
  */
 export const plansArrayBaseSelector = (state: Registry): Plan[] =>
   values((state as any)[reducerName].plansById);
 
+/** getInterventionType
+ * Gets interventionType from PlanFilters
+ * @param state - the redux store
+ * @param props - the plan filters object
+ */
 export const getInterventionType = (_: Registry, props: PlanFilters) => props.interventionType;
 
+/** getJurisdictionIds
+ * Gets jurisdictionIds from PlanFilters
+ * @param state - the redux store
+ * @param props - the plan filters object
+ */
 export const getJurisdictionIds = (_: Registry, props: PlanFilters) => props.jurisdictionIds;
 
+/** getParentJurisdictionId
+ * Gets parentJurisdictionId from PlanFilters
+ * @param state - the redux store
+ * @param props - the plan filters object
+ */
 export const getParentJurisdictionId = (_: Registry, props: PlanFilters) =>
   props.parentJurisdictionId;
 
+/** getStatusList
+ * Gets statusList from PlanFilters
+ * @param state - the redux store
+ * @param props - the plan filters object
+ */
 export const getStatusList = (_: Registry, props: PlanFilters) => props.statusList;
 
+/** getReason
+ * Gets reason from PlanFilters
+ * @param state - the redux store
+ * @param props - the plan filters object
+ */
 export const getReason = (_: Registry, props: PlanFilters) => props.reason;
 
 export const getPlansArrayByInterventionType = createSelector(

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -523,6 +523,7 @@ export function getPlanRecordById(state: Partial<Store>, id: string): PlanRecord
 export interface PlanFilters {
   interventionType?: InterventionType;
   jurisdictionId?: string;
+  parentJurisdictionId?: string;
   reason?: FIReasonType;
   statusList?: string[];
 }
@@ -536,6 +537,9 @@ export const plansArraySelector = (state: Registry): Plan[] =>
 export const getInterventionType = (_: Registry, props: PlanFilters) => props.interventionType;
 
 export const getJurisdictionId = (_: Registry, props: PlanFilters) => props.jurisdictionId;
+
+export const getParentJurisdictionId = (_: Registry, props: PlanFilters) =>
+  props.parentJurisdictionId;
 
 export const getStatusList = (_: Registry, props: PlanFilters) =>
   props.statusList || [PlanStatus.ACTIVE];
@@ -565,6 +569,18 @@ export const getPlansArrayByStatus = createSelector(
 export const getPlansArrayByReason = createSelector(
   [plansArraySelector, getReason],
   (plans, reason) => (reason ? plans.filter(plan => plan.plan_fi_reason === reason) : plans)
+);
+
+export const getPlansArrayByParentJurisdictionId = createSelector(
+  [plansArraySelector, getParentJurisdictionId],
+  (plans, parentJurisdictionId) =>
+    plans.filter(
+      plan =>
+        (parentJurisdictionId && !plan.jurisdiction_path ? false : true) &&
+        (parentJurisdictionId && plan.jurisdiction_path
+          ? plan.jurisdiction_path.includes(parentJurisdictionId)
+          : true)
+    )
 );
 
 export const getPlansArrayByInterventionTypeAndJurisdictionId = createSelector(

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -542,8 +542,7 @@ export const getJurisdictionIds = (_: Registry, props: PlanFilters) => props.jur
 export const getParentJurisdictionId = (_: Registry, props: PlanFilters) =>
   props.parentJurisdictionId;
 
-export const getStatusList = (_: Registry, props: PlanFilters) =>
-  props.statusList || [PlanStatus.ACTIVE];
+export const getStatusList = (_: Registry, props: PlanFilters) => props.statusList;
 
 export const getReason = (_: Registry, props: PlanFilters) => props.reason;
 
@@ -568,7 +567,9 @@ export const getPlansArrayByJurisdictionIds = createSelector(
 export const getPlansArrayByStatus = createSelector(
   [plansArrayBaseSelector, getStatusList],
   (plans, statusList) =>
-    plans.filter(plan => (statusList.length ? statusList.includes(plan.plan_status) : true))
+    statusList
+      ? plans.filter(plan => (statusList.length ? statusList.includes(plan.plan_status) : true))
+      : plans
 );
 
 export const getPlansArrayByReason = createSelector(

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -599,6 +599,11 @@ export const getPlansArrayByJurisdictionIds = createSelector(
       : plans
 );
 
+/** getPlansArrayByStatus
+ * Gets an array of Plan objects filtered by plan status
+ * @param state - the redux store
+ * @param props - the plan filters object
+ */
 export const getPlansArrayByStatus = createSelector(
   [plansArrayBaseSelector, getStatusList],
   (plans, statusList) =>

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -640,8 +640,9 @@ export const getPlansArrayByParentJurisdictionId = createSelector(
     )
 );
 
-/** plansArraySelector
- * Gets an array of Plan objects filtered by one or all of the following:
+/** makePlansArraySelector
+ * Returns a selector that gets an array of Plan objects filtered by one or all
+ * of the following:
  *    - interventionType
  *    - jurisdictionIds
  *    - plan status
@@ -652,17 +653,22 @@ export const getPlansArrayByParentJurisdictionId = createSelector(
  *
  * This selector is meant to be a memoized replacement for getPlanRecordsArray.
  *
+ * To use this selector, do something like:
+ *    const plansArraySelector = makePlansArraySelector();
+ *
  * @param {Registry} state - the redux store
  * @param {PlanFilters} props - the plan filters object
  */
-export const plansArraySelector = createSelector(
-  [
-    getPlansArrayByInterventionType,
-    getPlansArrayByJurisdictionIds,
-    getPlansArrayByStatus,
-    getPlansArrayByReason,
-    getPlansArrayByParentJurisdictionId,
-  ],
-  (plans, plans2, plans3, plans4, plans5) =>
-    intersect([plans, plans2, plans3, plans4, plans5], JSON.stringify)
-);
+export const makePlansArraySelector = () => {
+  return createSelector(
+    [
+      getPlansArrayByInterventionType,
+      getPlansArrayByJurisdictionIds,
+      getPlansArrayByStatus,
+      getPlansArrayByReason,
+      getPlansArrayByParentJurisdictionId,
+    ],
+    (plans, plans2, plans3, plans4, plans5) =>
+      intersect([plans, plans2, plans3, plans4, plans5], JSON.stringify)
+  );
+};

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -622,6 +622,11 @@ export const getPlansArrayByReason = createSelector(
   (plans, reason) => (reason ? plans.filter(plan => plan.plan_fi_reason === reason) : plans)
 );
 
+/** getPlansArrayByParentJurisdictionId
+ * Gets an array of Plan objects filtered by plan jurisdiction parent_id
+ * @param state - the redux store
+ * @param props - the plan filters object
+ */
 export const getPlansArrayByParentJurisdictionId = createSelector(
   [plansArrayBaseSelector, getParentJurisdictionId],
   (plans, parentJurisdictionId) =>

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -521,12 +521,13 @@ export function getPlanRecordById(state: Partial<Store>, id: string): PlanRecord
 
 /** RESELECT USAGE STARTS HERE */
 
+/** This interface represents the structure of plan filter options/params */
 export interface PlanFilters {
-  interventionType?: InterventionType;
-  jurisdictionIds?: string[];
-  parentJurisdictionId?: string;
-  reason?: FIReasonType;
-  statusList?: string[];
+  interventionType?: InterventionType /** The plan intervention type */;
+  jurisdictionIds?: string[] /** an array of jurisdiction ids */;
+  parentJurisdictionId?: string /** jurisdiction parent id */;
+  reason?: FIReasonType /** plan FI reason */;
+  statusList?: string[] /** array of plan statuses */;
 }
 
 /** plansArrayBaseSelector select an array of all plans

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -584,6 +584,11 @@ export const getPlansArrayByInterventionType = createSelector(
       : plans
 );
 
+/** getPlansArrayByJurisdictionIds
+ * Gets an array of Plan objects filtered by jurisdictionIds
+ * @param state - the redux store
+ * @param props - the plan filters object
+ */
 export const getPlansArrayByJurisdictionIds = createSelector(
   [plansArrayBaseSelector, getJurisdictionIds],
   (plans, jurisdictionIds) =>

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -571,6 +571,11 @@ export const getStatusList = (_: Registry, props: PlanFilters) => props.statusLi
  */
 export const getReason = (_: Registry, props: PlanFilters) => props.reason;
 
+/** getPlansArrayByInterventionType
+ * Gets an array of Plan objects filtered by interventionType
+ * @param state - the redux store
+ * @param props - the plan filters object
+ */
 export const getPlansArrayByInterventionType = createSelector(
   [plansArrayBaseSelector, getInterventionType],
   (plans, interventionType) =>

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -523,6 +523,7 @@ export function getPlanRecordById(state: Partial<Store>, id: string): PlanRecord
 export interface PlanFilters {
   interventionType?: InterventionType;
   jurisdictionId?: string;
+  reason?: FIReasonType;
   statusList?: string[];
 }
 
@@ -538,6 +539,8 @@ export const getJurisdictionId = (_: Registry, props: PlanFilters) => props.juri
 
 export const getStatusList = (_: Registry, props: PlanFilters) =>
   props.statusList || [PlanStatus.ACTIVE];
+
+export const getReason = (_: Registry, props: PlanFilters) => props.reason;
 
 export const getPlansArrayByInterventionType = createSelector(
   [plansArraySelector, getInterventionType],
@@ -557,6 +560,11 @@ export const getPlansArrayByStatus = createSelector(
   [plansArraySelector, getStatusList],
   (plans, statusList) =>
     plans.filter(plan => (statusList.length ? statusList.includes(plan.plan_status) : true))
+);
+
+export const getPlansArrayByReason = createSelector(
+  [plansArraySelector, getReason],
+  (plans, reason) => (reason ? plans.filter(plan => plan.plan_fi_reason === reason) : plans)
 );
 
 export const getPlansArrayByInterventionTypeAndJurisdictionId = createSelector(

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -13,7 +13,6 @@ import reducer, {
   getPlanRecordsIdArray,
   getPlansArray,
   getPlansArrayByInterventionType,
-  getPlansArrayByInterventionTypeAndJurisdictionId,
   getPlansArrayByJurisdictionIds,
   getPlansArrayByParentJurisdictionId,
   getPlansArrayByReason,
@@ -25,6 +24,7 @@ import reducer, {
   PlanRecord,
   PlanRecordResponse,
   plansArrayBaseSelector,
+  plansArraySelector,
   PlanStatus,
   reducerName,
   removePlansAction,
@@ -157,7 +157,7 @@ describe('reducers/plans', () => {
       values(allPlans).filter(e => e.jurisdiction_path.includes('2977'))
     );
     expect(
-      getPlansArrayByInterventionTypeAndJurisdictionId(store.getState(), {
+      plansArraySelector(store.getState(), {
         ...fiFilter,
         ...jurisdictionFilter,
       })

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -14,7 +14,7 @@ import reducer, {
   getPlansArray,
   getPlansArrayByInterventionType,
   getPlansArrayByInterventionTypeAndJurisdictionId,
-  getPlansArrayByJurisdictionId,
+  getPlansArrayByJurisdictionIds,
   getPlansArrayByParentJurisdictionId,
   getPlansArrayByReason,
   getPlansArrayByStatus,
@@ -130,7 +130,7 @@ describe('reducers/plans', () => {
       interventionType: InterventionType.FI,
     };
     const jurisdictionFilter = {
-      jurisdictionId: '450fc15b-5bd2-468a-927a-49cb10d3bcac',
+      jurisdictionIds: ['450fc15b-5bd2-468a-927a-49cb10d3bcac'],
     };
     const statusFilter = {
       statusList: [PlanStatus.DRAFT],
@@ -144,7 +144,7 @@ describe('reducers/plans', () => {
 
     expect(getPlansArrayByInterventionType(store.getState(), {})).toEqual(values(allPlans));
     expect(getPlansArrayByInterventionType(store.getState(), fiFilter)).toEqual(values(fiPlans));
-    expect(getPlansArrayByJurisdictionId(store.getState(), jurisdictionFilter)).toEqual(
+    expect(getPlansArrayByJurisdictionIds(store.getState(), jurisdictionFilter)).toEqual(
       values(allPlans).filter(e => e.jurisdiction_id === '450fc15b-5bd2-468a-927a-49cb10d3bcac')
     );
     expect(getPlansArrayByStatus(store.getState(), statusFilter)).toEqual(

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -15,6 +15,7 @@ import reducer, {
   getPlansArrayByInterventionType,
   getPlansArrayByInterventionTypeAndJurisdictionId,
   getPlansArrayByJurisdictionId,
+  getPlansArrayByStatus,
   getPlansById,
   getPlansIdArray,
   InterventionType,
@@ -129,10 +130,17 @@ describe('reducers/plans', () => {
     const jurisdictionFilter = {
       jurisdictionId: '450fc15b-5bd2-468a-927a-49cb10d3bcac',
     };
+    const statusFilter = {
+      statusList: [PlanStatus.DRAFT],
+    };
+
     expect(getPlansArrayByInterventionType(store.getState(), {})).toEqual(values(allPlans));
     expect(getPlansArrayByInterventionType(store.getState(), fiFilter)).toEqual(values(fiPlans));
     expect(getPlansArrayByJurisdictionId(store.getState(), jurisdictionFilter)).toEqual(
       values(allPlans).filter(e => e.jurisdiction_id === '450fc15b-5bd2-468a-927a-49cb10d3bcac')
+    );
+    expect(getPlansArrayByStatus(store.getState(), statusFilter)).toEqual(
+      values(allPlans).filter(e => e.plan_status === PlanStatus.DRAFT)
     );
     expect(
       getPlansArrayByInterventionTypeAndJurisdictionId(store.getState(), {

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -164,6 +164,25 @@ describe('reducers/plans', () => {
     ).toEqual(
       values(fiPlans).filter(e => e.jurisdiction_id === '450fc15b-5bd2-468a-927a-49cb10d3bcac')
     );
+
+    expect(
+      plansArraySelector(store.getState(), {
+        interventionType: InterventionType.FI,
+        reason: FIReasons[1],
+      })
+    ).toEqual(values(reactivePlans));
+    expect(
+      plansArraySelector(store.getState(), {
+        interventionType: InterventionType.FI,
+        reason: FIReasons[0],
+      })
+    ).toEqual(values(routinePlans));
+    expect(
+      plansArraySelector(store.getState(), {
+        interventionType: InterventionType.FI,
+        statusList: [PlanStatus.DRAFT],
+      })
+    ).toEqual(values(reactiveDraftPlans));
   });
 
   it('filters correctly when jurisdiction_parent_id is provided', () => {

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -15,6 +15,7 @@ import reducer, {
   getPlansArrayByInterventionType,
   getPlansArrayByInterventionTypeAndJurisdictionId,
   getPlansArrayByJurisdictionId,
+  getPlansArrayByParentJurisdictionId,
   getPlansArrayByReason,
   getPlansArrayByStatus,
   getPlansById,
@@ -137,6 +138,9 @@ describe('reducers/plans', () => {
     const reasonFilter = {
       reason: FIReasons[1],
     };
+    const parentJurisdictionFilter = {
+      parentJurisdictionId: '2977',
+    };
 
     expect(getPlansArrayByInterventionType(store.getState(), {})).toEqual(values(allPlans));
     expect(getPlansArrayByInterventionType(store.getState(), fiFilter)).toEqual(values(fiPlans));
@@ -148,6 +152,9 @@ describe('reducers/plans', () => {
     );
     expect(getPlansArrayByReason(store.getState(), reasonFilter)).toEqual(
       values(allPlans).filter(e => e.plan_fi_reason === FIReasons[1])
+    );
+    expect(getPlansArrayByParentJurisdictionId(store.getState(), parentJurisdictionFilter)).toEqual(
+      values(allPlans).filter(e => e.jurisdiction_path.includes('2977'))
     );
     expect(
       getPlansArrayByInterventionTypeAndJurisdictionId(store.getState(), {

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -82,6 +82,8 @@ describe('reducers/plans', () => {
     ]);
     expect(getPlansIdArray(store.getState(), InterventionType.IRS)).toEqual(['plan-id-2']);
 
+    expect(plansArraySelector(store.getState())).toEqual(values(allPlans));
+
     expect(getPlansArray(store.getState(), InterventionType.FI, [], null)).toEqual(values(fiPlans));
     expect(getPlansArray(store.getState(), InterventionType.IRS, [], null)).toEqual(
       values(irsPlans)

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -24,7 +24,7 @@ import reducer, {
   Plan,
   PlanRecord,
   PlanRecordResponse,
-  plansArraySelector,
+  plansArrayBaseSelector,
   PlanStatus,
   reducerName,
   removePlansAction,
@@ -51,7 +51,7 @@ describe('reducers/plans', () => {
     expect(getPlanRecordsById(store.getState())).toEqual({});
     expect(getPlanRecordsIdArray(store.getState())).toEqual([]);
     expect(getPlanRecordsArray(store.getState())).toEqual([]);
-    expect(plansArraySelector(store.getState())).toEqual([]);
+    expect(plansArrayBaseSelector(store.getState())).toEqual([]);
     expect(getPlanRecordById(store.getState(), 'somId')).toEqual(null);
     expect(getPlansArray(store.getState())).toEqual([]);
   });
@@ -88,7 +88,7 @@ describe('reducers/plans', () => {
     ]);
     expect(getPlansIdArray(store.getState(), InterventionType.IRS)).toEqual(['plan-id-2']);
 
-    expect(plansArraySelector(store.getState())).toEqual(values(allPlans));
+    expect(plansArrayBaseSelector(store.getState())).toEqual(values(allPlans));
 
     expect(getPlansArray(store.getState(), InterventionType.FI, [], null)).toEqual(values(fiPlans));
     expect(getPlansArray(store.getState(), InterventionType.IRS, [], null)).toEqual(

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -171,12 +171,14 @@ describe('reducers/plans', () => {
         reason: FIReasons[1],
       })
     ).toEqual(values(reactivePlans));
+
     expect(
       plansArraySelector(store.getState(), {
         interventionType: InterventionType.FI,
         reason: FIReasons[0],
       })
     ).toEqual(values(routinePlans));
+
     expect(
       plansArraySelector(store.getState(), {
         interventionType: InterventionType.FI,
@@ -184,6 +186,24 @@ describe('reducers/plans', () => {
         statusList: [PlanStatus.DRAFT],
       })
     ).toEqual(values(reactiveDraftPlans));
+
+    expect(
+      plansArraySelector(store.getState(), {
+        interventionType: InterventionType.FI,
+        jurisdictionIds: ['450fc15b-5bd2-468a-927a-49cb10d3bcac'],
+        parentJurisdictionId: '2939',
+        reason: FIReasons[0],
+        statusList: [PlanStatus.ACTIVE],
+      })
+    ).toEqual(
+      values(fiPlans).filter(
+        e =>
+          e.plan_fi_reason === FIReasons[0] &&
+          e.jurisdiction_path.includes('2939') &&
+          e.plan_status === PlanStatus.ACTIVE &&
+          e.jurisdiction_id === '450fc15b-5bd2-468a-927a-49cb10d3bcac'
+      )
+    );
   });
 
   it('filters correctly when jurisdiction_parent_id is provided', () => {

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -18,6 +18,7 @@ import reducer, {
   Plan,
   PlanRecord,
   PlanRecordResponse,
+  plansArraySelector,
   PlanStatus,
   reducerName,
   removePlansAction,
@@ -44,6 +45,7 @@ describe('reducers/plans', () => {
     expect(getPlanRecordsById(store.getState())).toEqual({});
     expect(getPlanRecordsIdArray(store.getState())).toEqual([]);
     expect(getPlanRecordsArray(store.getState())).toEqual([]);
+    expect(plansArraySelector(store.getState())).toEqual([]);
     expect(getPlanRecordById(store.getState(), 'somId')).toEqual(null);
     expect(getPlansArray(store.getState())).toEqual([]);
   });

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -180,6 +180,7 @@ describe('reducers/plans', () => {
     expect(
       plansArraySelector(store.getState(), {
         interventionType: InterventionType.FI,
+        reason: FIReasons[1],
         statusList: [PlanStatus.DRAFT],
       })
     ).toEqual(values(reactiveDraftPlans));

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -12,6 +12,9 @@ import reducer, {
   getPlanRecordsById,
   getPlanRecordsIdArray,
   getPlansArray,
+  getPlansArrayByInterventionType,
+  getPlansArrayByInterventionTypeAndJurisdictionId,
+  getPlansArrayByJurisdictionId,
   getPlansById,
   getPlansIdArray,
   InterventionType,
@@ -117,6 +120,27 @@ describe('reducers/plans', () => {
 
     expect(getPlanById(store.getState(), 'ed2b4b7c-3388-53d9-b9f6-6a19d1ffde1f')).toEqual(
       allPlans['ed2b4b7c-3388-53d9-b9f6-6a19d1ffde1f']
+    );
+
+    // RESELECT TESTS
+    const fiFilter = {
+      interventionType: InterventionType.FI,
+    };
+    const jurisdictionFilter = {
+      jurisdictionId: '450fc15b-5bd2-468a-927a-49cb10d3bcac',
+    };
+    expect(getPlansArrayByInterventionType(store.getState(), {})).toEqual(values(allPlans));
+    expect(getPlansArrayByInterventionType(store.getState(), fiFilter)).toEqual(values(fiPlans));
+    expect(getPlansArrayByJurisdictionId(store.getState(), jurisdictionFilter)).toEqual(
+      values(allPlans).filter(e => e.jurisdiction_id === '450fc15b-5bd2-468a-927a-49cb10d3bcac')
+    );
+    expect(
+      getPlansArrayByInterventionTypeAndJurisdictionId(store.getState(), {
+        ...fiFilter,
+        ...jurisdictionFilter,
+      })
+    ).toEqual(
+      values(fiPlans).filter(e => e.jurisdiction_id === '450fc15b-5bd2-468a-927a-49cb10d3bcac')
     );
   });
 

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -15,6 +15,7 @@ import reducer, {
   getPlansArrayByInterventionType,
   getPlansArrayByInterventionTypeAndJurisdictionId,
   getPlansArrayByJurisdictionId,
+  getPlansArrayByReason,
   getPlansArrayByStatus,
   getPlansById,
   getPlansIdArray,
@@ -133,6 +134,9 @@ describe('reducers/plans', () => {
     const statusFilter = {
       statusList: [PlanStatus.DRAFT],
     };
+    const reasonFilter = {
+      reason: FIReasons[1],
+    };
 
     expect(getPlansArrayByInterventionType(store.getState(), {})).toEqual(values(allPlans));
     expect(getPlansArrayByInterventionType(store.getState(), fiFilter)).toEqual(values(fiPlans));
@@ -141,6 +145,9 @@ describe('reducers/plans', () => {
     );
     expect(getPlansArrayByStatus(store.getState(), statusFilter)).toEqual(
       values(allPlans).filter(e => e.plan_status === PlanStatus.DRAFT)
+    );
+    expect(getPlansArrayByReason(store.getState(), reasonFilter)).toEqual(
+      values(allPlans).filter(e => e.plan_fi_reason === FIReasons[1])
     );
     expect(
       getPlansArrayByInterventionTypeAndJurisdictionId(store.getState(), {

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -20,11 +20,11 @@ import reducer, {
   getPlansById,
   getPlansIdArray,
   InterventionType,
+  makePlansArraySelector,
   Plan,
   PlanRecord,
   PlanRecordResponse,
   plansArrayBaseSelector,
-  plansArraySelector,
   PlanStatus,
   reducerName,
   removePlansAction,
@@ -58,6 +58,9 @@ describe('reducers/plans', () => {
 
   it('should fetch Plans', () => {
     store.dispatch(fetchPlans(fixtures.plans));
+
+    const plansArraySelector = makePlansArraySelector();
+
     const allPlans = keyBy(fixtures.plans, (plan: Plan) => plan.id);
     const fiPlans = pickBy(allPlans, (e: Plan) => e.plan_intervention_type === InterventionType.FI);
     const irsPlans = pickBy(

--- a/src/store/tests/ducks/random.ts
+++ b/src/store/tests/ducks/random.ts
@@ -4,6 +4,9 @@ export const reducerName = 'random';
 
 const initialState: string = '';
 
+// actions
+export const SET_RANDOM = 'reveal-test/reducer/SET_RANDOM';
+
 export default function reducer(state = initialState, action: AnyAction): string {
   switch (action.type) {
     case SET_RANDOM:
@@ -15,6 +18,3 @@ export default function reducer(state = initialState, action: AnyAction): string
       return state;
   }
 }
-
-// actions
-export const SET_RANDOM = 'reveal-test/reducer/SET_RANDOM';

--- a/yarn.lock
+++ b/yarn.lock
@@ -12153,6 +12153,11 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6130,6 +6130,11 @@ fast-levenshtein@~2.0.4:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast_array_intersect@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast_array_intersect/-/fast_array_intersect-1.1.0.tgz#8e8a83d95c515fd55bfb2b02da94da3d7f1c2b8b"
+  integrity sha512-/DCilZlUdz2XyNDF+ASs0PwY+RKG9Y4Silp/gbS72Cvbg4oibc778xcecg+pnNyiNHYgh/TApsiDTjpdniyShw==
+
 fastparse@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"


### PR DESCRIPTION
This PR adds Reselect, thereby Fixes #699.

Reselect is added in the plans reducer module in a way that the new selector, `plansArraySelector`,  effectively can fully replace `getPlanRecordsArray`.

`getPlanRecordsArray` should be fully replaced via #702

This is meant to support #692 and #651