### PR TITLE
Exclude server  from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,6 @@
     "noEmit": true,
     "jsx": "preserve"
   },
-  "include": ["src", "server"]
+  "include": ["src"],
+  "exclude": ["server"]
 }


### PR DESCRIPTION
At the moment this is required for the deployment to go fine. since
if the server remains included then when building the react-app
typescript gonna complain that the server folder files are missing
some types and npm modules. At the moment the ansible0-react role
does not provision for the installation of the would be reported
missing npm packages(the ones in o
/server/package.json)

partof #778 