### PR TITLE
Fix loadPlans service call in IRS plan page

### DIFF
--- a/src/configs/lang.ts
+++ b/src/configs/lang.ts
@@ -433,3 +433,7 @@ export const FAILED_TO_GET_EVENT_ID = translate(
   'FAILED_TO_GET_EVENT_ID',
   'Failed to extract event Id from plan'
 );
+export const FAILED_TO_EXTRACT_PLAN_RECORD = translate(
+  'FAILED_TO_EXTRACT_PLAN_RECORD',
+  'Failed to extract a plan record'
+);

--- a/src/configs/strings/en.json
+++ b/src/configs/strings/en.json
@@ -922,5 +922,9 @@
   "FAILED_TO_GET_EVENT_ID": {
     "message": "Failed to extract event id from plan",
     "description": "error message shown when app is unable to retrieve a value from a plan"
+  },
+  "FAILED_TO_EXTRACT_PLAN_RECORD": {
+    "message": "Failed to extract a plan record",
+    "description": "error message shown when utils for extracting a plan from a server response fails"
   }
 }

--- a/src/containers/pages/IRS/assignments/index.tsx
+++ b/src/containers/pages/IRS/assignments/index.tsx
@@ -26,12 +26,12 @@ import {
   REPORT_IRS_PLAN_URL,
 } from '../../../../constants';
 import { displayError } from '../../../../helpers/errors';
