### PR TITLE
Fix url to use jurisdictionId instead of plan_id

### DIFF
--- a/src/containers/pages/FocusInvestigation/map/active/index.tsx
+++ b/src/containers/pages/FocusInvestigation/map/active/index.tsx
@@ -223,7 +223,7 @@ const SingleActiveFIMap = (props: MapSingleFIProps & RouteComponentProps<RoutePa
   };
   const secondLastPage = {
     label: plan.jurisdiction_name,
-    url: `${FI_SINGLE_URL}/${plan.id}`,
+    url: `${FI_SINGLE_URL}/${plan.jurisdiction_id}`,
   };
   const breadCrumbProps: BreadCrumbProps = {
     currentPage: {

--- a/src/containers/pages/FocusInvestigation/map/active/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/pages/FocusInvestigation/map/active/tests/__snapshots__/index.test.tsx.snap
@@ -156,10 +156,10 @@ exports[`containers/pages/FocusInvestigation/activeMap renders SingleActiveFimap
           <Link
             key="4"
             replace={false}
-            to="/focus-investigation/view/ed2b4b7c-3388-53d9-b9f6-6a19d1ffde1f"
+            to="/focus-investigation/view/450fc15b-5bd2-468a-927a-49cb10d3bcac"
           >
             <a
-              href="/focus-investigation/view/ed2b4b7c-3388-53d9-b9f6-6a19d1ffde1f"
+              href="/focus-investigation/view/450fc15b-5bd2-468a-927a-49cb10d3bcac"
               onClick={[Function]}
             >
               NVI_439


### PR DESCRIPTION
close #839 
problem:
- the url to the focus Area view in focus investigation should be using the plan's jurisdiction_id but it was yet using the plan_id
solution:
- replace plan_id with jurisdiction_id