### PR TITLE
Remove server from transpiled folders

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
     "noEmit": true,
     "jsx": "preserve"
   },
-  "include": ["src", "server"],
-  "exclude": ["server/dist"]
+  "include": ["src"],
+  "exclude": ["server"]
 }


### PR DESCRIPTION
Yeah , i am only removing the server folder from the files that typescript can transpile from within the parent directory.

I am hoping this can act as a temporary fix to :
- when building from the parent directory typescript complains that files in server contain missing types.

When we build the react application we usually have not interest whatsoever in the server folder directories