### PR TITLE
{DNM} Add cookie Jar to express

### DIFF
--- a/server/.env.sample
+++ b/server/.env.sample
@@ -1,5 +1,5 @@
 NODE_ENV=development
-
+EXPRESS_OPENSRP_BASE_URL=https://reveal-stage.smartregister.org/opensrp
 EXPRESS_OPENSRP_ACCESS_TOKEN_URL=https://reveal-stage.smartregister.org/opensrp/oauth/token
 EXPRESS_OPENSRP_AUTHORIZATION_URL=https://reveal-stage.smartregister.org/opensrp/oauth/authorize
 EXPRESS_OPENSRP_CALLBACK_URL=http://localhost:3000/oauth/callback/OpenSRP/

--- a/server/package.json
+++ b/server/package.json
@@ -18,6 +18,7 @@
     "express-session": "^1.17.0",
     "helmet": "^3.21.2",
     "request": "^2.88.0",
+    "request-promise": "^4.2.5",
     "session-file-store": "^1.3.1",
     "typescript": "^3.7.5"
   },
@@ -30,6 +31,7 @@
     "@types/jest": "^25.1.3",
     "@types/node": "^13.5.0",
     "@types/request": "^2.48.4",
+    "@types/request-promise": "^4.1.46",
     "@types/session-file-store": "^1.2.1",
     "@types/supertest": "^2.0.8",
     "jest": "^25.1.0",

--- a/server/src/configs/__mocks__/envs.ts
+++ b/server/src/configs/__mocks__/envs.ts
@@ -11,6 +11,9 @@ export type EXPRESS_OPENSRP_AUTHORIZATION_URL = typeof EXPRESS_OPENSRP_AUTHORIZA
 export const EXPRESS_OPENSRP_CALLBACK_URL = 'http://localhost:3000/oauth/callback/OpenSRP/';
 export type EXPRESS_OPENSRP_CALLBACK_URL = typeof EXPRESS_OPENSRP_CALLBACK_URL;
 
+export const EXPRESS_FRONTEND_OPENSRP_CALLBACK_URL = '/fe/oauth/callback/opensrp';
+export type EXPRESS_FRONTEND_OPENSRP_CALLBACK_URL = typeof EXPRESS_FRONTEND_OPENSRP_CALLBACK_URL;
+
 export const EXPRESS_OPENSRP_USER_URL =
   'http://reveal-stage.smartregister.org/opensrp/user-details';
 export type EXPRESS_OPENSRP_USER_URL = typeof EXPRESS_OPENSRP_USER_URL;
@@ -36,7 +39,7 @@ export type EXPRESS_OPENSRP_CLIENT_ID = typeof EXPRESS_OPENSRP_CLIENT_ID;
 export const EXPRESS_OPENSRP_CLIENT_SECRET = process.env.EXPRESS_OPENSRP_CLIENT_SECRET;
 export type EXPRESS_OPENSRP_CLIENT_SECRET = typeof EXPRESS_OPENSRP_CLIENT_SECRET;
 
-export const EXPRESS_PORT = 3000;
+export const EXPRESS_PORT = 3001;
 export type EXPRESS_PORT = typeof EXPRESS_PORT;
 
 export const EXPRESS_SESSION_NAME = 'reveal-session';

--- a/server/src/configs/envs.ts
+++ b/server/src/configs/envs.ts
@@ -18,6 +18,10 @@ export const EXPRESS_OPENSRP_CALLBACK_URL =
   process.env.EXPRESS_OPENSRP_CALLBACK_URL || 'http://localhost:3000/oauth/callback/OpenSRP/';
 export type EXPRESS_OPENSRP_CALLBACK_URL = typeof EXPRESS_OPENSRP_CALLBACK_URL;
 
+export const EXPRESS_OPENSRP_BASE_URL =
+  process.env.EXPRESS_OPENSRP_BASE_URL || 'https://reveal-stage.smartregister.org/opensrp';
+export type EXPRESS_OPENSRP_BASE_URL = typeof EXPRESS_OPENSRP_BASE_URL;
+
 export const EXPRESS_OPENSRP_USER_URL =
   process.env.EXPRESS_OPENSRP_USER_URL ||
   'https://reveal-stage.smartregister.org/opensrp/user-details';

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -28,6 +28,7 @@ import {
   EXPRESS_SESSION_NAME,
   EXPRESS_SESSION_PATH,
   EXPRESS_SESSION_SECRET,
+  EXPRESS_OPENSRP_BASE_URL,
 } from './configs/envs';
 import { clientOauthRequest, cookieJar } from './utils';
 
