### PR TITLE
Improve test coverage for helpers/hooks

### DIFF
--- a/src/helpers/tests/hooks.test.tsx
+++ b/src/helpers/tests/hooks.test.tsx
@@ -1,0 +1,21 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import { useConfirmOnBrowserUnload } from '../hooks';
+
+const TestHook = ({ callback }: { callback: any }) => {
+  callback();
+  return null;
+};
+
+const testHook = (callback: any) => {
+  mount(<TestHook callback={callback} />);
+};
+
+describe('Display confimation alert on browser unload', () => {
+  it('should add beforeunload event successfully', async () => {
+    const spyAddEvent = jest.spyOn(window, 'addEventListener');
+    testHook(() => useConfirmOnBrowserUnload(true));
+    window.dispatchEvent(new Event('beforeunload'));
+    expect(spyAddEvent).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+  });
+});


### PR DESCRIPTION
Closes #667 
The function`useConfirmOnBrowserUnload`  houses a `React Hook` which has to run within the context of a `component`.  `TestHook` acts as a component from which we can load `useConfirmOnBrowserUnload` safely.