+import { extractPlanRecordResponseFromPlanPayload } from '../../../../helpers/utils';
 import { OpenSRPService } from '../../../../services/opensrp';
 import IRSPlansReducer, {
   reducerName as IRSPlansReducerName,
 } from '../../../../store/ducks/generic/plans';
 import {
-  extractPlanRecordResponseFromPlanPayload,
   fetchPlanRecords,
   InterventionType,
   makePlansArraySelector,

--- a/src/containers/pages/InterventionPlan/IRS/index.tsx
+++ b/src/containers/pages/InterventionPlan/IRS/index.tsx
@@ -35,10 +35,9 @@ import {
 } from '../../../../constants';
 
 import { displayError } from '../../../../helpers/errors';
-import { RouteParams } from '../../../../helpers/utils';
+import { extractPlanRecordResponseFromPlanPayload, RouteParams } from '../../../../helpers/utils';
 import { OpenSRPService } from '../../../../services/opensrp';
 import plansReducer, {
-  extractPlanRecordResponseFromPlanPayload,
   fetchPlanRecords,
   fetchPlans,
   getPlansArray,

--- a/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
+++ b/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
@@ -260,8 +260,8 @@ class IrsPlan extends React.Component<
     // GET PLAN
     if (planId && !planById) {
       await OpenSrpPlanService.read(planId)
-        .then((plan: PlanPayload) => {
-          const planRecord = extractPlanRecordResponseFromPlanPayload(plan);
+        .then((plan: PlanPayload[]) => {
+          const planRecord = extractPlanRecordResponseFromPlanPayload(plan[0]);
           if (planRecord) {
             return fetchPlansActionCreator([planRecord]);
           }

--- a/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
+++ b/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
@@ -115,7 +115,6 @@ import plansReducer, {
   extractPlanRecordResponseFromPlanPayload,
   fetchPlanRecords,
   getPlanRecordById,
-  PlanPayload,
   PlanRecord,
   PlanStatus,
   reducerName as plansReducerName,
@@ -134,6 +133,7 @@ import AssignTeamTableCell, {
 } from '../../../../../components/forms/AssignTeamTableCell';
 import { ADMN0_PCODE, JurisdictionTypes } from '../../../../../configs/types';
 import './../../../../../styles/css/drill-down-table.css';
+import { loadPlan } from './serviceCalls';
 import './style.css';
 
 /** register the plans reducer */
@@ -259,14 +259,9 @@ class IrsPlan extends React.Component<
 
     // GET PLAN
     if (planId && !planById) {
-      await OpenSrpPlanService.read(planId)
-        .then((plan: PlanPayload[]) => {
-          const planRecord = extractPlanRecordResponseFromPlanPayload(plan[0]);
-          if (planRecord) {
-            return fetchPlansActionCreator([planRecord]);
-          }
-        })
-        .catch(err => err);
+      await loadPlan(OpenSRPService, planId, fetchPlansActionCreator).catch(err =>
+        displayError(err)
+      );
     } else if (planById) {
       this.setState({ newPlan: planById });
     }

--- a/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
+++ b/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
@@ -60,6 +60,8 @@ import {
 } from '../../../../../constants';
 import { displayError } from '../../../../../helpers/errors';
 import {
+  extractPlanPayloadFromPlanRecord,
+  extractPlanRecordResponseFromPlanPayload,
   FlexObject,
   getFeatureByProperty,
   getGisidaMapById,
@@ -111,8 +113,6 @@ import organizationsReducer, {
   reducerName as organizationsReducerName,
 } from '../../../../../store/ducks/opensrp/organizations';
 import plansReducer, {
-  extractPlanPayloadFromPlanRecord,
-  extractPlanRecordResponseFromPlanPayload,
   fetchPlanRecords,
   getPlanRecordById,
   PlanRecord,

--- a/src/containers/pages/InterventionPlan/IRS/plan/serviceCalls.ts
+++ b/src/containers/pages/InterventionPlan/IRS/plan/serviceCalls.ts
@@ -1,11 +1,8 @@
 import { OPENSRP_PLANS } from '../../../../../constants';
 import { displayError } from '../../../../../helpers/errors';
+import { extractPlanRecordResponseFromPlanPayload } from '../../../../../helpers/utils';
 import { OpenSRPService } from '../../../../../services/opensrp';
-import {
-  extractPlanRecordResponseFromPlanPayload,
-  fetchPlanRecords,
-  PlanPayload,
-} from '../../../../../store/ducks/plans';
+import { fetchPlanRecords, PlanPayload } from '../../../../../store/ducks/plans';
 
 type UUID = string;
 

--- a/src/containers/pages/InterventionPlan/IRS/plan/serviceCalls.ts
+++ b/src/containers/pages/InterventionPlan/IRS/plan/serviceCalls.ts
@@ -1,0 +1,31 @@
+import { OPENSRP_PLANS } from '../../../../../constants';
+import { displayError } from '../../../../../helpers/errors';
+import { OpenSRPService } from '../../../../../services/opensrp';
+import {
+  extractPlanRecordResponseFromPlanPayload,
+  fetchPlanRecords,
+  PlanPayload,
+} from '../../../../../store/ducks/plans';
+
+type UUID = string;
+
+/** loads a plan and dispatches action to add plan to store
+ * @param {OpenSRPService} service - the opensrp service
+ * @param {UUID} planId - uuid of the plan to be got in the api call
+ * @param {actionCreator} - action creator.
+ */
+export async function loadPlan(
+  service: typeof OpenSRPService,
+  planId: UUID,
+  actionCreator: typeof fetchPlanRecords
+) {
+  const OpenSrpPlanService = new service(OPENSRP_PLANS);
+  await OpenSrpPlanService.read(planId)
+    .then((plan: PlanPayload[]) => {
+      const planRecord = extractPlanRecordResponseFromPlanPayload(plan[0]);
+      if (planRecord) {
+        actionCreator([planRecord]);
+      }
+    })
+    .catch(err => displayError(err));
+}

--- a/src/containers/pages/InterventionPlan/IRS/plan/tests/serviceCalls.test.tsx
+++ b/src/containers/pages/InterventionPlan/IRS/plan/tests/serviceCalls.test.tsx
@@ -1,0 +1,55 @@
+import { OpenSRPService } from '../../../../../../services/opensrp';
+import { irsPlanDefinition1 } from '../../tests/fixtures';
+import { loadPlan } from '../serviceCalls';
+
+// tslint:disable-next-line: no-var-requires
+const fetch = require('jest-fetch-mock');
+
+describe('src/containers/pages/InterventionPlan/IRS/plan/serviceCals', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.clearAllMocks();
+  });
+
+  it('loadPlan works correctly', async () => {
+    // mock fetchPlanRecords
+    const actionCreatorMock = jest.fn();
+    fetch.once(JSON.stringify([irsPlanDefinition1]));
+
+    loadPlan(OpenSRPService, 'someId', actionCreatorMock).catch(err => err);
+    await new Promise(resolve => setImmediate(resolve));
+
+    // check the url ; calls are as expected
+    expect(fetch.mock.calls).toEqual([
+      [
+        'https://reveal-stage.smartregister.org/opensrp/rest/plans/someId',
+        {
+          headers: {
+            accept: 'application/json',
+            authorization: 'Bearer null',
+            'content-type': 'application/json;charset=UTF-8',
+          },
+          method: 'GET',
+        },
+      ],
+    ]);
+
+    // action creator called correctly
+    expect(actionCreatorMock).toHaveBeenCalledWith([
+      {
+        date: '2019-08-09',
+        effective_period_end: '2019-08-29',
+        effective_period_start: '2019-08-09',
+        fi_reason: 'Routine',
+        fi_status: 'A1',
+        identifier: '0230f9e8-1f30-5e91-8693-4c993661785e',
+        intervention_type: 'IRS',
+        jurisdictions: ['3952'],
+        name: 'IRS-2019-08-09',
+        status: 'draft',
+        title: 'IRS 2019-08-09',
+        version: '1',
+      },
+    ]);
+  });
+});

--- a/src/helpers/tests/utils.test.tsx
+++ b/src/helpers/tests/utils.test.tsx
@@ -13,14 +13,17 @@ import {
 } from '../../colors';
 import { ONADATA_OAUTH_STATE, OPENSRP_OAUTH_STATE, PLAN_UUID_NAMESPACE } from '../../configs/env';
 import { SORT_BY_EFFECTIVE_PERIOD_START_FIELD } from '../../constants';
+import { irsPlanDefinition1 } from '../../containers/pages/InterventionPlan/IRS/tests/fixtures';
 import { Plan } from '../../store/ducks/plans';
 import { InitialTask } from '../../store/ducks/tasks';
 import * as fixtures from '../../store/ducks/tests/fixtures';
 import { plan1, plan5, plan6, plan99, sortedPlansArray } from '../../store/ducks/tests/fixtures';
+import * as helpers from '../errors';
 import { colorMaps } from '../structureColorMaps';
 import {
   descendingOrderSort,
   extractPlan,
+  extractPlanRecordResponseFromPlanPayload,
   generateNameSpacedUUID,
   getColor,
   getColorByValue,
@@ -316,5 +319,12 @@ describe('helpers/utils', () => {
       SORT_BY_EFFECTIVE_PERIOD_START_FIELD
     );
     expect(sortedPlans).toEqual(sortedPlansArray);
+  });
+  it('extractPlanRecordResponseFromPlanPayload shows error as expected', () => {
+    const displayErrorMock = jest.fn();
+    (helpers as any).displayError = displayErrorMock;
+    const result = extractPlanRecordResponseFromPlanPayload([irsPlanDefinition1] as any);
+    expect(result).toBeNull();
+    expect(displayErrorMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -4,17 +4,7 @@ import { get, keyBy, keys, pickBy, values } from 'lodash';
 import { AnyAction, Store } from 'redux';
 import { createSelector } from 'reselect';
 import SeamlessImmutable from 'seamless-immutable';
-import uuidv4 from 'uuid/v4';
 import { FIReasonType, FIStatusType } from '../../components/forms/PlanForm/types';
-import { FAILED_TO_EXTRACT_PLAN_RECORD } from '../../configs/lang';
-import {
-  FIReasons,
-  FIStatuses,
-  PlanAction,
-  planActivities,
-  PlanGoal,
-} from '../../configs/settings';
-import { displayError } from '../../helpers/errors';
 import { descendingOrderSort, FlexObject, removeNullJurisdictionPlans } from '../../helpers/utils';
 
 /** the reducer name */
@@ -104,74 +94,6 @@ export interface PlanPayload {
   version: string;
 }
 
-/** extractPlanPayloadFromPlanRecord */
-export const extractPlanPayloadFromPlanRecord = (planRecord: PlanRecord): PlanPayload | null => {
-  const {
-    plan_date: date,
-    plan_id: identifier,
-    plan_effective_period_end: end,
-    plan_effective_period_start: start,
-    plan_jurisdictions_ids,
-    plan_status: status,
-    plan_title: title,
-    plan_intervention_type: interventionType,
-    plan_version,
-  } = planRecord;
-  if (plan_jurisdictions_ids) {
-    const planPayload: PlanPayload = {
-      action: [],
-      date,
-      effectivePeriod: {
-        end,
-        start,
-      },
-      goal: [],
-      identifier,
-      jurisdiction: plan_jurisdictions_ids.map(id => ({ code: id })),
-      name: title.trim().replace(/ /g, '-'),
-      serverVersion: 0,
-      status,
-      title,
-      useContext: [
-        {
-          code: 'interventionType',
-          valueCodableConcept: interventionType,
-        },
-      ],
-      version: plan_version || '1',
-    };
-
-    // build PlanActions and PlanGoals
-    let planAction: PlanAction;
-    let planGoal: PlanGoal;
-    if (interventionType === InterventionType.IRS) {
-      const { action, goal } = planActivities[InterventionType.IRS];
-      planAction = {
-        ...action,
-        identifier: uuidv4(),
-        timingPeriod: {
-          end,
-          start,
-        },
-      };
-      planGoal = {
-        ...goal,
-        target: [
-          {
-            ...goal.target[0],
-            due: end,
-          },
-        ],
-      };
-      planPayload.action.push(planAction);
-      planPayload.goal.push(planGoal);
-    }
-
-    return planPayload;
-  }
-  return null;
-};
-
 /** PlanEventType - enum for Plan Event logging */
 export enum PlanEventType {
   CREATE = 'Create Plan',
@@ -203,67 +125,6 @@ export interface PlanEventPayload {
   type: 'Event';
   version: number;
 }
-
-/** extracts a planRecord from the planPayload which is the object received from the opensrp service
- * @param {PlanPayload} planPayload - payload used when creating/updating a plan via OpenSRP plans Endpoint
- *
- * @return {PlanRecordResponse | null} the extracted plan details or null if the plan wasn't valid
- */
-export const extractPlanRecordResponseFromPlanPayload = (
-  planPayload: PlanPayload
-): PlanRecordResponse | null => {
-  const {
-    date,
-    effectivePeriod,
-    identifier,
-    status,
-    title,
-    useContext,
-    version,
-    name,
-  } = planPayload;
-  if (useContext && effectivePeriod) {
-    const { end, start } = effectivePeriod;
-    let planInterventionType = InterventionType.FI;
-    let planFiReason: FIReasonType = FIReasons[0];
-    let planFiStatus: FIStatusType = FIStatuses[0];
-    for (const context of useContext) {
-      switch (context.code) {
-        case 'interventionType': {
-          planInterventionType = context.valueCodableConcept as InterventionType;
-          break;
-        }
-        case 'fiReason': {
-          planFiReason = context.valueCodableConcept as FIReasonType;
-          break;
-        }
-        case 'fiStatus': {
-          planFiStatus = context.valueCodableConcept as FIStatusType;
-          break;
-        }
-      }
-    }
-    const planRecordResponse: PlanRecordResponse = {
-      date,
-      effective_period_end: end,
-      effective_period_start: start,
-      fi_reason: planFiReason,
-      fi_status: planFiStatus,
-      identifier,
-      intervention_type: planInterventionType,
-      name,
-      status,
-      title,
-      version,
-    };
-    if (planPayload.jurisdiction) {
-      planRecordResponse.jurisdictions = planPayload.jurisdiction.map(j => j.code);
-    }
-    return planRecordResponse;
-  }
-  displayError(new Error(FAILED_TO_EXTRACT_PLAN_RECORD));
-  return null;
-};
 
 // actions
 /** PLANS_FETCHED action type */

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -204,6 +204,11 @@ export interface PlanEventPayload {
   version: number;
 }
 
+/** extracts a planRecord from the planPayload which is the object received from the opensrp service
+ * @param {PlanPayload} planPayload - payload used when creating/updating a plan via OpenSRP plans Endpoint
+ *
+ * @return {PlanRecordResponse | null} the extracted plan details or null if the plan wasn't valid
+ */
 export const extractPlanRecordResponseFromPlanPayload = (
   planPayload: PlanPayload
 ): PlanRecordResponse | null => {

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -6,6 +6,7 @@ import { createSelector } from 'reselect';
 import SeamlessImmutable from 'seamless-immutable';
 import uuidv4 from 'uuid/v4';
 import { FIReasonType, FIStatusType } from '../../components/forms/PlanForm/types';
+import { FAILED_TO_EXTRACT_PLAN_RECORD } from '../../configs/lang';
 import {
   FIReasons,
   FIStatuses,
@@ -13,6 +14,7 @@ import {
   planActivities,
   PlanGoal,
 } from '../../configs/settings';
+import { displayError } from '../../helpers/errors';
 import { descendingOrderSort, FlexObject, removeNullJurisdictionPlans } from '../../helpers/utils';
 
 /** the reducer name */
@@ -254,6 +256,7 @@ export const extractPlanRecordResponseFromPlanPayload = (
     }
     return planRecordResponse;
   }
+  displayError(new Error(FAILED_TO_EXTRACT_PLAN_RECORD));
   return null;
 };
 

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -205,7 +205,16 @@ export interface PlanEventPayload {
 export const extractPlanRecordResponseFromPlanPayload = (
   planPayload: PlanPayload
 ): PlanRecordResponse | null => {
-  const { date, effectivePeriod, identifier, status, title, useContext, version } = planPayload;
+  const {
+    date,
+    effectivePeriod,
+    identifier,
+    status,
+    title,
+    useContext,
+    version,
+    name,
+  } = planPayload;
   if (useContext && effectivePeriod) {
     const { end, start } = effectivePeriod;
     let planInterventionType = InterventionType.FI;

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -3,11 +3,8 @@ import { cloneDeep, keyBy, keys, pickBy, values } from 'lodash';
 import { FlushThunks } from 'redux-testkit';
 import { FIReasons } from '../../../configs/settings';
 import { PLAN_RECORD_BY_ID, SORT_BY_EFFECTIVE_PERIOD_START_FIELD } from '../../../constants';
-import { irsPlanDefinition1 } from '../../../containers/pages/InterventionPlan/IRS/tests/fixtures';
-import * as helpers from '../../../helpers/errors';
 import store from '../../index';
 import reducer, {
-  extractPlanRecordResponseFromPlanPayload,
   fetchPlanRecords,
   fetchPlans,
   getPlanById,
@@ -386,13 +383,5 @@ describe('reducers/plans', () => {
 
     const planRecordsArray = [...plansArraySelector(store.getState(), {})];
     expect(planRecordsArray).toEqual(fixtures.sortedPlanRecordArray);
-  });
-
-  it('extractPlanRecordResponseFromPlanPayload shows error as expected', () => {
-    const displayErrorMock = jest.fn();
-    (helpers as any).displayError = displayErrorMock;
-    const result = extractPlanRecordResponseFromPlanPayload([irsPlanDefinition1] as any);
-    expect(result).toBeNull();
-    expect(displayErrorMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/store/ducks/tests/plans.test.ts
+++ b/src/store/ducks/tests/plans.test.ts
@@ -3,8 +3,11 @@ import { cloneDeep, keyBy, keys, pickBy, values } from 'lodash';
 import { FlushThunks } from 'redux-testkit';
 import { FIReasons } from '../../../configs/settings';
 import { PLAN_RECORD_BY_ID, SORT_BY_EFFECTIVE_PERIOD_START_FIELD } from '../../../constants';
+import { irsPlanDefinition1 } from '../../../containers/pages/InterventionPlan/IRS/tests/fixtures';
+import * as helpers from '../../../helpers/errors';
 import store from '../../index';
 import reducer, {
+  extractPlanRecordResponseFromPlanPayload,
   fetchPlanRecords,
   fetchPlans,
   getPlanById,
@@ -383,5 +386,13 @@ describe('reducers/plans', () => {
 
     const planRecordsArray = [...plansArraySelector(store.getState(), {})];
     expect(planRecordsArray).toEqual(fixtures.sortedPlanRecordArray);
+  });
+
+  it('extractPlanRecordResponseFromPlanPayload shows error as expected', () => {
+    const displayErrorMock = jest.fn();
+    (helpers as any).displayError = displayErrorMock;
+    const result = extractPlanRecordResponseFromPlanPayload([irsPlanDefinition1] as any);
+    expect(result).toBeNull();
+    expect(displayErrorMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Bug: service call to get a plan in `IrsPlan` returns an array but the component assumes it returns a single object.
As a result the component would be unable to extract the planRecord. As consequence the plan is not added to the store.
The component just keeps spinning obliviously.
This is evident when you refresh the page, otherwise if the plan is already in the store,the page loads as expected