@@ -119,7 +120,7 @@ const oauthLogin = (_: express.Request, res: express.Response) => {
 
 const oauthCallback = (req: express.Request, res: express.Response, next: express.NextFunction) => {
   const provider = opensrpAuth;
-  customRequest.get('https://reveal-stage.smartregister.org/opensrp', () => {
+  customRequest.get(EXPRESS_OPENSRP_BASE_URL, () => {
     /** start of previous implementation */
     provider.code
       .getToken(req.originalUrl)

--- a/server/src/tests/awscookies.test.ts
+++ b/server/src/tests/awscookies.test.ts
@@ -71,7 +71,6 @@ describe('src/index.ts.awscookies', () => {
         expect(res.header.location).toEqual(EXPRESS_FRONTEND_OPENSRP_CALLBACK_URL);
         expect(res.notFound).toBeFalsy();
         expect(res.redirect).toBeTruthy();
-        // server.close();
         done();
       });
   });

--- a/server/src/tests/awscookies.test.ts
+++ b/server/src/tests/awscookies.test.ts
@@ -1,0 +1,78 @@
+// test to simulate how the thailand server responds with cookies.
+// specifically, we want to check that the cookies that the load-balancer
+// would send in the preflight request(inside the callback handler), are included
+// in further requests from the express server to the identity server.
+import nock from 'nock';
+import request from 'supertest';
+import { EXPRESS_FRONTEND_OPENSRP_CALLBACK_URL } from '../configs/envs';
+import server from '../index';
+import { parsedApiResponse } from './fixtures';
+
+// tslint:disable-next-line: no-var-requires
+const { panic } = require('./utils');
+
+const oauthCallbackUri = '/oauth/callback/OpenSRP/?code=Boi4Wz&state=opensrp';
+
+const awsCookie = [
+  'AWSALB=MkLQfzGel7fZhIVHD7rRHd8YFrSOlyASIIF3BYPyILJLRHQqFmL1QizZ/M4Pdrmm3euZssvywcu427N28Xv5uTlhNO9Y6LMmnL6BZrxGP+XwLil6g56hrTrddP1c; Expires=Fri, 03 Apr 2020 18:01:36 GMT; Path=/',
+  'AWSALBCORS=MkLQfzGel7fZhIVHD7rRHd8YFrSOlyASIIF3BYPyILJLRHQqFmL1QizZ/M4Pdrmm3euZssvywcu427N28Xv5uTlhNO9Y6LMmnL6BZrxGP+XwLil6g56hrTrddP1c; Expires=Fri, 03 Apr 2020 18:01:36 GMT; Path=/; SameSite=None; Secure',
+];
+
+const tokenResponseBody = {
+  access_token: 'f91d35a8-452c-4901-9f34-cf79d6353233',
+  expires_in: 148,
+  refresh_token: 'f9960324-2853-4aed-940b-74c9aba5c154',
+  scope: 'read write',
+  token_type: 'bearer',
+};
+
+describe('src/index.ts.awscookies', () => {
+  afterAll(() => {
+    server.close();
+  });
+
+  it('E2E: oauth/opensrp/callback works correctly', done => {
+    nock('https://reveal-stage.smartregister.org')
+      .persist()
+      .defaultReplyHeaders({
+        'set-cookie': awsCookie,
+      })
+      .get(`/opensrp/user-details`)
+      .reply(200, parsedApiResponse);
+
+    nock('https://reveal-stage.smartregister.org')
+      .persist()
+      .defaultReplyHeaders({
+        'set-cookie': awsCookie,
+      })
+      .get('/opensrp')
+      .reply(200, {}, {});
+
+    // we need to check that the headers are sent along with this request.
+    nock('https://reveal-stage.smartregister.org', {
+      reqheaders: {
+        cookie:
+          'AWSALB=MkLQfzGel7fZhIVHD7rRHd8YFrSOlyASIIF3BYPyILJLRHQqFmL1QizZ/M4Pdrmm3euZssvywcu427N28Xv5uTlhNO9Y6LMmnL6BZrxGP+XwLil6g56hrTrddP1c; AWSALBCORS=MkLQfzGel7fZhIVHD7rRHd8YFrSOlyASIIF3BYPyILJLRHQqFmL1QizZ/M4Pdrmm3euZssvywcu427N28Xv5uTlhNO9Y6LMmnL6BZrxGP+XwLil6g56hrTrddP1c',
+      },
+    })
+      .persist()
+      .post('/opensrp/oauth/token')
+      .reply(200, tokenResponseBody);
+
+    /** PS: This test will start failing on  Fri, 14 May 3019 11:55:39 GMT */
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementationOnce(() => new Date('3019-05-14T11:01:58.135Z').valueOf());
+
+    request(server)
+      .get(oauthCallbackUri)
+      .end((err, res: request.Response) => {
+        panic(err, done);
+        expect(res.header.location).toEqual(EXPRESS_FRONTEND_OPENSRP_CALLBACK_URL);
+        expect(res.notFound).toBeFalsy();
+        expect(res.redirect).toBeTruthy();
+        // server.close();
+        done();
+      });
+  });
+});

--- a/server/src/tests/utils.js
+++ b/server/src/tests/utils.js
@@ -17,7 +17,17 @@ const extractCookies = headers => {
   }, {});
 };
 
+/** util func for tests, evaluates a nock-type response for err
+ * and fails test if err.
+ */
+const panic = (err, done) => {
+  if (err) {
+    done(err);
+  }
+};
+
 module.exports = {
   shapeFlags,
   extractCookies,
+  panic,
 };

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -1,0 +1,28 @@
+import ClientOAuth2 from 'client-oauth2';
+import requestPromise from 'request-promise';
+
+/** cookie jar for all requests done by requests and request-promise */
+export const cookieJar = requestPromise.jar();
+
+/** function to override client-oauth's  default request function
+ * @param {string} method - http verb
+ * @param {string} url - the url | uri
+ * @param {string} body - the stringified body
+ * @param {{ [key: string]: string | string[] }} headers - the headers
+ */
+export const clientOauthRequest: ClientOAuth2.Request = (method, url, body, headers) => {
+  const requestOptions = {
+    body,
+    headers,
+    jar: cookieJar,
+    method,
+    resolveWithFullResponse: true,
+    uri: url,
+  };
+  return requestPromise(requestOptions).then(res => {
+    return {
+      body: res.body,
+      status: res.statusCode,
+    };
+  });
+};

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -384,6 +384,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/bluebird@*":
+  version "3.5.30"
+  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.30.tgz#ee034a0eeea8b84ed868b1aa60d690b08a6cfbc5"
+  integrity sha512-8LhzvcjIoqoi1TghEkRMkbbmM+jhHnBokPGkJWjclMK+Ks0MxEBow3/p2/iFTZ+OIbJHQDSfpgdZEb+af3gfVw==
+
 "@types/body-parser@*":
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.17.1.tgz#18fcf61768fb5c30ccc508c21d6fd2e8b3bf7897"
@@ -508,7 +513,15 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
-"@types/request@^2.48.4":
+"@types/request-promise@^4.1.46":
+  version "4.1.46"
+  resolved "https://registry.yarnpkg.com/@types/request-promise/-/request-promise-4.1.46.tgz#37df6efae984316dfbfbbe8fcda37f3ba52822f2"
+  integrity sha512-3Thpj2Va5m0ji3spaCk8YKrjkZyZc6RqUVOphA0n/Xet66AW/AiOAs5vfXhQIL5NmkaO7Jnun7Nl9NEjJ2zBaw==
+  dependencies:
+    "@types/bluebird" "*"
+    "@types/request" "*"
+
+"@types/request@*", "@types/request@^2.48.4":
   version "2.48.4"
   resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.4.tgz#df3d43d7b9ed3550feaa1286c6eabf0738e6cf7e"
   integrity sha512-W1t1MTKYR8PxICH+A4HgEIPuAC3sbljoEVfyZbeFJJDbr30guDspJri2XOaM2E+Un7ZjrihaDi7cf6fPa2tbgw==
@@ -835,6 +848,11 @@ binary-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
+
+bluebird@^3.5.0:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
+  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 body-parser@1.19.0:
   version "1.19.0"
@@ -3897,6 +3915,16 @@ request-promise-native@^1.0.7:
   resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.8.tgz#a455b960b826e44e2bf8999af64dff2bfe58cb36"
   integrity sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==
   dependencies:
+    request-promise-core "1.1.3"
+    stealthy-require "^1.1.1"
+    tough-cookie "^2.3.3"
+
+request-promise@^4.2.5:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.5.tgz#186222c59ae512f3497dfe4d75a9c8461bd0053c"
+  integrity sha512-ZgnepCykFdmpq86fKGwqntyTiUrHycALuGggpyCZwMvGaZWgxW6yagT0FHkgo5LzYvOaCNvxYwWYIjevSH1EDg==
+  dependencies:
+    bluebird "^3.5.0"
     request-promise-core "1.1.3"
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"


### PR DESCRIPTION
close #768 close #770 
Adds a "pre-flight" request in the callback handler a cookie jar.
So from the above request we can then extract all cookies from `reveal-th.smartregister` including the load balancer cookies, save those in a cookie jar and apply them to all other requests to `reveal-th.smartregister`