### PR TITLE
Use OpenSrpService from OpenSrp web for CRUD operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@onaio/session-reducer": "^0.0.10",
     "@onaio/superset-connector": "^0.0.13",
     "@onaio/utils": "^0.0.1",
+    "@opensrp/server-service": "^0.0.1",
     "@testing-library/react": "^10.0.1",
     "@types/bootstrap": "^4.2.1",
     "@types/fetch-mock": "^7.2.3",

--- a/src/services/opensrp/index.ts
+++ b/src/services/opensrp/index.ts
@@ -25,19 +25,6 @@ export interface URLParams {
   [key: string]: string | number | boolean;
 }
 
-/** params option type */
-type paramsType = URLParams | null;
-
-/** converts URL params object to string
- * @param {URLParams} obj - the object representing URL params
- * @returns {string} URL params as a string
- */
-export function getURLParams(obj: URLParams | {}): string {
-  return Object.entries(obj)
-    .map(([key, val]) => `${key}=${val}`)
-    .join('&');
-}
-
 /** converts filter params object to string
  * @param {URLParams} obj - the object representing filter params
  * @returns {string} filter params as a string
@@ -46,17 +33,6 @@ export function getFilterParams(obj: URLParams | {}): string {
   return Object.entries(obj)
     .map(([key, val]) => `${key}:${val}`)
     .join(',');
-}
-
-/** get payload for fetch
- * @param {HTTPMethod} method - the HTTP method
- * @returns the payload
- */
-export function getPayload(method: HTTPMethod) {
-  return {
-    headers: getDefaultHeaders() as HeadersInit,
-    method,
-  };
 }
 
 /** get payload for fetch
@@ -72,21 +48,8 @@ export function getPayloadOptions(_: AbortSignal, method: HTTPMethod) {
   };
 }
 
-/** Get URL
- * @param {string} url - the url
- * @param {paramType} params - the url params object
- * @returns {string} the final url
- */
-export function getURL(url: string, params: paramsType = null): string {
-  let result = url;
-  if (params) {
-    result = `${result}?${getURLParams(params)}`;
-  }
-  return result;
-}
-
 /** The OpenSRP service class
- *
+ * Extends class OpenSRPService from OpenSRPService web
  * Sample usage:
  * -------------
  * const service = new OpenSRPService('the-endpoint');
@@ -99,75 +62,12 @@ export function getURL(url: string, params: paramsType = null): string {
  *
  * **To update an object**: service.update(theObject)
  */
