### PR TITLE
Refactor IRS reporting-legend's text

### DIFF
--- a/src/components/formatting/IRSIndicatorLegend/tests/__snapshots__/index.test.tsx.snap
+++ b/src/components/formatting/IRSIndicatorLegend/tests/__snapshots__/index.test.tsx.snap
@@ -128,7 +128,7 @@ exports[`/components/formatting/IRSIndicatorLegend renders correctly for namibia
           Red
         </td>
         <td>
-          20% - 75%
+          20% -&lt; 75%
         </td>
       </tr>
       <tr
@@ -143,7 +143,7 @@ exports[`/components/formatting/IRSIndicatorLegend renders correctly for namibia
           Yellow
         </td>
         <td>
-          75% &gt;-&lt; 90%
+          75% -&lt; 90%
         </td>
       </tr>
       <tr

--- a/src/components/formatting/IRSIndicatorLegend/tests/__snapshots__/index.test.tsx.snap
+++ b/src/components/formatting/IRSIndicatorLegend/tests/__snapshots__/index.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`/components/formatting/IRSIndicatorLegend renders correctly for default
           Yellow
         </td>
         <td>
-          75% - 90%
+          75% &gt;-&lt; 90%
         </td>
       </tr>
       <tr
@@ -143,7 +143,7 @@ exports[`/components/formatting/IRSIndicatorLegend renders correctly for namibia
           Yellow
         </td>
         <td>
-          75% - 90%
+          75% &gt;-&lt; 90%
         </td>
       </tr>
       <tr

--- a/src/components/formatting/IRSIndicatorLegend/tests/index.test.tsx
+++ b/src/components/formatting/IRSIndicatorLegend/tests/index.test.tsx
@@ -1,7 +1,8 @@
 import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
+import { values } from 'lodash';
 import React from 'react';
-import IRSIndicatorLegend from '..';
+import IRSIndicatorLegend, { generateRangeStrings } from '..';
 import { indicatorThresholdsIRS, indicatorThresholdsLookUpIRS } from '../../../../configs/settings';
 
 const zambiaIndicatorRows = 'zambia2019';
@@ -30,5 +31,17 @@ describe('/components/formatting/IRSIndicatorLegend', () => {
     expect(toJson(wrapper.find('.card-header'))).toMatchSnapshot('header');
     expect(toJson(wrapper.find('Table'))).toMatchSnapshot('indicator table namibia');
     wrapper.unmount();
+  });
+  it('generateRangeStrings works correctly nominal case', () => {
+    const sampleThresholds = indicatorThresholdsIRS;
+
+    const indicatorItems = values(sampleThresholds);
+    const response = generateRangeStrings(indicatorItems);
+    expect(response).toEqual([
+      { color: '#dddddd', name: 'Grey', text: '< 20%', value: 0.2 },
+      { color: '#FF4136', name: 'Red', orEquals: true, text: '20% - 75%', value: 0.75 },
+      { color: '#FFDC00', name: 'Yellow', text: '75% >-< 90%', value: 0.9 },
+      { color: '#2ECC40', name: 'Green', orEquals: true, text: '90% - 100%', value: 1 },
+    ]);
   });
 });

--- a/src/configs/settings.ts
+++ b/src/configs/settings.ts
@@ -891,7 +891,6 @@ export const indicatorThresholdsIRSNamibia: IndicatorThresholds = {
   RED_THRESHOLD: {
     color: '#FF4136',
     name: IRS_RED_THRESHOLD,
-    orEquals: true,
     value: 0.75,
   },
   YELLOW_THRESHOLD: {

--- a/src/configs/settings.ts
+++ b/src/configs/settings.ts
@@ -853,6 +853,7 @@ export const indicatorThresholdsIRS: IndicatorThresholds = {
   GREEN_THRESHOLD: {
     color: '#2ECC40',
     name: IRS_GREEN_THRESHOLD,
+    orEquals: true,
     value: 1,
   },
   GREY_THRESHOLD: {
@@ -879,6 +880,7 @@ export const indicatorThresholdsIRSNamibia: IndicatorThresholds = {
   GREEN_THRESHOLD: {
     color: '#4C9A2A',
     name: IRS_GREEN_THRESHOLD,
+    orEquals: true,
     value: 1,
   },
   GREY_THRESHOLD: {

--- a/src/containers/pages/IRS/Map/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/pages/IRS/Map/tests/__snapshots__/index.test.tsx.snap
@@ -158,6 +158,7 @@ Array [
         "GREEN_THRESHOLD": Object {
           "color": "#2ECC40",
           "name": "Green",
+          "orEquals": true,
           "value": 1,
         },
         "GREY_THRESHOLD": Object {
@@ -214,6 +215,7 @@ Array [
         "GREEN_THRESHOLD": Object {
           "color": "#2ECC40",
           "name": "Green",
+          "orEquals": true,
           "value": 1,
         },
         "GREY_THRESHOLD": Object {
@@ -270,6 +272,7 @@ Array [
         "GREEN_THRESHOLD": Object {
           "color": "#2ECC40",
           "name": "Green",
+          "orEquals": true,
           "value": 1,
         },
         "GREY_THRESHOLD": Object {
@@ -326,6 +329,7 @@ Array [
         "GREEN_THRESHOLD": Object {
           "color": "#2ECC40",
           "name": "Green",
+          "orEquals": true,
           "value": 1,
         },
         "GREY_THRESHOLD": Object {


### PR DESCRIPTION
The range symbols( < - >) or operators will now also respect the `orEquals` IndicatorItem property. for example an indicatorItem with {orEquals: true, value: 20} will now be shown as `- 20%` and not `< 20%`

close #774