### PR TITLE
Replace getPlanRecordsArray function.

### DIFF
--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -44,6 +44,7 @@ export const MOSQUITO_COLLECTION_ACTIVITY_CODE = 'mosquitoCollection';
 export const GA_ENV_TEST = 'test';
 export const PLAN_ID = 'plan_id';
 export const PLAN_INTERVENTION_TYPE = 'plan_intervention_type';
+export const PLAN_RECORD_BY_ID = 'planRecordsById';
 
 // internal urls
 export const LOGIN_URL = '/login';

--- a/src/containers/pages/IRS/assignments/index.tsx
+++ b/src/containers/pages/IRS/assignments/index.tsx
@@ -19,7 +19,12 @@ import {
   TITLE,
 } from '../../../../configs/lang';
 import { planStatusDisplay } from '../../../../configs/settings';
-import { ASSIGN_PLAN_URL, HOME_URL, REPORT_IRS_PLAN_URL } from '../../../../constants';
+import {
+  ASSIGN_PLAN_URL,
+  HOME_URL,
+  PLAN_RECORD_BY_ID,
+  REPORT_IRS_PLAN_URL,
+} from '../../../../constants';
 import { displayError } from '../../../../helpers/errors';
 import { OpenSRPService } from '../../../../services/opensrp';
 import IRSPlansReducer, {
@@ -41,7 +46,7 @@ reducerRegistry.register(IRSPlansReducerName, IRSPlansReducer);
 const OpenSrpPlanService = new OpenSRPService('plans');
 
 /** Plans filter selector */
-const plansArraySelector = makePlansArraySelector('planRecordsById');
+const plansArraySelector = makePlansArraySelector(PLAN_RECORD_BY_ID);
 
 /** interface for PlanAssignmentsListProps props */
 interface PlanAssignmentsListProps {

--- a/src/containers/pages/IRS/assignments/index.tsx
+++ b/src/containers/pages/IRS/assignments/index.tsx
@@ -1,5 +1,6 @@
 import ListView from '@onaio/list-view';
 import reducerRegistry from '@onaio/redux-reducer-registry';
+import { Registry } from '@onaio/redux-reducer-registry';
 import React, { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
@@ -28,8 +29,8 @@ import IRSPlansReducer, {
 import {
   extractPlanRecordResponseFromPlanPayload,
   fetchPlanRecords,
-  getPlanRecordsArray,
   InterventionType,
+  makePlansArraySelector,
   PlanRecord,
   PlanRecordResponse,
   PlanStatus,
@@ -39,6 +40,9 @@ import {
 reducerRegistry.register(IRSPlansReducerName, IRSPlansReducer);
 
 const OpenSrpPlanService = new OpenSRPService('plans');
+
+/** Plans filter selector */
+const plansArraySelector = makePlansArraySelector('planRecordsById');
 
 /** interface for PlanAssignmentsListProps props */
 interface PlanAssignmentsListProps {
@@ -155,9 +159,18 @@ interface DispatchedStateProps {
 /** map state to props */
 const mapStateToProps = (state: Partial<Store>): DispatchedStateProps => {
   const planStatus = [PlanStatus.ACTIVE];
-  const fiPlans = getPlanRecordsArray(state, InterventionType.FI, planStatus);
-  const irsPlans = getPlanRecordsArray(state, InterventionType.IRS, planStatus);
-  const mdaPlans = getPlanRecordsArray(state, InterventionType.MDA, planStatus);
+  const fiPlans = plansArraySelector(state as Registry, {
+    interventionType: InterventionType.FI,
+    statusList: planStatus,
+  });
+  const irsPlans = plansArraySelector(state as Registry, {
+    interventionType: InterventionType.IRS,
+    statusList: planStatus,
+  });
+  const mdaPlans = plansArraySelector(state as Registry, {
+    interventionType: InterventionType.MDA,
+    statusList: planStatus,
+  });
   const plans = [...fiPlans, ...irsPlans, ...mdaPlans].sort(
     (a: PlanRecord, b: PlanRecord) => Date.parse(b.plan_date) - Date.parse(a.plan_date)
   );

--- a/src/containers/pages/IRS/assignments/index.tsx
+++ b/src/containers/pages/IRS/assignments/index.tsx
@@ -1,6 +1,5 @@
 import ListView from '@onaio/list-view';
-import reducerRegistry from '@onaio/redux-reducer-registry';
-import { Registry } from '@onaio/redux-reducer-registry';
+import reducerRegistry, { Registry } from '@onaio/redux-reducer-registry';
 import React, { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';

--- a/src/containers/pages/InterventionPlan/IRS/index.tsx
+++ b/src/containers/pages/InterventionPlan/IRS/index.tsx
@@ -40,9 +40,9 @@ import plansReducer, {
   extractPlanRecordResponseFromPlanPayload,
   fetchPlanRecords,
   fetchPlans,
-  getPlanRecordsArray,
   getPlansArray,
   InterventionType,
+  makePlansArraySelector,
   Plan,
   PlanPayload,
   PlanRecord,
@@ -51,6 +51,7 @@ import plansReducer, {
   reducerName as plansReducerName,
 } from '../../../../store/ducks/plans';
 
+import { Registry } from '@onaio/redux-reducer-registry';
 import { Helmet } from 'react-helmet';
 import DrillDownTableLinkedCell from '../../../../components/DrillDownTableLinkedCell';
 import HeaderBreadcrumbs, {
@@ -85,6 +86,9 @@ export const defaultIrsPlansProps: IrsPlansProps = {
   pageTitle: '',
   plansArray: [],
 };
+
+/** Plans filter selector */
+const plansArraySelector = makePlansArraySelector('planRecordsById');
 
 /** IrsPlans - component for IRS Plans page */
 class IrsPlans extends React.Component<IrsPlansProps & RouteComponentProps<RouteParams>, {}> {
@@ -243,7 +247,10 @@ const mapStateToProps = (state: Partial<Store>, ownProps: any): DispatchedStateP
   const isDraftsList = ownProps.path === INTERVENTION_IRS_DRAFTS_URL;
   const planStatus = [PlanStatus.DRAFT];
   const pageTitle = `${IRS_PLANS}${isDraftsList ? ` ${DRAFTS_PARENTHESIS}` : ''}`;
-  const plansRecordsArray = getPlanRecordsArray(state, InterventionType.IRS, planStatus);
+  const plansRecordsArray = plansArraySelector(state as Registry, {
+    interventionType: InterventionType.IRS,
+    statusList: planStatus,
+  });
   const plansArray = getPlansArray(state, InterventionType.IRS, planStatus);
 
   const props = {

--- a/src/containers/pages/InterventionPlan/IRS/index.tsx
+++ b/src/containers/pages/InterventionPlan/IRS/index.tsx
@@ -30,6 +30,7 @@ import {
   INTERVENTION_IRS_URL,
   NEW,
   PLAN,
+  PLAN_RECORD_BY_ID,
   REPORT,
 } from '../../../../constants';
 
@@ -87,7 +88,7 @@ export const defaultIrsPlansProps: IrsPlansProps = {
 };
 
 /** Plans filter selector */
-const plansArraySelector = makePlansArraySelector('planRecordsById');
+const plansArraySelector = makePlansArraySelector(PLAN_RECORD_BY_ID);
 
 /** IrsPlans - component for IRS Plans page */
 class IrsPlans extends React.Component<IrsPlansProps & RouteComponentProps<RouteParams>, {}> {

--- a/src/containers/pages/InterventionPlan/IRS/index.tsx
+++ b/src/containers/pages/InterventionPlan/IRS/index.tsx
@@ -8,7 +8,7 @@ import { Button } from 'reactstrap';
 import { Store } from 'redux';
 
 import DrillDownTable from '@onaio/drill-down-table';
-import reducerRegistry from '@onaio/redux-reducer-registry';
+import reducerRegistry, { Registry } from '@onaio/redux-reducer-registry';
 import superset from '@onaio/superset-connector';
 
 import {
@@ -51,7 +51,6 @@ import plansReducer, {
   reducerName as plansReducerName,
 } from '../../../../store/ducks/plans';
 
-import { Registry } from '@onaio/redux-reducer-registry';
 import { Helmet } from 'react-helmet';
 import DrillDownTableLinkedCell from '../../../../components/DrillDownTableLinkedCell';
 import HeaderBreadcrumbs, {

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -533,8 +533,8 @@ export interface PlanFilters {
 /** plansArrayBaseSelector select an array of all plans
  * @param state - the redux store
  */
-export const plansArrayBaseSelector = (state: Registry): Plan[] =>
-  values((state as any)[reducerName].plansById);
+export const plansArrayBaseSelector = (planFilter?: string) => (state: Registry): Plan[] =>
+  values((state as any)[reducerName][planFilter ? planFilter : 'plansById']);
 
 /** getInterventionType
  * Gets interventionType from PlanFilters
@@ -577,68 +577,73 @@ export const getReason = (_: Registry, props: PlanFilters) => props.reason;
  * @param {Registry} state - the redux store
  * @param {PlanFilters} props - the plan filters object
  */
-export const getPlansArrayByInterventionType = createSelector(
-  [plansArrayBaseSelector, getInterventionType],
-  (plans, interventionType) =>
-    interventionType
-      ? plans.filter(plan => plan.plan_intervention_type === interventionType)
-      : plans
-);
+export const getPlansArrayByInterventionType = (planFilter?: string) =>
+  createSelector(
+    [plansArrayBaseSelector(planFilter), getInterventionType],
+    (plans, interventionType) =>
+      interventionType
+        ? plans.filter(plan => plan.plan_intervention_type === interventionType)
+        : plans
+  );
 
 /** getPlansArrayByJurisdictionIds
  * Gets an array of Plan objects filtered by jurisdictionIds
  * @param {Registry} state - the redux store
  * @param {PlanFilters} props - the plan filters object
  */
-export const getPlansArrayByJurisdictionIds = createSelector(
-  [plansArrayBaseSelector, getJurisdictionIds],
-  (plans, jurisdictionIds) =>
-    jurisdictionIds
-      ? plans.filter(plan =>
-          jurisdictionIds.length ? jurisdictionIds.includes(plan.jurisdiction_id) : true
-        )
-      : plans
-);
+export const getPlansArrayByJurisdictionIds = (planFilter?: string) =>
+  createSelector(
+    [plansArrayBaseSelector(planFilter), getJurisdictionIds],
+    (plans, jurisdictionIds) =>
+      jurisdictionIds
+        ? plans.filter(plan =>
+            jurisdictionIds.length ? jurisdictionIds.includes(plan.jurisdiction_id) : true
+          )
+        : plans
+  );
 
 /** getPlansArrayByStatus
  * Gets an array of Plan objects filtered by plan status
  * @param {Registry} state - the redux store
  * @param {PlanFilters} props - the plan filters object
  */
-export const getPlansArrayByStatus = createSelector(
-  [plansArrayBaseSelector, getStatusList],
-  (plans, statusList) =>
-    statusList
-      ? plans.filter(plan => (statusList.length ? statusList.includes(plan.plan_status) : true))
-      : plans
-);
+export const getPlansArrayByStatus = (planFilter?: string) =>
+  createSelector(
+    [plansArrayBaseSelector(planFilter), getStatusList],
+    (plans, statusList) =>
+      statusList
+        ? plans.filter(plan => (statusList.length ? statusList.includes(plan.plan_status) : true))
+        : plans
+  );
 
 /** getPlansArrayByReason
  * Gets an array of Plan objects filtered by FI plan reason
  * @param {Registry} state - the redux store
  * @param {PlanFilters} props - the plan filters object
  */
-export const getPlansArrayByReason = createSelector(
-  [plansArrayBaseSelector, getReason],
-  (plans, reason) => (reason ? plans.filter(plan => plan.plan_fi_reason === reason) : plans)
-);
+export const getPlansArrayByReason = (planFilter?: string) =>
+  createSelector(
+    [plansArrayBaseSelector(planFilter), getReason],
+    (plans, reason) => (reason ? plans.filter(plan => plan.plan_fi_reason === reason) : plans)
+  );
 
 /** getPlansArrayByParentJurisdictionId
  * Gets an array of Plan objects filtered by plan jurisdiction parent_id
  * @param {Registry} state - the redux store
  * @param {PlanFilters} props - the plan filters object
  */
-export const getPlansArrayByParentJurisdictionId = createSelector(
-  [plansArrayBaseSelector, getParentJurisdictionId],
-  (plans, parentJurisdictionId) =>
-    plans.filter(
-      plan =>
-        (parentJurisdictionId && !plan.jurisdiction_path ? false : true) &&
-        (parentJurisdictionId && plan.jurisdiction_path
-          ? plan.jurisdiction_path.includes(parentJurisdictionId)
-          : true)
-    )
-);
+export const getPlansArrayByParentJurisdictionId = (planFilter?: string) =>
+  createSelector(
+    [plansArrayBaseSelector(planFilter), getParentJurisdictionId],
+    (plans, parentJurisdictionId) =>
+      plans.filter(
+        plan =>
+          (parentJurisdictionId && !plan.jurisdiction_path ? false : true) &&
+          (parentJurisdictionId && plan.jurisdiction_path
+            ? plan.jurisdiction_path.includes(parentJurisdictionId)
+            : true)
+      )
+  );
 
 /** makePlansArraySelector
  * Returns a selector that gets an array of Plan objects filtered by one or all
@@ -659,14 +664,14 @@ export const getPlansArrayByParentJurisdictionId = createSelector(
  * @param {Registry} state - the redux store
  * @param {PlanFilters} props - the plan filters object
  */
-export const makePlansArraySelector = () => {
+export const makePlansArraySelector = (planFilter?: string) => {
   return createSelector(
     [
-      getPlansArrayByInterventionType,
-      getPlansArrayByJurisdictionIds,
-      getPlansArrayByStatus,
-      getPlansArrayByReason,
-      getPlansArrayByParentJurisdictionId,
+      getPlansArrayByInterventionType(planFilter),
+      getPlansArrayByJurisdictionIds(planFilter),
+      getPlansArrayByStatus(planFilter),
+      getPlansArrayByReason(planFilter),
+      getPlansArrayByParentJurisdictionId(planFilter),
     ],
     (plans, plans2, plans3, plans4, plans5) =>
       intersect([plans, plans2, plans3, plans4, plans5], JSON.stringify)

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -533,8 +533,8 @@ export interface PlanFilters {
 /** plansArrayBaseSelector select an array of all plans
  * @param state - the redux store
  */
-export const plansArrayBaseSelector = (planFilter?: string) => (state: Registry): Plan[] =>
-  values((state as any)[reducerName][planFilter ? planFilter : 'plansById']);
+export const plansArrayBaseSelector = (planKey?: string) => (state: Registry): Plan[] =>
+  values((state as any)[reducerName][planKey ? planKey : 'plansById']);
 
 /** getInterventionType
  * Gets interventionType from PlanFilters
@@ -577,9 +577,9 @@ export const getReason = (_: Registry, props: PlanFilters) => props.reason;
  * @param {Registry} state - the redux store
  * @param {PlanFilters} props - the plan filters object
  */
-export const getPlansArrayByInterventionType = (planFilter?: string) =>
+export const getPlansArrayByInterventionType = (planKey?: string) =>
   createSelector(
-    [plansArrayBaseSelector(planFilter), getInterventionType],
+    [plansArrayBaseSelector(planKey), getInterventionType],
     (plans, interventionType) =>
       interventionType
         ? plans.filter(plan => plan.plan_intervention_type === interventionType)
@@ -591,9 +591,9 @@ export const getPlansArrayByInterventionType = (planFilter?: string) =>
  * @param {Registry} state - the redux store
  * @param {PlanFilters} props - the plan filters object
  */
-export const getPlansArrayByJurisdictionIds = (planFilter?: string) =>
+export const getPlansArrayByJurisdictionIds = (planKey?: string) =>
   createSelector(
-    [plansArrayBaseSelector(planFilter), getJurisdictionIds],
+    [plansArrayBaseSelector(planKey), getJurisdictionIds],
     (plans, jurisdictionIds) =>
       jurisdictionIds
         ? plans.filter(plan =>
@@ -607,9 +607,9 @@ export const getPlansArrayByJurisdictionIds = (planFilter?: string) =>
  * @param {Registry} state - the redux store
  * @param {PlanFilters} props - the plan filters object
  */
-export const getPlansArrayByStatus = (planFilter?: string) =>
+export const getPlansArrayByStatus = (plantype?: string) =>
   createSelector(
-    [plansArrayBaseSelector(planFilter), getStatusList],
+    [plansArrayBaseSelector(plantype), getStatusList],
     (plans, statusList) =>
       statusList
         ? plans.filter(plan => (statusList.length ? statusList.includes(plan.plan_status) : true))
@@ -621,9 +621,9 @@ export const getPlansArrayByStatus = (planFilter?: string) =>
  * @param {Registry} state - the redux store
  * @param {PlanFilters} props - the plan filters object
  */
-export const getPlansArrayByReason = (planFilter?: string) =>
+export const getPlansArrayByReason = (planKey?: string) =>
   createSelector(
-    [plansArrayBaseSelector(planFilter), getReason],
+    [plansArrayBaseSelector(planKey), getReason],
     (plans, reason) => (reason ? plans.filter(plan => plan.plan_fi_reason === reason) : plans)
   );
 
@@ -632,9 +632,9 @@ export const getPlansArrayByReason = (planFilter?: string) =>
  * @param {Registry} state - the redux store
  * @param {PlanFilters} props - the plan filters object
  */
-export const getPlansArrayByParentJurisdictionId = (planFilter?: string) =>
+export const getPlansArrayByParentJurisdictionId = (planKey?: string) =>
   createSelector(
-    [plansArrayBaseSelector(planFilter), getParentJurisdictionId],
+    [plansArrayBaseSelector(planKey), getParentJurisdictionId],
     (plans, parentJurisdictionId) =>
       plans.filter(
         plan =>
@@ -664,14 +664,14 @@ export const getPlansArrayByParentJurisdictionId = (planFilter?: string) =>
  * @param {Registry} state - the redux store
  * @param {PlanFilters} props - the plan filters object
  */
-export const makePlansArraySelector = (planFilter?: string) => {
+export const makePlansArraySelector = (planKey?: string) => {
   return createSelector(
     [
-      getPlansArrayByInterventionType(planFilter),
-      getPlansArrayByJurisdictionIds(planFilter),
-      getPlansArrayByStatus(planFilter),
-      getPlansArrayByReason(planFilter),
-      getPlansArrayByParentJurisdictionId(planFilter),
+      getPlansArrayByInterventionType(planKey),
+      getPlansArrayByJurisdictionIds(planKey),
+      getPlansArrayByStatus(planKey),
+      getPlansArrayByReason(planKey),
+      getPlansArrayByParentJurisdictionId(planKey),
     ],
     (plans, plans2, plans3, plans4, plans5) =>
       intersect([plans, plans2, plans3, plans4, plans5], JSON.stringify)

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -476,26 +476,6 @@ export function getPlanRecordsById(
   );
 }
 
-/** getPlanRecordsArray - get an array of PlanRecords
- * @param {Partial<Store>} state - the redux store
- * @param {InterventionType} intervention - the intervention type
- * @param {string[]} status - the plan statuses
- * @param {string} reason - the plan reason
- */
-export function getPlanRecordsArray(
-  state: Partial<Store>,
-  intervention: InterventionType | null = null,
-  statusList: string[] = [PlanStatus.ACTIVE],
-  reason: string | null = null
-): PlanRecord[] {
-  return values((state as any)[reducerName].planRecordsById).filter(
-    (plan: PlanRecord) =>
-      (intervention ? plan.plan_intervention_type === intervention : true) &&
-      (statusList.length ? statusList.includes(plan.plan_status) : true) &&
-      (reason ? plan.plan_fi_reason === reason : true)
-  );
-}
-
 /** getPlanRecordsIdArray - get an array of PlanRecord ids
  * @param {Partial<Store>} state - the redux store
  * @param {InterventionType} intervention - the intervention type

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -8,7 +8,6 @@ import reducer, {
   fetchPlans,
   getPlanById,
   getPlanRecordById,
-  getPlanRecordsArray,
   getPlanRecordsById,
   getPlanRecordsIdArray,
   getPlansArray,
@@ -50,7 +49,6 @@ describe('reducers/plans', () => {
     expect(getPlanById(store.getState(), 'someId')).toEqual(null);
     expect(getPlanRecordsById(store.getState())).toEqual({});
     expect(getPlanRecordsIdArray(store.getState())).toEqual([]);
-    expect(getPlanRecordsArray(store.getState())).toEqual([]);
     expect(plansArrayBaseSelector()(store.getState())).toEqual([]);
     expect(getPlanRecordById(store.getState(), 'somId')).toEqual(null);
     expect(getPlansArray(store.getState())).toEqual([]);
@@ -288,12 +286,7 @@ describe('reducers/plans', () => {
       plansArraySelector(store.getState(), { interventionType: InterventionType.IRS })
     ).toEqual(irsPlanRecordsArray);
 
-    expect(getPlanRecordsArray(store.getState(), InterventionType.FI)).toEqual(fiPlanRecordsArray);
-    expect(getPlanRecordsArray(store.getState(), InterventionType.IRS)).toEqual(
-      irsPlanRecordsArray
-    );
-
-    const planRecordsArray = [...getPlanRecordsArray(store.getState())].sort(
+    const planRecordsArray = [...plansArraySelector(store.getState(), {})].sort(
       (a: PlanRecord, b: PlanRecord) => Date.parse(b.plan_date) - Date.parse(a.plan_date)
     );
     expect(planRecordsArray).toEqual(fixtures.sortedPlanRecordArray);

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -2,6 +2,7 @@ import reducerRegistry from '@onaio/redux-reducer-registry';
 import { cloneDeep, keyBy, keys, pickBy, values } from 'lodash';
 import { FlushThunks } from 'redux-testkit';
 import { FIReasons } from '../../../configs/settings';
+import { PLAN_RECORD_BY_ID } from '../../../constants';
 import store from '../../index';
 import reducer, {
   fetchPlanRecords,
@@ -256,7 +257,7 @@ describe('reducers/plans', () => {
   it('should fetch PlanRecords', () => {
     store.dispatch(fetchPlanRecords(fixtures.planRecordResponses as PlanRecordResponse[]));
     const { planRecordsById: allPlanRecords } = fixtures;
-    const plansArraySelector = makePlansArraySelector('planRecordsById');
+    const plansArraySelector = makePlansArraySelector(PLAN_RECORD_BY_ID);
 
     const fiPlanRecords = pickBy(
       allPlanRecords,

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -51,7 +51,7 @@ describe('reducers/plans', () => {
     expect(getPlanRecordsById(store.getState())).toEqual({});
     expect(getPlanRecordsIdArray(store.getState())).toEqual([]);
     expect(getPlanRecordsArray(store.getState())).toEqual([]);
-    expect(plansArrayBaseSelector(store.getState())).toEqual([]);
+    expect(plansArrayBaseSelector()(store.getState())).toEqual([]);
     expect(getPlanRecordById(store.getState(), 'somId')).toEqual(null);
     expect(getPlansArray(store.getState())).toEqual([]);
   });
@@ -91,7 +91,7 @@ describe('reducers/plans', () => {
     ]);
     expect(getPlansIdArray(store.getState(), InterventionType.IRS)).toEqual(['plan-id-2']);
 
-    expect(plansArrayBaseSelector(store.getState())).toEqual(values(allPlans));
+    expect(plansArrayBaseSelector()(store.getState())).toEqual(values(allPlans));
 
     expect(getPlansArray(store.getState(), InterventionType.FI, [], null)).toEqual(values(fiPlans));
     expect(getPlansArray(store.getState(), InterventionType.IRS, [], null)).toEqual(
@@ -145,20 +145,20 @@ describe('reducers/plans', () => {
       parentJurisdictionId: '2977',
     };
 
-    expect(getPlansArrayByInterventionType(store.getState(), {})).toEqual(values(allPlans));
-    expect(getPlansArrayByInterventionType(store.getState(), fiFilter)).toEqual(values(fiPlans));
-    expect(getPlansArrayByJurisdictionIds(store.getState(), jurisdictionFilter)).toEqual(
+    expect(getPlansArrayByInterventionType()(store.getState(), {})).toEqual(values(allPlans));
+    expect(getPlansArrayByInterventionType()(store.getState(), fiFilter)).toEqual(values(fiPlans));
+    expect(getPlansArrayByJurisdictionIds()(store.getState(), jurisdictionFilter)).toEqual(
       values(allPlans).filter(e => e.jurisdiction_id === '450fc15b-5bd2-468a-927a-49cb10d3bcac')
     );
-    expect(getPlansArrayByStatus(store.getState(), statusFilter)).toEqual(
+    expect(getPlansArrayByStatus()(store.getState(), statusFilter)).toEqual(
       values(allPlans).filter(e => e.plan_status === PlanStatus.DRAFT)
     );
-    expect(getPlansArrayByReason(store.getState(), reasonFilter)).toEqual(
+    expect(getPlansArrayByReason()(store.getState(), reasonFilter)).toEqual(
       values(allPlans).filter(e => e.plan_fi_reason === FIReasons[1])
     );
-    expect(getPlansArrayByParentJurisdictionId(store.getState(), parentJurisdictionFilter)).toEqual(
-      values(allPlans).filter(e => e.jurisdiction_path.includes('2977'))
-    );
+    expect(
+      getPlansArrayByParentJurisdictionId()(store.getState(), parentJurisdictionFilter)
+    ).toEqual(values(allPlans).filter(e => e.jurisdiction_path.includes('2977')));
     expect(
       plansArraySelector(store.getState(), {
         ...fiFilter,
@@ -258,6 +258,7 @@ describe('reducers/plans', () => {
   it('should fetch PlanRecords', () => {
     store.dispatch(fetchPlanRecords(fixtures.planRecordResponses as PlanRecordResponse[]));
     const { planRecordsById: allPlanRecords } = fixtures;
+    const plansArraySelector = makePlansArraySelector('planRecordsById');
 
     const fiPlanRecords = pickBy(
       allPlanRecords,
@@ -279,6 +280,14 @@ describe('reducers/plans', () => {
 
     const fiPlanRecordsArray = values(fiPlanRecords);
     const irsPlanRecordsArray = values(irsPlanRecords);
+
+    expect(plansArraySelector(store.getState(), { interventionType: InterventionType.FI })).toEqual(
+      fiPlanRecordsArray
+    );
+    expect(
+      plansArraySelector(store.getState(), { interventionType: InterventionType.IRS })
+    ).toEqual(irsPlanRecordsArray);
+
     expect(getPlanRecordsArray(store.getState(), InterventionType.FI)).toEqual(fiPlanRecordsArray);
     expect(getPlanRecordsArray(store.getState(), InterventionType.IRS)).toEqual(
       irsPlanRecordsArray


### PR DESCRIPTION
Closes #702 
Replaces all occurrences of `getPlanRecordsArray` with `plansArraySelector`.
Refactors `makePlansArraySelector` to make it more configurable.