-export class OpenSRPService {
-  public baseURL: string;
-  public endpoint: string;
-  public generalURL: string;
-
-  constructor(endpoint: string, baseURL: string = OPENSRP_API_BASE_URL) {
-    this.endpoint = endpoint;
-    this.baseURL = baseURL;
-    this.generalURL = `${this.baseURL}${this.endpoint}`;
-  }
-
-  /** create method
-   * Send a POST request to the general endpoint containing the new object data
-   * Successful requests will result in a HTTP status 201 response with no body
-   * @param {T} data - the data to be POSTed
-   * @param {params} params - the url params object
-   * @param {HTTPMethod} method - the HTTP method
-   * @returns the object returned by API
-   */
-  public async create<T>(data: T, params: paramsType = null, method: HTTPMethod = 'POST') {
-    const service = new OpenSRPServiceWeb(this.baseURL, this.endpoint, getPayloadOptions);
-    return await service.create(data, params, method);
-  }
-
-  /** read method
-   * Send a GET request to the url for the specific object
-   * @param {string|number} id - the identifier of the object
-   * @param {params} params - the url params object
-   * @param {HTTPMethod} method - the HTTP method
-   * @returns the object returned by API
-   */
-  public async read(id: string | number, params: paramsType = null, method: HTTPMethod = 'GET') {
-    const service = new OpenSRPServiceWeb(this.baseURL, this.endpoint, getPayloadOptions);
-    return await service.read(id, params, method);
-  }
-
-  /** update method
-   * Simply send the updated object as PUT request to the general endpoint URL
-   * Successful requests will result in a HTTP status 200/201 response with no body
-   * @param {T} data - the data to be POSTed
-   * @param {params} params - the url params object
-   * @param {HTTPMethod} method - the HTTP method
-   * @returns the object returned by API
-   */
-  public async update<T>(data: T, params: paramsType = null, method: HTTPMethod = 'PUT') {
-    const service = new OpenSRPServiceWeb(this.baseURL, this.endpoint, getPayloadOptions);
-    return await service.update(data, params, method);
-  }
-
-  /** list method
-   * Send a GET request to the general API endpoint
-   * @param {params} params - the url params object
-   * @param {HTTPMethod} method - the HTTP method
-   * @returns list of objects returned by API
-   */
-  public async list(params: paramsType = null, method: HTTPMethod = 'GET') {
-    const service = new OpenSRPServiceWeb(this.baseURL, this.endpoint, getPayloadOptions);
-    return await service.list(params, method);
-  }
-
-  /** delete method
-   * Send a DELETE request to the general endpoint
-   * Successful requests will result in a HTTP status 204
-   * @param {params} params - the url params object
-   * @param {HTTPMethod} method - the HTTP method
-   * @returns the object returned by API
-   */
-  public async delete(params: paramsType = null, method: HTTPMethod = 'DELETE') {
-    const service = new OpenSRPServiceWeb(this.baseURL, this.endpoint, getPayloadOptions);
-    return await service.delete(params, method);
+export class OpenSRPService extends OpenSRPServiceWeb {
+  constructor(
+    endpoint: string,
+    baseURL: string = OPENSRP_API_BASE_URL,
+    getPayload: typeof getPayloadOptions = getPayloadOptions
+  ) {
+    super(baseURL, endpoint, getPayload);
   }
 }

--- a/src/services/opensrp/index.ts
+++ b/src/services/opensrp/index.ts
@@ -64,8 +64,8 @@ export function getPayload(method: HTTPMethod) {
  * @param {HTTPMethod} method - the HTTP method
  * @returns the payload
  */
-/* tslint:disable-next-line: no-unused-variable */
-export function getPayloadOptions(signal: AbortSignal, method: HTTPMethod) {
+
+export function getPayloadOptions(_: AbortSignal, method: HTTPMethod) {
   return {
     headers: getDefaultHeaders() as HeadersInit,
     method,

--- a/src/services/opensrp/index.ts
+++ b/src/services/opensrp/index.ts
@@ -1,3 +1,4 @@
+import { OpenSRPService as OpenSRPServiceWeb } from '@opensrp/server-service';
 import { IncomingHttpHeaders } from 'http';
 import { OPENSRP_API_BASE_URL } from '../../configs/env';
 import store from '../../store';
@@ -58,6 +59,19 @@ export function getPayload(method: HTTPMethod) {
   };
 }
 
+/** get payload for fetch
+ * @param {AbortSignal} signal - signal object that allows you to communicate with a DOM request
+ * @param {HTTPMethod} method - the HTTP method
+ * @returns the payload
+ */
+/* tslint:disable-next-line: no-unused-variable */
+export function getPayloadOptions(signal: AbortSignal, method: HTTPMethod) {
+  return {
+    headers: getDefaultHeaders() as HeadersInit,
+    method,
+  };
+}
+
 /** Get URL
  * @param {string} url - the url
  * @param {paramType} params - the url params object
@@ -105,22 +119,8 @@ export class OpenSRPService {
    * @returns the object returned by API
    */
   public async create<T>(data: T, params: paramsType = null, method: HTTPMethod = 'POST') {
-    const url = getURL(this.generalURL, params);
-    const payload = {
-      ...getPayload(method),
-      'Cache-Control': 'no-cache',
-      Pragma: 'no-cache',
-      body: JSON.stringify(data),
-    };
-    const response = await fetch(url, payload);
-
-    if (!response.ok || response.status !== 201) {
-      throw new Error(
-        `OpenSRPService create on ${this.endpoint} failed, HTTP status ${response.status}`
-      );
-    }
-
-    return {};
+    const service = new OpenSRPServiceWeb(this.baseURL, this.endpoint, getPayloadOptions);
+    return await service.create(data, params, method);
   }
 
   /** read method
@@ -131,16 +131,8 @@ export class OpenSRPService {
    * @returns the object returned by API
    */
   public async read(id: string | number, params: paramsType = null, method: HTTPMethod = 'GET') {
-    const url = getURL(`${this.generalURL}/${id}`, params);
-    const response = await fetch(url, getPayload(method));
-
-    if (!response.ok) {
-      throw new Error(
-        `OpenSRPService read on ${this.endpoint} failed, HTTP status ${response.status}`
-      );
-    }
-
-    return await response.json();
+    const service = new OpenSRPServiceWeb(this.baseURL, this.endpoint, getPayloadOptions);
+    return await service.read(id, params, method);
   }
 
   /** update method
@@ -152,22 +144,8 @@ export class OpenSRPService {
    * @returns the object returned by API
    */
   public async update<T>(data: T, params: paramsType = null, method: HTTPMethod = 'PUT') {
-    const url = getURL(this.generalURL, params);
-    const payload = {
-      ...getPayload(method),
-      'Cache-Control': 'no-cache',
-      Pragma: 'no-cache',
-      body: JSON.stringify(data),
-    };
-    const response = await fetch(url, payload);
-
-    if (!response.ok) {
-      throw new Error(
-        `OpenSRPService update on ${this.endpoint} failed, HTTP status ${response.status}`
-      );
-    }
-
-    return {};
+    const service = new OpenSRPServiceWeb(this.baseURL, this.endpoint, getPayloadOptions);
+    return await service.update(data, params, method);
   }
 
   /** list method
@@ -177,16 +155,8 @@ export class OpenSRPService {
    * @returns list of objects returned by API
    */
   public async list(params: paramsType = null, method: HTTPMethod = 'GET') {
-    const url = getURL(this.generalURL, params);
-    const response = await fetch(url, getPayload(method));
-
-    if (!response.ok) {
-      throw new Error(
-        `OpenSRPService list on ${this.endpoint} failed, HTTP status ${response.status}`
-      );
-    }
-
-    return await response.json();
+    const service = new OpenSRPServiceWeb(this.baseURL, this.endpoint, getPayloadOptions);
+    return await service.list(params, method);
   }
 
   /** delete method
@@ -197,15 +167,7 @@ export class OpenSRPService {
    * @returns the object returned by API
    */
   public async delete(params: paramsType = null, method: HTTPMethod = 'DELETE') {
-    const url = getURL(this.generalURL, params);
-    const response = await fetch(url, getPayload(method));
-
-    if (response.ok || response.status === 204 || response.status === 200) {
-      return {};
-    } else {
-      throw new Error(
-        `OpenSRPService delete on ${this.endpoint} failed, HTTP status ${response.status}`
-      );
-    }
+    const service = new OpenSRPServiceWeb(this.baseURL, this.endpoint, getPayloadOptions);
+    return await service.delete(params, method);
   }
 }

--- a/src/services/opensrp/tests/index.test.ts
+++ b/src/services/opensrp/tests/index.test.ts
@@ -2,15 +2,7 @@ import { getOpenSRPUserInfo } from '@onaio/gatekeeper';
 import { authenticateUser } from '@onaio/session-reducer';
 import { EmptyObject } from '../../../configs/types';
 import store from '../../../store';
-import {
-  getDefaultHeaders,
-  getFilterParams,
-  getPayload,
-  getPayloadOptions,
-  getURL,
-  getURLParams,
-  OpenSRPService,
-} from '../index';
+import { getDefaultHeaders, getFilterParams, getPayloadOptions, OpenSRPService } from '../index';
 import { createPlan, plansListResponse } from './fixtures/plans';
 import { OpenSRPAPIResponse } from './fixtures/session';
 /* tslint:disable-next-line no-var-requires */
@@ -34,7 +26,7 @@ describe('services/OpenSRP', () => {
     });
   });
 
-  it('getPayloadOptions and getPayload works', async () => {
+  it('getPayloadOptions works', async () => {
     const output = {
       headers: {
         accept: 'application/json',
@@ -45,7 +37,6 @@ describe('services/OpenSRP', () => {
     };
     const signal = new AbortController().signal;
     expect(getPayloadOptions(signal, 'POST')).toEqual({ ...output });
-    expect(getPayload('POST')).toEqual({ ...output });
   });
 
   it('OpenSRPService constructor works', async () => {
@@ -53,21 +44,6 @@ describe('services/OpenSRP', () => {
     expect(planService.baseURL).toEqual('https://test.smartregister.org/opensrp/rest/');
     expect(planService.endpoint).toEqual('plans');
     expect(planService.generalURL).toEqual('https://test.smartregister.org/opensrp/rest/plans');
-  });
-
-  it('getURLParams works', async () => {
-    expect(getURLParams({})).toEqual('');
-    expect(getURLParams({ foo: 'bar', leet: 1337, mosh: 'pitt' })).toEqual(
-      'foo=bar&leet=1337&mosh=pitt'
-    );
-  });
-
-  it('getURL works', async () => {
-    const url = 'https://test.smartregister.org/opensrp/rest/plans';
-    expect(getURL(url)).toEqual(url);
-    expect(getURL(url, { foo: 'bar', leet: 1337, mosh: 'pitt' })).toEqual(
-      `${url}?foo=bar&leet=1337&mosh=pitt`
-    );
   });
 
   it('getFilterParams works', async () => {

--- a/src/services/opensrp/tests/index.test.ts
+++ b/src/services/opensrp/tests/index.test.ts
@@ -2,7 +2,13 @@ import { getOpenSRPUserInfo } from '@onaio/gatekeeper';
 import { authenticateUser } from '@onaio/session-reducer';
 import { EmptyObject } from '../../../configs/types';
 import store from '../../../store';
-import { getDefaultHeaders, getFilterParams, getURLParams, OpenSRPService } from '../index';
+import {
+  getDefaultHeaders,
+  getFilterParams,
+  getPayloadOptions,
+  getURLParams,
+  OpenSRPService,
+} from '../index';
 import { createPlan, plansListResponse } from './fixtures/plans';
 import { OpenSRPAPIResponse } from './fixtures/session';
 /* tslint:disable-next-line no-var-requires */
@@ -23,6 +29,18 @@ describe('services/OpenSRP', () => {
       accept: 'application/json',
       authorization: 'Bearer hunter2',
       'content-type': 'application/json;charset=UTF-8',
+    });
+  });
+
+  it('getPayloadOptions works', async () => {
+    const signal = new AbortController().signal;
+    expect(getPayloadOptions(signal, 'POST')).toEqual({
+      headers: {
+        accept: 'application/json',
+        authorization: 'Bearer hunter2',
+        'content-type': 'application/json;charset=UTF-8',
+      },
+      method: 'POST',
     });
   });
 

--- a/src/services/opensrp/tests/index.test.ts
+++ b/src/services/opensrp/tests/index.test.ts
@@ -5,7 +5,9 @@ import store from '../../../store';
 import {
   getDefaultHeaders,
   getFilterParams,
+  getPayload,
   getPayloadOptions,
+  getURL,
   getURLParams,
   OpenSRPService,
 } from '../index';
@@ -32,16 +34,18 @@ describe('services/OpenSRP', () => {
     });
   });
 
-  it('getPayloadOptions works', async () => {
-    const signal = new AbortController().signal;
-    expect(getPayloadOptions(signal, 'POST')).toEqual({
+  it('getPayloadOptions and getPayload works', async () => {
+    const output = {
       headers: {
         accept: 'application/json',
         authorization: 'Bearer hunter2',
         'content-type': 'application/json;charset=UTF-8',
       },
       method: 'POST',
-    });
+    };
+    const signal = new AbortController().signal;
+    expect(getPayloadOptions(signal, 'POST')).toEqual({ ...output });
+    expect(getPayload('POST')).toEqual({ ...output });
   });
 
   it('OpenSRPService constructor works', async () => {
@@ -55,6 +59,14 @@ describe('services/OpenSRP', () => {
     expect(getURLParams({})).toEqual('');
     expect(getURLParams({ foo: 'bar', leet: 1337, mosh: 'pitt' })).toEqual(
       'foo=bar&leet=1337&mosh=pitt'
+    );
+  });
+
+  it('getURL works', async () => {
+    const url = 'https://test.smartregister.org/opensrp/rest/plans';
+    expect(getURL(url)).toEqual(url);
+    expect(getURL(url, { foo: 'bar', leet: 1337, mosh: 'pitt' })).toEqual(
+      `${url}?foo=bar&leet=1337&mosh=pitt`
     );
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1731,6 +1731,13 @@
   resolved "https://registry.yarnpkg.com/@onaio/utils/-/utils-0.0.1.tgz#c4b6b0afb3b7ad6e2b6135a160d3d79e53e286af"
   integrity sha512-JybtApO1LqxidE+avNdu6Qq+EOvywn92/h++HIMvA5DIKMZ6e1OGdG2ZMbFkylmx8JpvVcFypSIomPzKUYvL7w==
 
+"@opensrp/server-service@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@opensrp/server-service/-/server-service-0.0.1.tgz#4a66c991bfb61658af2db12961c9fde4e8a3c396"
+  integrity sha512-2E5rszxz7yiLp1RHsz1Cl6ppaPknpiUxtT2DSm+R7YeWepaKLQVM5A9Cp4ONkNXIDRweWOvJo8PUpLqaE2AlQg==
+  dependencies:
+    "@onaio/session-reducer" "^0.0.11"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"


### PR DESCRIPTION
Closes #682 
Start using `OpenSrpService` from `@opensrp/server-service`  library located at [OpenSrp Web](https://github.com/OpenSRP/opensrp-web/tree/master/packages/opensrp-server-service) to perform all `CRUD` operations.