### PR TITLE
Get plan assignments all at once

### DIFF
--- a/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
+++ b/src/containers/pages/InterventionPlan/IRS/plan/index.tsx
@@ -280,9 +280,29 @@ class IrsPlan extends React.Component<
           // save all organizations to store
           store.dispatch(fetchOrganizationsActionCreator(response));
           // get all assignments
-          return this.getAllAssignments(planId, response, (nextAssignments: Assignment[]) =>
-            store.dispatch(fetchAssignmentsActionCreator(nextAssignments))
-          );
+          // TODO: remove this
+          // return this.getAllAssignments(planId, response, (nextAssignments: Assignment[]) =>
+          //   store.dispatch(fetchAssignmentsActionCreator(nextAssignments))
+          // );
+        })
+        .catch((err: Error) => {
+          displayError(err);
+        });
+
+      // get all assignments
+      OpenSrpAssignedService.list({ plan: planId })
+        .then((response: any[]) => {
+          // TODO: remove any
+          const assignments: Assignment[] = response.map(assignment => {
+            return {
+              fromDate: moment(assignment.fromDate).format(),
+              jurisdiction: assignment.jurisdictionId,
+              organization: assignment.organizationId,
+              plan: assignment.planId,
+              toDate: moment(assignment.toDate).format(),
+            };
+          });
+          store.dispatch(fetchAssignmentsActionCreator(assignments));
         })
         .catch((err: Error) => {
           displayError(err);


### PR DESCRIPTION
This commit changes how the assign page works but fetching all plan
assignments from OpenSRP in one API call instead of possibly hundreds/thousands.

I consider this a workaround to stabilize the assign page by making things more stable,
more work will be done in: https://github.com/onaio/reveal-frontend/issues/892
and https://github.com/onaio/reveal-frontend/issues/788

Fixes: https://github.com/onaio/reveal-frontend/issues/913