### PR TITLE
Fix the application auto logging out bug

### DIFF
--- a/src/components/page/CustomCallback/index.tsx
+++ b/src/components/page/CustomCallback/index.tsx
@@ -7,7 +7,7 @@ import { Redirect, RouteComponentProps, withRouter } from 'react-router';
 import { toast } from 'react-toastify';
 import { EXPRESS_OAUTH_GET_STATE_URL } from '../../../configs/env';
 import { WELCOME_BACK } from '../../../configs/lang';
-import { EXPRESS_LOGIN_URL, HOME_URL } from '../../../constants';
+import { EXPRESS_LOGIN_URL, HOME_URL, LOGOUT_URL } from '../../../constants';
 import { growl } from '../../../helpers/utils';
 import store from '../../../store';
 import Loading from '../Loading';
@@ -30,7 +30,21 @@ export const BaseSuccessfulLoginComponent: React.FC<RouteComponentProps> = props
 export const SuccessfulLoginComponent = withRouter(BaseSuccessfulLoginComponent);
 
 const BaseUnsuccessfulLogin: React.FC<RouteComponentProps> = props => {
-  window.location.href = `${EXPRESS_LOGIN_URL}${props.location.search}`;
+  let redirectTo = `${EXPRESS_LOGIN_URL}${props.location.search}`;
+  const indirectionURLs = [LOGOUT_URL];
+  /** we should probably sieve some routes from being passed on.
+   * For instance we don't need to redirect to logout since we are already in
+   * the Unsuccessful Login component, meaning we are already logged out.
+   */
+  const stringifiedUrls = indirectionURLs.map(url => querystring.stringify({ next: url }));
+  for (const url of stringifiedUrls) {
+    if (props.location.search.includes(url)) {
+      redirectTo = EXPRESS_LOGIN_URL;
+      break;
+    }
+  }
+
+  window.location.href = redirectTo;
   return <></>;
 };
 

--- a/src/components/page/CustomCallback/tests/index.test.tsx
+++ b/src/components/page/CustomCallback/tests/index.test.tsx
@@ -2,12 +2,17 @@ import { mount } from 'enzyme';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { Route, Switch } from 'react-router-dom';
-import { SuccessfulLoginComponent } from '..';
+import { SuccessfulLoginComponent, UnSuccessfulLogin } from '..';
+import { EXPRESS_LOGIN_URL } from '../../../../constants';
 
 const App = () => {
   return (
     <Switch>
       <Route exact={true} path="/callback" component={SuccessfulLoginComponent} />
+      {/* tslint:disable-next-line: jsx-no-lambda */}
+      <Route exact={true} path="/failedCallback" component={UnSuccessfulLogin} />
+      {/* tslint:disable-next-line: jsx-no-lambda */}
+      <Route path="/login" component={() => <div id="login" />} />
       {/* tslint:disable-next-line: jsx-no-lambda */}
       <Route path="/teams" component={() => <div id="teams" />} />
       {/* tslint:disable-next-line: jsx-no-lambda */}
@@ -17,7 +22,6 @@ const App = () => {
     </Switch>
   );
 };
-
 describe('src/components/page/CustomCallback.SuccessfulLogin', () => {
   it('renders correctly', () => {
     const wrapper = mount(
@@ -59,5 +63,73 @@ describe('src/components/page/CustomCallback.SuccessfulLogin', () => {
     );
     // should redirect to plans
     expect(wrapper.find('#plans').length).toEqual(1);
+  });
+});
+
+describe('src/components/page/CustomCallback.UnsuccessfulLogin', () => {
+  const ActualWindowLocation = window.location;
+  afterAll(() => {
+    window.location = ActualWindowLocation;
+  });
+  delete window.location;
+  const applyHrefMock = (mock: jest.Mock) => {
+    (window.location as any) = {
+      set href(url: string) {
+        mock(url);
+      },
+    };
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  it('renders unsuccessful login correctly', () => {
+    const hrefMock = jest.fn();
+    applyHrefMock(hrefMock);
+    mount(
+      <MemoryRouter
+        initialEntries={[{ pathname: `/failedCallback`, search: '', hash: '', state: {} }]}
+      >
+        <App />
+      </MemoryRouter>
+    );
+    expect(hrefMock).toBeCalledWith(EXPRESS_LOGIN_URL);
+  });
+
+  it('Appends correct path when searchParams is given', () => {
+    const hrefMock = jest.fn();
+    applyHrefMock(hrefMock);
+    mount(
+      <MemoryRouter
+        initialEntries={[
+          { pathname: `/failedCallback`, search: '?next=%2Fteams', hash: '', state: {} },
+        ]}
+      >
+        <App />
+      </MemoryRouter>
+    );
+    expect(hrefMock).toBeCalledWith(`${EXPRESS_LOGIN_URL}?next=%2Fteams`);
+  });
+
+  it('Redirects only to login if searchParam url is not allowable', () => {
+    const hrefMock = jest.fn();
+    applyHrefMock(hrefMock);
+    mount(
+      <MemoryRouter
+        initialEntries={[
+          {
+            hash: '',
+            pathname: `/failedCallback`,
+            search: '?next=%2Flogout',
+            state: {},
+          },
+        ]}
+      >
+        <App />
+      </MemoryRouter>
+    );
+    expect(hrefMock).toBeCalledWith(EXPRESS_LOGIN_URL);
   });
 });


### PR DESCRIPTION
**BUG** (There isn't an ticket for this.)
Currently visible on [staging](https://web.reveal-stage.smartregister.org/):

  login
  logout
  login
  Observe that you are not redirected to home, you are actually logget out.

**why**
the logout url is sometime appended to the express server login url as a next path that the express server should redirect to after logging in, therefor meaning that on the second login you actually got logged in and automatically logged out.

This Pr is intended to hopefully fix that issue.