### PR TITLE
Add a way to traverse opensrp jurisdictions tree

### DIFF
--- a/src/components/TreeWalker/README.md
+++ b/src/components/TreeWalker/README.md
@@ -1,0 +1,55 @@
+# TreeWalker
+
+This is a set of utilities that together provide functionality to traverse up and down the OpenSRP jurisdictions tree.
+
+## withTreeWalker
+
+`withTreeWalker` is a higher order component that takes a regular component as an input, and adds tree walking super powers to it. :)
+
+```tsx
+interface SomeProps extends WithWalkerProps {
+  smile: string;
+}
+
+const SomeComponent = withTreeWalker<SomeProps>(() => <div>I Love Oov</div>);
+
+// then use it like this:
+<SomeComponent jurisdictionId={someJurisdiction.id} limits={limitTree} smile=":-)" />;
+```
+
+`withTreeWalker` will pass all the original props to the wrapped component (that would be `SomeComponent` in the example above). But, crucially, it adds other props which are the result of jurisdiction tree-walking:
+
+- currentNode: the current jurisdiction
+- currentChildren: the current jurisdiction's children
+- hierarchy: the full path to the current jurisdiction, ordered from the root parent, all the way to the current jurisdiction
+- loadChildren: a callback that when called loads the children of the desired jurisdiction. Usually it will be called with an input being one of the elements in the `currentChildren` array, and would result in tree traversal to view that element's children.
+
+These 4 props keep on changing as you go up and down the jurisdiction tree to allow the wrapped component to react to the changes. Basically, `withTreeWalker` provides any old component the ability to traverse and react to OpenSRP jurisdictions tree traversal in a generic way.
+
+## Helpers
+
+### getAncestors
+
+This function is able to recursively call the OpenSRP location API to get all the ancestors of a given jurisdictions.
+
+```ts
+getAncestors(someJurisdiction);
+// returns something like [rootParent, grandParent, immediateParent]
+```
+
+### getChildren
+
+This function is able to get the children jurisdictions of the provided input jurisdiction.
+
+```ts
+getChildren(urlParams, someJurisdiction);
+// returns something like [child1, child2, child3]
+```
+
+The function can optionally take a third parameter - a hierarchy of jurisdictions, which would limit the children returned to only those found within the provided hierarchy. This might be useful, when doing things like traversing down a plan's jurisdiction hierarchy to get jurisdiction geometries - in which case you would not want any other children returned but only those within the plan hierarchy.
+
+An interesting thing to note is that this function's only required parameter is its first one which is an object containing the URL parameters to send to the OpenSRP API for the locations "findByProperties" endpoint. Indeed it is possible to get children only using this parameter i.e. the jurisdiction (2nd param) is optional!
+
+## Read the code
+
+For more, and for specific details on what parameters all the above take, we encourage you to read the code. It is also just good practice.

--- a/src/components/TreeWalker/constants.ts
+++ b/src/components/TreeWalker/constants.ts
@@ -1,0 +1,4 @@
+export const ACTIVE = 'Active';
+export const FIND_BY_ID = 'location/findByJurisdictionIds';
+export const FIND_BY_PROPERTIES = 'location/findByProperties';
+export const LOCATION = 'location';

--- a/src/components/TreeWalker/constants.ts
+++ b/src/components/TreeWalker/constants.ts
@@ -2,3 +2,4 @@ export const ACTIVE = 'Active';
 export const FIND_BY_ID = 'location/findByJurisdictionIds';
 export const FIND_BY_PROPERTIES = 'location/findByProperties';
 export const LOCATION = 'location';
+export const COULDNT_LOAD_PARENTS = 'Could not load parents';

--- a/src/components/TreeWalker/helpers.ts
+++ b/src/components/TreeWalker/helpers.ts
@@ -37,7 +37,8 @@ export const getAncestors = async (
   apiEndpoint: string = locationListAPIEndpoints.location,
   serviceClass: typeof OpenSRPService = OpenSRPService
 ): Promise<Result<OpenSRPJurisdiction[]>> => {
-  if (!path.includes(jurisdiction)) {
+  // Add the jurisdiction to the beginning of the array
+  if (!path.map(e => e.id).includes(jurisdiction.id)) {
     path.unshift(jurisdiction);
   }
 
@@ -49,7 +50,6 @@ export const getAncestors = async (
   }
 
   const service = new serviceClass(apiEndpoint);
-
   const result = await service
     .read(jurisdiction.properties.parentId, defaultLocationParams)
     .then((response: OpenSRPJurisdiction) => {

--- a/src/components/TreeWalker/helpers.ts
+++ b/src/components/TreeWalker/helpers.ts
@@ -35,16 +35,16 @@ export const locationListAPIEndpoints: APIEndpoints = {
  *
  * @param jurisdiction - the jurisdiction in question
  * @param path - array of ancestors
+ * @param errorMessage - message to show when an error happens
  * @param apiEndpoint - the API endpoint
  * @param serviceClass - the API helper class
- * @param errorMessage - message to show when an error happens
  */
 export const getAncestors = async (
   jurisdiction: OpenSRPJurisdiction,
   path: OpenSRPJurisdiction[] = [],
+  errorMessage: string = COULDNT_LOAD_PARENTS,
   apiEndpoint: string = locationListAPIEndpoints.location,
-  serviceClass: typeof OpenSRPService = OpenSRPService,
-  errorMessage: string = COULDNT_LOAD_PARENTS
+  serviceClass: typeof OpenSRPService = OpenSRPService
 ): Promise<Result<OpenSRPJurisdiction[]>> => {
   // Add the jurisdiction to the beginning of the array
   if (!path.map(e => e.id).includes(jurisdiction.id)) {

--- a/src/components/TreeWalker/helpers.ts
+++ b/src/components/TreeWalker/helpers.ts
@@ -1,7 +1,6 @@
 import { Result } from '@onaio/utils';
-import { URLParams } from '@opensrp/server-service/dist/types';
-import { OpenSRPService } from '../../services/opensrp';
-import { OpenSRPJurisdiction } from './types';
+import { OpenSRPService, URLParams } from '../../services/opensrp';
+import { APIEndpoints, OpenSRPJurisdiction, SimpleJurisdicion } from './types';
 
 /** Default params to be used when fetching locations from OpenSRP */
 export const defaultLocationParams = {
@@ -12,6 +11,12 @@ export const defaultLocationParams = {
 /** Default property to be used when fetching locations from OpenSRP */
 export const defaultLocationPropertyFilters = {
   status: 'Active',
+};
+
+export const locationListAPIEndpoints: APIEndpoints = {
+  findByJurisdictionIds: 'location/findByJurisdictionIds',
+  findByProperties: 'location/findByProperties',
+  location: 'location',
 };
 
 /** Get ancestors of a jurisdiction from OpenSRP
@@ -27,9 +32,9 @@ export const defaultLocationPropertyFilters = {
  */
 export const getAncestors = async (
   jurisdiction: OpenSRPJurisdiction,
-  apiEndpoint: string,
-  serviceClass: typeof OpenSRPService,
-  path: OpenSRPJurisdiction[] = []
+  path: OpenSRPJurisdiction[] = [],
+  apiEndpoint: string = locationListAPIEndpoints.location,
+  serviceClass: typeof OpenSRPService = OpenSRPService
 ): Promise<Result<OpenSRPJurisdiction[]>> => {
   if (!path.includes(jurisdiction)) {
     path.unshift(jurisdiction);
@@ -62,7 +67,7 @@ export const getAncestors = async (
     };
   } else {
     if (result.value !== null) {
-      return getAncestors(result.value, apiEndpoint, serviceClass, path);
+      return getAncestors(result.value, path);
     }
     return result;
   }
@@ -72,16 +77,60 @@ export const getAncestors = async (
  *
  * @param params - URL params to send with the request to the API
  * @param jurisdiction - the jurisdiction in question
- * @param apiEndpoint - the API endpoint
+ * @param limitTree - an array that limits the children we try and get from the API
+ * @param apiEndpoints - the API endpoints to use
  * @param serviceClass - the API helper class
  */
 export const getChildren = async (
   params: URLParams,
-  _: OpenSRPJurisdiction | null,
-  apiEndpoint: string,
-  serviceClass: typeof OpenSRPService
+  jurisdiction: OpenSRPJurisdiction | null,
+  limitTree: SimpleJurisdicion[] = [
+    { id: '1337', parentId: '3019' },
+    {
+      id: 'dad42fa6-b9b8-4658-bf25-bfa7ab5b16ae',
+      parentId: '872cc59e-0bce-427a-bd1f-6ef674dba8e2',
+    },
+    {
+      id: 'd56a4344-a7d0-4285-9fe4-c64fd7fc27d4',
+      parentId: '872cc59e-0bce-427a-bd1f-6ef674dba8e2',
+    },
+  ],
+  apiEndpoints: APIEndpoints = locationListAPIEndpoints,
+  serviceClass: typeof OpenSRPService = OpenSRPService
 ): Promise<Result<OpenSRPJurisdiction[]>> => {
-  const service = new serviceClass(apiEndpoint);
+  let service = new serviceClass(apiEndpoints.findByProperties);
+
+  // console.log("jurisdiction >>> ", jurisdiction)
+  // console.log("params >>> ", params)
+
+  if (limitTree && limitTree.length > 0) {
+    // Basically if limitTree has any elements, then we need to ensure that when
+    // getting children from the API, we limit ourselves only to the jurisdictions
+    // contained in limitTree
+
+    // first we get the current parent i.e. the one whose children we want
+    let currentParentId: string | undefined;
+    if (jurisdiction !== null) {
+      currentParentId = jurisdiction.id;
+    } else if (typeof params.parentId === 'string') {
+      currentParentId = params.parentId;
+    }
+
+    // console.log("currentParentId >>> ", currentParentId)
+
+    // Next, if limitTree contains any elements whose parent is currentParentId then
+    // we only fetch those and not all the children that may possibly be on the API server
+    if (currentParentId) {
+      const jurisdictionIds = limitTree
+        .filter(elem => elem.parentId === currentParentId)
+        .map(elem => elem.id);
+      // console.log("jurisdictionIds >>> ", jurisdictionIds)
+      if (jurisdictionIds.length > 0) {
+        service = new serviceClass(apiEndpoints.findByJurisdictionIds);
+        params.jurisdiction_ids = jurisdictionIds.join(',');
+      }
+    }
+  }
 
   const result = await service
     .list(params)

--- a/src/components/TreeWalker/helpers.ts
+++ b/src/components/TreeWalker/helpers.ts
@@ -105,16 +105,23 @@ export const getChildren = async (
       }
     }
 
-    // Next, if limitTree contains any elements whose parent is currentParentId then
-    // we only fetch those and not all the children that may possibly be on the API server
+    // We next want to find relevant jurisdictionIds for the current parent
+    // If we do find them, we will ONLY fetch them from
+    let jurisdictionIds: string[] = [];
     if (currentParentId) {
-      const jurisdictionIds = limitTree
-        .filter(elem => elem.parentId === currentParentId)
-        .map(elem => elem.id);
-      if (jurisdictionIds.length > 0) {
-        service = new serviceClass(apiEndpoints.findByJurisdictionIds);
-        params.jurisdiction_ids = jurisdictionIds.join(',');
-      }
+      // if we have a currentParentId then we check if limitTree contains any jurisdictions whose parent is currentParentId
+      jurisdictionIds = limitTree
+        .filter(elem => elem.jurisdiction_parent_id === currentParentId)
+        .map(elem => elem.jurisdiction_id);
+    } else {
+      // if no currentParentId then we check if we have any jurisdictions that have no parent
+      jurisdictionIds = limitTree
+        .filter(elem => elem.jurisdiction_parent_id === '' || !elem.jurisdiction_parent_id)
+        .map(elem => elem.jurisdiction_id);
+    }
+    if (jurisdictionIds.length > 0) {
+      service = new serviceClass(apiEndpoints.findByJurisdictionIds);
+      params.jurisdiction_ids = jurisdictionIds.join(',');
     }
   }
 

--- a/src/components/TreeWalker/helpers.ts
+++ b/src/components/TreeWalker/helpers.ts
@@ -83,25 +83,12 @@ export const getAncestors = async (
  */
 export const getChildren = async (
   params: URLParams,
-  jurisdiction: OpenSRPJurisdiction | null,
-  limitTree: SimpleJurisdiction[] = [
-    { id: '1337', parentId: '3019' },
-    {
-      id: 'dad42fa6-b9b8-4658-bf25-bfa7ab5b16ae',
-      parentId: '872cc59e-0bce-427a-bd1f-6ef674dba8e2',
-    },
-    {
-      id: 'd56a4344-a7d0-4285-9fe4-c64fd7fc27d4',
-      parentId: '872cc59e-0bce-427a-bd1f-6ef674dba8e2',
-    },
-  ],
+  jurisdiction: OpenSRPJurisdiction | string | null,
+  limitTree: SimpleJurisdiction[] = [],
   apiEndpoints: APIEndpoints = locationListAPIEndpoints,
   serviceClass: typeof OpenSRPService = OpenSRPService
 ): Promise<Result<OpenSRPJurisdiction[]>> => {
   let service = new serviceClass(apiEndpoints.findByProperties);
-
-  // console.log("jurisdiction >>> ", jurisdiction)
-  // console.log("params >>> ", params)
 
   if (limitTree && limitTree.length > 0) {
     // Basically if limitTree has any elements, then we need to ensure that when
@@ -110,13 +97,13 @@ export const getChildren = async (
 
     // first we get the current parent i.e. the one whose children we want
     let currentParentId: string | undefined;
-    if (jurisdiction !== null) {
-      currentParentId = jurisdiction.id;
-    } else if (typeof params.parentId === 'string') {
-      currentParentId = params.parentId;
+    if (jurisdiction) {
+      if (typeof jurisdiction === 'string') {
+        currentParentId = jurisdiction;
+      } else {
+        currentParentId = jurisdiction.id;
+      }
     }
-
-    // console.log("currentParentId >>> ", currentParentId)
 
     // Next, if limitTree contains any elements whose parent is currentParentId then
     // we only fetch those and not all the children that may possibly be on the API server
@@ -124,7 +111,6 @@ export const getChildren = async (
       const jurisdictionIds = limitTree
         .filter(elem => elem.parentId === currentParentId)
         .map(elem => elem.id);
-      // console.log("jurisdictionIds >>> ", jurisdictionIds)
       if (jurisdictionIds.length > 0) {
         service = new serviceClass(apiEndpoints.findByJurisdictionIds);
         params.jurisdiction_ids = jurisdictionIds.join(',');

--- a/src/components/TreeWalker/helpers.ts
+++ b/src/components/TreeWalker/helpers.ts
@@ -1,7 +1,13 @@
 import { Result } from '@onaio/utils';
 import { uniqBy } from 'lodash';
 import { OpenSRPService, URLParams } from '../../services/opensrp';
-import { ACTIVE, FIND_BY_ID, FIND_BY_PROPERTIES, LOCATION } from './constants';
+import {
+  ACTIVE,
+  COULDNT_LOAD_PARENTS,
+  FIND_BY_ID,
+  FIND_BY_PROPERTIES,
+  LOCATION,
+} from './constants';
 import { APIEndpoints, OpenSRPJurisdiction, SimpleJurisdiction } from './types';
 
 /** Default params to be used when fetching locations from OpenSRP */
@@ -28,15 +34,17 @@ export const locationListAPIEndpoints: APIEndpoints = {
  * of the supplied jurisdiction, including the jurisdiction
  *
  * @param jurisdiction - the jurisdiction in question
+ * @param path - array of ancestors
  * @param apiEndpoint - the API endpoint
  * @param serviceClass - the API helper class
- * @param path - array of ancestors
+ * @param errorMessage - message to show when an error happens
  */
 export const getAncestors = async (
   jurisdiction: OpenSRPJurisdiction,
   path: OpenSRPJurisdiction[] = [],
   apiEndpoint: string = locationListAPIEndpoints.location,
-  serviceClass: typeof OpenSRPService = OpenSRPService
+  serviceClass: typeof OpenSRPService = OpenSRPService,
+  errorMessage: string = COULDNT_LOAD_PARENTS
 ): Promise<Result<OpenSRPJurisdiction[]>> => {
   // Add the jurisdiction to the beginning of the array
   if (!path.map(e => e.id).includes(jurisdiction.id)) {
@@ -64,7 +72,7 @@ export const getAncestors = async (
 
   if (!result) {
     return {
-      error: Error('Could not load parents'),
+      error: Error(errorMessage),
       value: null,
     };
   } else {

--- a/src/components/TreeWalker/helpers.ts
+++ b/src/components/TreeWalker/helpers.ts
@@ -62,7 +62,7 @@ export const getAncestors = async (
 
   if (!result) {
     return {
-      error: Error('Could get load parents'),
+      error: Error('Could not load parents'),
       value: null,
     };
   } else {
@@ -86,7 +86,7 @@ export const getChildren = async (
   params: URLParams,
   jurisdiction: OpenSRPJurisdiction | string | null,
   limitTree: SimpleJurisdiction[] = [],
-  chunkSize: number = 20,
+  chunkSize: number = 25,
   apiEndpoints: APIEndpoints = locationListAPIEndpoints,
   serviceClass: typeof OpenSRPService = OpenSRPService
 ): Promise<Result<OpenSRPJurisdiction[]>> => {
@@ -138,6 +138,7 @@ export const getChildren = async (
 
   return Promise.all(promises)
     .then(results => {
+      // We are concatenating all the resulting array so that we return all nodes in one array
       return { error: null, value: [].concat.apply([], results) };
     })
     .catch((error: Error) => {

--- a/src/components/TreeWalker/helpers.ts
+++ b/src/components/TreeWalker/helpers.ts
@@ -1,4 +1,5 @@
 import { Result } from '@onaio/utils';
+import { uniqBy } from 'lodash';
 import { OpenSRPService, URLParams } from '../../services/opensrp';
 import { APIEndpoints, OpenSRPJurisdiction, SimpleJurisdiction } from './types';
 
@@ -123,6 +124,7 @@ export const getChildren = async (
         .filter(elem => elem.jurisdiction_parent_id === '' || !elem.jurisdiction_parent_id)
         .map(elem => elem.jurisdiction_id);
     }
+
     if (jurisdictionIds.length > 0) {
       service = new serviceClass(apiEndpoints.findByJurisdictionIds);
       // jurisdictionIds may have a huge number of elements and so we need to chunk
@@ -138,8 +140,10 @@ export const getChildren = async (
 
   return Promise.all(promises)
     .then(results => {
-      // We are concatenating all the resulting array so that we return all nodes in one array
-      return { error: null, value: [].concat.apply([], results) };
+      // We are concatenating all the resulting arrays so that we return all nodes in one array
+      const children = [].concat.apply([], results);
+      // then we remove duplicates and return the children
+      return { error: null, value: uniqBy(children, 'id') };
     })
     .catch((error: Error) => {
       return { error, value: null };

--- a/src/components/TreeWalker/helpers.ts
+++ b/src/components/TreeWalker/helpers.ts
@@ -9,6 +9,11 @@ export const defaultLocationParams = {
   return_geometry: false,
 };
 
+/** Default property to be used when fetching locations from OpenSRP */
+export const defaultLocationPropertyFilters = {
+  status: 'Active',
+};
+
 /** Get ancestors of a jurisdiction from OpenSRP
  *
  * This is a recursive function that traverses the OpenSRP jurisdiction tree

--- a/src/components/TreeWalker/helpers.ts
+++ b/src/components/TreeWalker/helpers.ts
@@ -1,0 +1,48 @@
+import { Result } from '@onaio/utils';
+import { OpenSRPService } from '../../services/opensrp';
+import { OpenSRPJurisdiction } from './types';
+
+export const defaultParams = {
+  is_jurisdiction: true,
+  return_geometry: false,
+};
+
+export const getAncestors = async (
+  jurisdiction: OpenSRPJurisdiction,
+  path: OpenSRPJurisdiction[] = []
+): Promise<Result<OpenSRPJurisdiction[]>> => {
+  if (!path.includes(jurisdiction)) {
+    path.unshift(jurisdiction);
+  }
+
+  if (jurisdiction.properties.geographicLevel === 0 || !jurisdiction.properties.parentId) {
+    return {
+      error: null,
+      value: path,
+    };
+  }
+
+  const service = new OpenSRPService('location');
+  const result = await service
+    .read(jurisdiction.properties.parentId, defaultParams)
+    .then((response: OpenSRPJurisdiction) => {
+      if (response) {
+        return { error: null, value: response };
+      }
+    })
+    .catch((error: Error) => {
+      return { error, value: null };
+    });
+
+  if (!result) {
+    return {
+      error: Error('Could not load parents'),
+      value: null,
+    };
+  } else {
+    if (result.value !== null) {
+      return getAncestors(result.value, path);
+    }
+    return result;
+  }
+};

--- a/src/components/TreeWalker/helpers.ts
+++ b/src/components/TreeWalker/helpers.ts
@@ -1,6 +1,7 @@
 import { Result } from '@onaio/utils';
 import { uniqBy } from 'lodash';
 import { OpenSRPService, URLParams } from '../../services/opensrp';
+import { ACTIVE, FIND_BY_ID, FIND_BY_PROPERTIES, LOCATION } from './constants';
 import { APIEndpoints, OpenSRPJurisdiction, SimpleJurisdiction } from './types';
 
 /** Default params to be used when fetching locations from OpenSRP */
@@ -11,13 +12,13 @@ export const defaultLocationParams = {
 
 /** Default property to be used when fetching locations from OpenSRP */
 export const defaultLocationPropertyFilters = {
-  status: 'Active',
+  status: ACTIVE,
 };
 
 export const locationListAPIEndpoints: APIEndpoints = {
-  findByJurisdictionIds: 'location/findByJurisdictionIds',
-  findByProperties: 'location/findByProperties',
-  location: 'location',
+  findByJurisdictionIds: FIND_BY_ID,
+  findByProperties: FIND_BY_PROPERTIES,
+  location: LOCATION,
 };
 
 /** Get ancestors of a jurisdiction from OpenSRP

--- a/src/components/TreeWalker/helpers.ts
+++ b/src/components/TreeWalker/helpers.ts
@@ -1,6 +1,6 @@
 import { Result } from '@onaio/utils';
 import { OpenSRPService, URLParams } from '../../services/opensrp';
-import { APIEndpoints, OpenSRPJurisdiction, SimpleJurisdicion } from './types';
+import { APIEndpoints, OpenSRPJurisdiction, SimpleJurisdiction } from './types';
 
 /** Default params to be used when fetching locations from OpenSRP */
 export const defaultLocationParams = {
@@ -84,7 +84,7 @@ export const getAncestors = async (
 export const getChildren = async (
   params: URLParams,
   jurisdiction: OpenSRPJurisdiction | null,
-  limitTree: SimpleJurisdicion[] = [
+  limitTree: SimpleJurisdiction[] = [
     { id: '1337', parentId: '3019' },
     {
       id: 'dad42fa6-b9b8-4658-bf25-bfa7ab5b16ae',

--- a/src/components/TreeWalker/helpers.ts
+++ b/src/components/TreeWalker/helpers.ts
@@ -16,9 +16,9 @@ export const defaultLocationParams = {
  * of the supplied jurisdiction, including the jurisdiction
  *
  * @param jurisdiction - the jurisdiction in question
- * @param path - array of ancestors
  * @param apiEndpoint - the API endpoint
  * @param serviceClass - the API helper class
+ * @param path - array of ancestors
  */
 export const getAncestors = async (
   jurisdiction: OpenSRPJurisdiction,
@@ -65,8 +65,8 @@ export const getAncestors = async (
 
 /** Get children of a jurisdiction from OpenSRP
  *
+ * @param params - URL params to send with the request to the API
  * @param jurisdiction - the jurisdiction in question
- * @param path - array of ancestors
  * @param apiEndpoint - the API endpoint
  * @param serviceClass - the API helper class
  */

--- a/src/components/TreeWalker/helpers.ts
+++ b/src/components/TreeWalker/helpers.ts
@@ -86,7 +86,7 @@ export const getChildren = async (
   params: URLParams,
   jurisdiction: OpenSRPJurisdiction | string | null,
   limitTree: SimpleJurisdiction[] = [],
-  chunkSize: number = 25,
+  chunkSize: number = 20,
   apiEndpoints: APIEndpoints = locationListAPIEndpoints,
   serviceClass: typeof OpenSRPService = OpenSRPService
 ): Promise<Result<OpenSRPJurisdiction[]>> => {

--- a/src/components/TreeWalker/helpers.ts
+++ b/src/components/TreeWalker/helpers.ts
@@ -2,11 +2,21 @@ import { Result } from '@onaio/utils';
 import { OpenSRPService } from '../../services/opensrp';
 import { OpenSRPJurisdiction } from './types';
 
-export const defaultParams = {
+/** Default params to be used when fetching locations from OpenSRP */
+export const defaultLocationParams = {
   is_jurisdiction: true,
   return_geometry: false,
 };
 
+/** Get ancestors of a jurisdiction from OpenSRP
+ *
+ * This is a recursive function that traverses the OpenSRP jurisdiction tree
+ * upwards (i.e. towards the root parent), and returns an array of all the ancestors
+ * of the supplied jurisdiction, including the jurisdiction
+ *
+ * @param jurisdiction - the jurisdiction in question
+ * @param path - array of ancestors
+ */
 export const getAncestors = async (
   jurisdiction: OpenSRPJurisdiction,
   path: OpenSRPJurisdiction[] = []
@@ -24,7 +34,7 @@ export const getAncestors = async (
 
   const service = new OpenSRPService('location');
   const result = await service
-    .read(jurisdiction.properties.parentId, defaultParams)
+    .read(jurisdiction.properties.parentId, defaultLocationParams)
     .then((response: OpenSRPJurisdiction) => {
       if (response) {
         return { error: null, value: response };

--- a/src/components/TreeWalker/index.tsx
+++ b/src/components/TreeWalker/index.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment, useEffect, useState } from 'react';
 import { displayError } from '../../helpers/errors';
 import { getFilterParams, OpenSRPService, URLParams } from '../../services/opensrp';
+import { LOCATION } from './constants';
 import {
   defaultLocationParams,
   defaultLocationPropertyFilters,
@@ -31,7 +32,7 @@ export const defaultTreeWalkerProps: TreeWalkerProps = {
   limits: [],
   params: defaultLocationParams,
   propertyFilters: defaultLocationPropertyFilters,
-  readAPIEndpoint: 'location',
+  readAPIEndpoint: LOCATION,
   serviceClass: OpenSRPService,
 };
 

--- a/src/components/TreeWalker/index.tsx
+++ b/src/components/TreeWalker/index.tsx
@@ -7,7 +7,7 @@ import {
   getAncestors,
   getChildren,
 } from './helpers';
-import { OpenSRPJurisdiction } from './types';
+import { OpenSRPJurisdiction, SimpleJurisdiction } from './types';
 
 /** Type def for the TreeWalker component */
 export interface TreeWalkerProps {
@@ -15,6 +15,7 @@ export interface TreeWalkerProps {
   getAncestorsFunc: typeof getAncestors /** function to get ancestors */;
   getChildrenFunc: typeof getChildren /** function to get children */;
   jurisdictionId: string /** jurisdiction id --> used to start walking the tree from a particular point/node */;
+  limits: SimpleJurisdiction[] /** If set, tree-walking will be limited to these jurisdictions */;
   params: URLParams /** URL params to send with the request to the API */;
   propertyFilters: URLParams /** property filters to send with the request to the API */;
   readAPIEndpoint: string /** the API endpoint to get a single object */;
@@ -27,6 +28,7 @@ export const defaultTreeWalkerProps: TreeWalkerProps = {
   getAncestorsFunc: getAncestors,
   getChildrenFunc: getChildren,
   jurisdictionId: '',
+  limits: [],
   params: defaultLocationParams,
   propertyFilters: defaultLocationPropertyFilters,
   readAPIEndpoint: 'location',
@@ -75,6 +77,7 @@ export function withTreeWalker<T>(WrappedComponent: React.FC<T>) {
       getAncestorsFunc,
       getChildrenFunc,
       jurisdictionId,
+      limits,
       params,
       propertyFilters,
       readAPIEndpoint,
@@ -128,7 +131,7 @@ export function withTreeWalker<T>(WrappedComponent: React.FC<T>) {
 
     // On component mount or whenever parentId changes, we try and get the currentNode's children
     useEffect(() => {
-      getChildrenFunc(paramsToUse, currentNode || parentId)
+      getChildrenFunc(paramsToUse, currentNode || parentId, limits)
         .then(result => {
           if (result.value !== null) {
             setCurrentChildren(result.value);

--- a/src/components/TreeWalker/index.tsx
+++ b/src/components/TreeWalker/index.tsx
@@ -4,130 +4,187 @@ import { getFilterParams, OpenSRPService, URLParams } from '../../services/opens
 import { defaultLocationParams, getAncestors } from './helpers';
 import { OpenSRPJurisdiction } from './types';
 
-interface SimpleProps {
+export interface TreeWalkerProps {
   apiEndpoint: string;
   jurisdictionId: string;
   params: URLParams;
   serviceClass: typeof OpenSRPService;
 }
 
-const defaultSimpleProps: SimpleProps = {
+export const defaultTreeWalkerProps: TreeWalkerProps = {
   apiEndpoint: 'location/findByProperties',
   jurisdictionId: '',
   params: defaultLocationParams,
   serviceClass: OpenSRPService,
 };
 
-const Simple = (props: SimpleProps) => {
-  const [current, setCurrent] = useState<OpenSRPJurisdiction[]>([]);
-  const [selectedJurisdiction, setSelectedJurisdiction] = useState<OpenSRPJurisdiction | null>(
-    null
-  );
-  const [hierarchy, setHierarchy] = useState<OpenSRPJurisdiction[]>([]);
-  const [loading, setLoading] = useState<boolean>(true);
-  const { apiEndpoint, jurisdictionId, params, serviceClass } = props;
+export interface WithWalkerProps extends TreeWalkerProps {
+  current: OpenSRPJurisdiction[];
+  hierarchy: OpenSRPJurisdiction[];
+  loadMore: any;
+  selectedJurisdiction: OpenSRPJurisdiction | null;
+}
 
-  const service = new serviceClass(apiEndpoint);
-
-  const parentId = selectedJurisdiction ? selectedJurisdiction.id : jurisdictionId;
-
-  const propertiesToFilter = {
-    status: 'Active',
-    ...(parentId === '' && { geographicLevel: 0 }),
-    ...(parentId !== '' && { parentId }),
-  };
-
-  const paramsToUse = {
-    ...params,
-    ...(Object.keys(propertiesToFilter).length > 0 && {
-      properties_filter: getFilterParams(propertiesToFilter),
-    }),
-  };
-
-  useEffect(() => {
-    if (!selectedJurisdiction && jurisdictionId !== '') {
-      const singleService = new OpenSRPService('location');
-      singleService
-        .read(jurisdictionId, params)
-        .then((response: OpenSRPJurisdiction) => {
-          if (response) {
-            setSelectedJurisdiction(response);
-            getAncestors(response)
-              .then(result => {
-                if (result.value !== null) {
-                  setHierarchy(result.value);
-                } else {
-                  displayError(result.error);
-                }
-              })
-              .catch((error: Error) => displayError(error));
-          }
-        })
-        .catch((error: Error) => displayError(error));
-    }
-  }, []);
-
-  useEffect(() => {
-    service
-      .list(paramsToUse)
-      .then((response: OpenSRPJurisdiction[]) => {
-        if (response) {
-          setCurrent(response);
-        }
-      })
-      .finally(() => setLoading(false))
-      .catch((error: Error) => displayError(error));
-  }, [parentId]);
-
-  if (loading === true) {
-    return <Fragment>Loading...</Fragment>;
-  }
-
-  const loadMore = (item: OpenSRPJurisdiction, _: Event | React.MouseEvent) => {
-    if (!hierarchy.includes(item)) {
-      hierarchy.push(item);
-    } else {
-      // remove all elements in the array that come after item
-      // hierarchy should include elements only up to the current item
-      hierarchy.length = hierarchy.indexOf(item) + 1;
-    }
-    setHierarchy(hierarchy);
-    setSelectedJurisdiction(item);
-  };
-
-  if (current.length > 0 || selectedJurisdiction !== null) {
-    return (
-      <Fragment>
-        {selectedJurisdiction && (
-          <Fragment>
-            <h4>Currently Selected</h4>
-            <span>{selectedJurisdiction.properties.name}</span>
-          </Fragment>
-        )}
-        <h4>Path</h4>
-        {hierarchy.map((item: OpenSRPJurisdiction, index: number) => (
-          <span key={`jzz-${index}`} onClick={e => loadMore(item, e)}>
-            {' '}
-            {item.properties.name}
-            {'>> '}
-          </span>
-        ))}
-        <h4>Current children</h4>
-        <ul>
-          {current.map((item: OpenSRPJurisdiction, index: number) => (
-            <li key={`jxx-${index}`} onClick={e => loadMore(item, e)}>
-              {item.properties.name}
-            </li>
-          ))}
-        </ul>
-        ;
-      </Fragment>
-    );
-  } else {
-    return <Fragment>No Options</Fragment>;
-  }
+export const defaultWalkerProps: WithWalkerProps = {
+  ...defaultTreeWalkerProps,
+  current: [],
+  hierarchy: [],
+  loadMore: null,
+  selectedJurisdiction: null,
 };
 
-Simple.defaultProps = defaultSimpleProps;
+// This function takes a component...
+export function withTreeWalker<T>(WrappedComponent: React.FC<T>) {
+  // ...and returns another component...
+  const TreeWalker = (props: TreeWalkerProps & T) => {
+    const [current, setCurrent] = useState<OpenSRPJurisdiction[]>([]);
+    const [selectedJurisdiction, setSelectedJurisdiction] = useState<OpenSRPJurisdiction | null>(
+      null
+    );
+    const [hierarchy, setHierarchy] = useState<OpenSRPJurisdiction[]>([]);
+    const [loading, setLoading] = useState<boolean>(true);
+    const { apiEndpoint, jurisdictionId, params, serviceClass } = props;
 
-export { Simple };
+    const service = new serviceClass(apiEndpoint);
+
+    const parentId = selectedJurisdiction ? selectedJurisdiction.id : jurisdictionId;
+
+    const propertiesToFilter = {
+      status: 'Active',
+      ...(parentId === '' && { geographicLevel: 0 }),
+      ...(parentId !== '' && { parentId }),
+    };
+
+    const paramsToUse = {
+      ...params,
+      ...(Object.keys(propertiesToFilter).length > 0 && {
+        properties_filter: getFilterParams(propertiesToFilter),
+      }),
+    };
+
+    useEffect(() => {
+      if (!selectedJurisdiction && jurisdictionId !== '') {
+        const singleService = new OpenSRPService('location');
+        singleService
+          .read(jurisdictionId, params)
+          .then((response: OpenSRPJurisdiction) => {
+            if (response) {
+              setSelectedJurisdiction(response);
+              getAncestors(response)
+                .then(result => {
+                  if (result.value !== null) {
+                    setHierarchy(result.value);
+                  } else {
+                    displayError(result.error);
+                  }
+                })
+                .catch((error: Error) => displayError(error));
+            }
+          })
+          .catch((error: Error) => displayError(error));
+      }
+    }, []);
+
+    useEffect(() => {
+      service
+        .list(paramsToUse)
+        .then((response: OpenSRPJurisdiction[]) => {
+          if (response) {
+            setCurrent(response);
+          }
+        })
+        .finally(() => setLoading(false))
+        .catch((error: Error) => displayError(error));
+    }, [parentId]);
+
+    if (loading === true) {
+      return <Fragment>Loading...</Fragment>;
+    }
+
+    const loadMore = (item: OpenSRPJurisdiction, _: Event | React.MouseEvent) => {
+      if (!hierarchy.includes(item)) {
+        hierarchy.push(item);
+      } else {
+        // remove all elements in the array that come after item
+        // hierarchy should include elements only up to the current item
+        hierarchy.length = hierarchy.indexOf(item) + 1;
+      }
+      setHierarchy(hierarchy);
+      setSelectedJurisdiction(item);
+    };
+
+    const wrappedProps = {
+      ...props,
+      current,
+      hierarchy,
+      loadMore,
+      selectedJurisdiction,
+    };
+
+    return <WrappedComponent {...wrappedProps} />;
+  };
+
+  TreeWalker.defaultProps = {
+    ...defaultTreeWalkerProps,
+    ...defaultWalkerProps,
+  };
+
+  return TreeWalker;
+}
+
+// interface BaseProps extends WithWalkerProps {
+//   smile: string;
+// }
+
+// const Base = (props: BaseProps) => {
+//   const { current, hierarchy, loadMore, selectedJurisdiction, smile } = props;
+
+//   if (current.length > 0 || selectedJurisdiction !== null) {
+//     return (
+//       <Fragment>
+//         {selectedJurisdiction && (
+//           <Fragment>
+//             <h4>Currently Selected {smile}</h4>
+//             <span>{selectedJurisdiction.properties.name}</span>
+//           </Fragment>
+//         )}
+//         <h4>Path</h4>
+//         {hierarchy.map((item: OpenSRPJurisdiction, index: number) => (
+//           <span key={`jzz-${index}`} onClick={e => loadMore(item, e)}>
+//             {' '}
+//             {item.properties.name}
+//             {'>> '}
+//           </span>
+//         ))}
+//         <h4>Current children</h4>
+//         <ul>
+//           {current.map((item: OpenSRPJurisdiction, index: number) => (
+//             <li key={`jxx-${index}`} onClick={e => loadMore(item, e)}>
+//               {item.properties.name}
+//             </li>
+//           ))}
+//         </ul>
+//         ;
+//       </Fragment>
+//     );
+//   } else {
+//     return <Fragment>No Options</Fragment>;
+//   }
+// };
+
+// const xxx: BaseProps = {
+//   ...defaultTreeWalkerProps,
+//   ...defaultWalkerProps,
+//   smile: ":=)"
+// };
+
+// Base.defaultProps = xxx;
+
+// const Simple = withTreeWalker<BaseProps>(Base);
+
+// Simple.defaultProps = {
+//   ...Simple.defaultProps,
+//   // smile: ":=)"
+// }
+
+// export { Simple };

--- a/src/components/TreeWalker/index.tsx
+++ b/src/components/TreeWalker/index.tsx
@@ -10,8 +10,8 @@ import {
 import { OpenSRPJurisdiction, SimpleJurisdiction } from './types';
 
 /** Type def for the TreeWalker component */
-export interface TreeWalkerProps {
-  LoadingIndicator: React.FC /** Element to show loading indicator */;
+export interface TreeWalkerProps<T = any> {
+  LoadingIndicator: React.FC<T> /** Element to show loading indicator */;
   getAncestorsFunc: typeof getAncestors /** function to get ancestors */;
   getChildrenFunc: typeof getChildren /** function to get children */;
   jurisdictionId: string /** jurisdiction id --> used to start walking the tree from a particular point/node */;

--- a/src/components/TreeWalker/index.tsx
+++ b/src/components/TreeWalker/index.tsx
@@ -15,7 +15,6 @@ export interface TreeWalkerProps {
   getAncestorsFunc: typeof getAncestors /** function to get ancestors */;
   getChildrenFunc: typeof getChildren /** function to get children */;
   jurisdictionId: string /** jurisdiction id --> used to start walking the tree from a particular point/node */;
-  listAPIEndpoint: string /** the API endpoint to get a list of objects */;
   params: URLParams /** URL params to send with the request to the API */;
   propertyFilters: URLParams /** property filters to send with the request to the API */;
   readAPIEndpoint: string /** the API endpoint to get a single object */;
@@ -28,7 +27,6 @@ export const defaultTreeWalkerProps: TreeWalkerProps = {
   getAncestorsFunc: getAncestors,
   getChildrenFunc: getChildren,
   jurisdictionId: '',
-  listAPIEndpoint: 'location/findByProperties',
   params: defaultLocationParams,
   propertyFilters: defaultLocationPropertyFilters,
   readAPIEndpoint: 'location',
@@ -77,7 +75,6 @@ export function withTreeWalker<T>(WrappedComponent: React.FC<T>) {
       getAncestorsFunc,
       getChildrenFunc,
       jurisdictionId,
-      listAPIEndpoint,
       params,
       propertyFilters,
       readAPIEndpoint,
@@ -108,13 +105,13 @@ export function withTreeWalker<T>(WrappedComponent: React.FC<T>) {
     //  2. get this currentNode's ancestors and add them to the hierarchy
     useEffect(() => {
       if (!currentNode && jurisdictionId !== '') {
-        const singleService = new OpenSRPService(readAPIEndpoint);
+        const singleService = new serviceClass(readAPIEndpoint);
         singleService
           .read(jurisdictionId, params)
           .then((response: OpenSRPJurisdiction) => {
             if (response) {
               setCurrentNode(response);
-              getAncestorsFunc(response, readAPIEndpoint, serviceClass)
+              getAncestorsFunc(response)
                 .then(result => {
                   if (result.value !== null) {
                     setHierarchy(result.value);
@@ -131,7 +128,7 @@ export function withTreeWalker<T>(WrappedComponent: React.FC<T>) {
 
     // On component mount or whenever parentId changes, we try and get the currentNode's children
     useEffect(() => {
-      getChildrenFunc(paramsToUse, currentNode, listAPIEndpoint, serviceClass)
+      getChildrenFunc(paramsToUse, currentNode)
         .then(result => {
           if (result.value !== null) {
             setCurrentChildren(result.value);

--- a/src/components/TreeWalker/index.tsx
+++ b/src/components/TreeWalker/index.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment, useEffect, useState } from 'react';
 import { displayError } from '../../helpers/errors';
 import { getFilterParams, OpenSRPService, URLParams } from '../../services/opensrp';
-import { LOCATION } from './constants';
+import { COULDNT_LOAD_PARENTS, LOCATION } from './constants';
 import {
   defaultLocationParams,
   defaultLocationPropertyFilters,
@@ -16,6 +16,9 @@ export interface TreeWalkerProps<T = any> {
   getAncestorsFunc: typeof getAncestors /** function to get ancestors */;
   getChildrenFunc: typeof getChildren /** function to get children */;
   jurisdictionId: string /** jurisdiction id --> used to start walking the tree from a particular point/node */;
+  labels: {
+    loadAncestorsError: string;
+  } /** Objects that holds strings to be displayed in the component */;
   limits: SimpleJurisdiction[] /** If set, tree-walking will be limited to these jurisdictions */;
   params: URLParams /** URL params to send with the request to the API */;
   propertyFilters: URLParams /** property filters to send with the request to the API */;
@@ -29,6 +32,9 @@ export const defaultTreeWalkerProps: TreeWalkerProps = {
   getAncestorsFunc: getAncestors,
   getChildrenFunc: getChildren,
   jurisdictionId: '',
+  labels: {
+    loadAncestorsError: COULDNT_LOAD_PARENTS,
+  },
   limits: [],
   params: defaultLocationParams,
   propertyFilters: defaultLocationPropertyFilters,
@@ -78,6 +84,7 @@ export function withTreeWalker<T>(WrappedComponent: React.FC<T>) {
       getAncestorsFunc,
       getChildrenFunc,
       jurisdictionId,
+      labels,
       limits,
       params,
       propertyFilters,
@@ -118,7 +125,7 @@ export function withTreeWalker<T>(WrappedComponent: React.FC<T>) {
           .then((response: OpenSRPJurisdiction) => {
             if (response) {
               setCurrentNode(response);
-              getAncestorsFunc(response)
+              getAncestorsFunc(response, [], labels.loadAncestorsError)
                 .then(result => {
                   if (result.value !== null) {
                     setHierarchy(result.value);

--- a/src/components/TreeWalker/index.tsx
+++ b/src/components/TreeWalker/index.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment, useEffect, useState } from 'react';
-import { displayError } from '../helpers/errors';
-import { getFilterParams, OpenSRPService, URLParams } from '../services/opensrp';
+import { displayError } from '../../helpers/errors';
+import { getFilterParams, OpenSRPService, URLParams } from '../../services/opensrp';
 
 /** interface for jurisdiction options
  * These are received from the OpenSRP API

--- a/src/components/TreeWalker/index.tsx
+++ b/src/components/TreeWalker/index.tsx
@@ -128,7 +128,7 @@ export function withTreeWalker<T>(WrappedComponent: React.FC<T>) {
 
     // On component mount or whenever parentId changes, we try and get the currentNode's children
     useEffect(() => {
-      getChildrenFunc(paramsToUse, currentNode)
+      getChildrenFunc(paramsToUse, currentNode || parentId)
         .then(result => {
           if (result.value !== null) {
             setCurrentChildren(result.value);

--- a/src/components/TreeWalker/index.tsx
+++ b/src/components/TreeWalker/index.tsx
@@ -107,7 +107,10 @@ export function withTreeWalker<T>(WrappedComponent: React.FC<T>) {
     //  1. get the object for jurisdictionId and set it as the currentNode
     //  2. get this currentNode's ancestors and add them to the hierarchy
     useEffect(() => {
-      if (!currentNode && jurisdictionId !== '') {
+      if (
+        (!currentNode && jurisdictionId) !== '' ||
+        (currentNode && currentNode.id !== jurisdictionId)
+      ) {
         const singleService = new serviceClass(readAPIEndpoint);
         singleService
           .read(jurisdictionId, params)
@@ -127,7 +130,7 @@ export function withTreeWalker<T>(WrappedComponent: React.FC<T>) {
           })
           .catch((error: Error) => displayError(error));
       }
-    }, []);
+    }, [jurisdictionId]);
 
     // On component mount or whenever parentId changes, we try and get the currentNode's children
     useEffect(() => {

--- a/src/components/TreeWalker/index.tsx
+++ b/src/components/TreeWalker/index.tsx
@@ -1,7 +1,12 @@
 import React, { Fragment, useEffect, useState } from 'react';
 import { displayError } from '../../helpers/errors';
 import { getFilterParams, OpenSRPService, URLParams } from '../../services/opensrp';
-import { defaultLocationParams, getAncestors, getChildren } from './helpers';
+import {
+  defaultLocationParams,
+  defaultLocationPropertyFilters,
+  getAncestors,
+  getChildren,
+} from './helpers';
 import { OpenSRPJurisdiction } from './types';
 
 /** Type def for the TreeWalker component */
@@ -12,6 +17,7 @@ export interface TreeWalkerProps {
   jurisdictionId: string /** jurisdiction id --> used to start walking the tree from a particular point/node */;
   listAPIEndpoint: string /** the API endpoint to get a list of objects */;
   params: URLParams /** URL params to send with the request to the API */;
+  propertyFilters: URLParams /** property filters to send with the request to the API */;
   readAPIEndpoint: string /** the API endpoint to get a single object */;
   serviceClass: typeof OpenSRPService /** the API helper class */;
 }
@@ -24,6 +30,7 @@ export const defaultTreeWalkerProps: TreeWalkerProps = {
   jurisdictionId: '',
   listAPIEndpoint: 'location/findByProperties',
   params: defaultLocationParams,
+  propertyFilters: defaultLocationPropertyFilters,
   readAPIEndpoint: 'location',
   serviceClass: OpenSRPService,
 };
@@ -72,6 +79,7 @@ export function withTreeWalker<T>(WrappedComponent: React.FC<T>) {
       jurisdictionId,
       listAPIEndpoint,
       params,
+      propertyFilters,
       readAPIEndpoint,
       serviceClass,
     } = props;
@@ -80,7 +88,7 @@ export function withTreeWalker<T>(WrappedComponent: React.FC<T>) {
     const parentId = currentNode ? currentNode.id : jurisdictionId;
 
     const propertiesToFilter = {
-      status: 'Active',
+      ...propertyFilters,
       ...(parentId === '' && { geographicLevel: 0 }),
       ...(parentId !== '' && { parentId }),
     };

--- a/src/components/TreeWalker/tests/fixtures.ts
+++ b/src/components/TreeWalker/tests/fixtures.ts
@@ -80,6 +80,17 @@ export const raNchelenge: OpenSRPJurisdiction = {
   },
 };
 
+export const raKashikishiHAHC: OpenSRPJurisdiction = {
+  ...raZambia,
+  id: limitTree[1].jurisdiction_id,
+  properties: {
+    ...raZambia.properties,
+    geographicLevel: limitTree[1].jurisdiction_geographic_level,
+    name: limitTree[1].jurisdiction_name,
+    parentId: limitTree[1].jurisdiction_parent_id,
+  },
+};
+
 export const raKsh2: OpenSRPJurisdiction = {
   ...raZambia,
   id: limitTree[3].jurisdiction_id,

--- a/src/components/TreeWalker/tests/fixtures.ts
+++ b/src/components/TreeWalker/tests/fixtures.ts
@@ -1,3 +1,5 @@
+import { OpenSRPJurisdiction } from '../types';
+
 export const limitTree = [
   {
     jurisdiction_geographic_level: 1,
@@ -43,7 +45,7 @@ export const limitTree = [
   },
 ];
 
-export const raZambia = {
+export const raZambia: OpenSRPJurisdiction = {
   id: '0ddd9ad1-452b-4825-a92a-49cb9fc82d18',
   properties: {
     code: '22bc44dd-752d-4c20-8761-617361b4f1e7',
@@ -56,7 +58,29 @@ export const raZambia = {
   type: 'Feature',
 };
 
-export const raKsh2 = {
+export const raLuapula: OpenSRPJurisdiction = {
+  ...raZambia,
+  id: limitTree[0].jurisdiction_id,
+  properties: {
+    ...raZambia.properties,
+    geographicLevel: limitTree[0].jurisdiction_geographic_level,
+    name: limitTree[0].jurisdiction_name,
+    parentId: limitTree[0].jurisdiction_parent_id,
+  },
+};
+
+export const raNchelenge: OpenSRPJurisdiction = {
+  ...raZambia,
+  id: limitTree[2].jurisdiction_id,
+  properties: {
+    ...raZambia.properties,
+    geographicLevel: limitTree[2].jurisdiction_geographic_level,
+    name: limitTree[2].jurisdiction_name,
+    parentId: limitTree[2].jurisdiction_parent_id,
+  },
+};
+
+export const raKsh2: OpenSRPJurisdiction = {
   ...raZambia,
   id: limitTree[3].jurisdiction_id,
   properties: {
@@ -67,7 +91,7 @@ export const raKsh2 = {
   },
 };
 
-export const raKsh3 = {
+export const raKsh3: OpenSRPJurisdiction = {
   ...raZambia,
   id: limitTree[4].jurisdiction_id,
   properties: {

--- a/src/components/TreeWalker/tests/fixtures.ts
+++ b/src/components/TreeWalker/tests/fixtures.ts
@@ -1,0 +1,79 @@
+export const limitTree = [
+  {
+    jurisdiction_geographic_level: 1,
+    jurisdiction_id: 'cec79f21-33c3-43f5-a8af-59a47aa61b84',
+    jurisdiction_name: 'ra Luapula',
+    jurisdiction_parent_id: '0ddd9ad1-452b-4825-a92a-49cb9fc82d18',
+    plan_id: 'aadc1c80-23f7-509e-9ca2-1172265c06b9',
+  },
+  {
+    jurisdiction_geographic_level: 3,
+    jurisdiction_id: '8d44d54e-8b4c-465c-9e93-364a25739a6d',
+    jurisdiction_name: 'ra Kashikishi HAHC',
+    jurisdiction_parent_id: 'dfb858b5-b3e5-4871-9d1c-ae2f3fa83b63',
+    plan_id: 'aadc1c80-23f7-509e-9ca2-1172265c06b9',
+  },
+  {
+    jurisdiction_geographic_level: 2,
+    jurisdiction_id: 'dfb858b5-b3e5-4871-9d1c-ae2f3fa83b63',
+    jurisdiction_name: 'ra Nchelenge',
+    jurisdiction_parent_id: 'cec79f21-33c3-43f5-a8af-59a47aa61b84',
+    plan_id: 'aadc1c80-23f7-509e-9ca2-1172265c06b9',
+  },
+  {
+    jurisdiction_geographic_level: 4,
+    jurisdiction_id: 'fca0d71d-0410-45d3-8305-a9f092a150b8',
+    jurisdiction_name: 'ra_ksh_2',
+    jurisdiction_parent_id: '8d44d54e-8b4c-465c-9e93-364a25739a6d',
+    plan_id: 'aadc1c80-23f7-509e-9ca2-1172265c06b9',
+  },
+  {
+    jurisdiction_geographic_level: 4,
+    jurisdiction_id: 'xyz0d71d-0410-45d3-8305-a9f092a150b8',
+    jurisdiction_name: 'ra_ksh_3',
+    jurisdiction_parent_id: '8d44d54e-8b4c-465c-9e93-364a25739a6d',
+    plan_id: 'aadc1c80-23f7-509e-9ca2-1172265c06b9',
+  },
+  {
+    jurisdiction_geographic_level: 0,
+    jurisdiction_id: '0ddd9ad1-452b-4825-a92a-49cb9fc82d18',
+    jurisdiction_name: 'ra Zambia',
+    jurisdiction_parent_id: '',
+    plan_id: 'aadc1c80-23f7-509e-9ca2-1172265c06b9',
+  },
+];
+
+export const raZambia = {
+  id: '0ddd9ad1-452b-4825-a92a-49cb9fc82d18',
+  properties: {
+    code: '22bc44dd-752d-4c20-8761-617361b4f1e7',
+    geographicLevel: 0,
+    name: 'ra Zambia',
+    status: 'Active',
+    version: 0,
+  },
+  serverVersion: 1574076919370,
+  type: 'Feature',
+};
+
+export const raKsh2 = {
+  ...raZambia,
+  id: limitTree[3].jurisdiction_id,
+  properties: {
+    ...raZambia.properties,
+    geographicLevel: limitTree[3].jurisdiction_geographic_level,
+    name: limitTree[3].jurisdiction_name,
+    parentId: limitTree[3].jurisdiction_parent_id,
+  },
+};
+
+export const raKsh3 = {
+  ...raZambia,
+  id: limitTree[4].jurisdiction_id,
+  properties: {
+    ...raZambia.properties,
+    geographicLevel: limitTree[4].jurisdiction_geographic_level,
+    name: limitTree[4].jurisdiction_name,
+    parentId: limitTree[4].jurisdiction_parent_id,
+  },
+};

--- a/src/components/TreeWalker/tests/helpers.test.ts
+++ b/src/components/TreeWalker/tests/helpers.test.ts
@@ -32,7 +32,6 @@ describe('TreeWalker/helpers', () => {
 
   it('getAncestors works for non-root jurisdictions', async () => {
     fetch.mockResponses(
-      [JSON.stringify(raNchelenge), { status: 200 }],
       [JSON.stringify(raLuapula), { status: 200 }],
       [JSON.stringify(raZambia), { status: 200 }]
     );
@@ -40,10 +39,6 @@ describe('TreeWalker/helpers', () => {
     const result = await getAncestors(raNchelenge);
     await flushPromises();
     expect(fetch.mock.calls).toEqual([
-      [
-        'https://reveal-stage.smartregister.org/opensrp/rest/location/cec79f21-33c3-43f5-a8af-59a47aa61b84?is_jurisdiction=true&return_geometry=false',
-        partOfResult,
-      ],
       [
         'https://reveal-stage.smartregister.org/opensrp/rest/location/cec79f21-33c3-43f5-a8af-59a47aa61b84?is_jurisdiction=true&return_geometry=false',
         partOfResult,

--- a/src/components/TreeWalker/tests/helpers.test.ts
+++ b/src/components/TreeWalker/tests/helpers.test.ts
@@ -69,14 +69,7 @@ describe('TreeWalker/helpers', () => {
     expect(fetch.mock.calls).toEqual([
       [
         'https://reveal-stage.smartregister.org/opensrp/rest/location/findByJurisdictionIds?is_jurisdiction=true&properties_filter=status%3AActive%2CgeographicLevel%3A0&return_geometry=false&jurisdiction_ids=0ddd9ad1-452b-4825-a92a-49cb9fc82d18',
-        {
-          headers: {
-            accept: 'application/json',
-            authorization: 'Bearer null',
-            'content-type': 'application/json;charset=UTF-8',
-          },
-          method: 'GET',
-        },
+        partOfResult,
       ],
     ]);
     expect(result).toEqual({ error: null, value: [raZambia] });
@@ -95,14 +88,7 @@ describe('TreeWalker/helpers', () => {
     expect(fetch.mock.calls).toEqual([
       [
         'https://reveal-stage.smartregister.org/opensrp/rest/location/findByProperties?is_jurisdiction=true&properties_filter=status%3AActive%2CgeographicLevel%3A0&return_geometry=false',
-        {
-          headers: {
-            accept: 'application/json',
-            authorization: 'Bearer null',
-            'content-type': 'application/json;charset=UTF-8',
-          },
-          method: 'GET',
-        },
+        partOfResult,
       ],
     ]);
     expect(result).toEqual({ error: null, value: [raZambia] });
@@ -134,14 +120,7 @@ describe('TreeWalker/helpers', () => {
     expect(fetch.mock.calls).toEqual([
       [
         'https://reveal-stage.smartregister.org/opensrp/rest/location/findByJurisdictionIds?is_jurisdiction=true&properties_filter=status%3AActive%2CparentId%3A8d44d54e-8b4c-465c-9e93-364a25739a6d&return_geometry=false&jurisdiction_ids=fca0d71d-0410-45d3-8305-a9f092a150b8%2Cxyz0d71d-0410-45d3-8305-a9f092a150b8',
-        {
-          headers: {
-            accept: 'application/json',
-            authorization: 'Bearer null',
-            'content-type': 'application/json;charset=UTF-8',
-          },
-          method: 'GET',
-        },
+        partOfResult,
       ],
     ]);
     expect(result).toEqual({ error: null, value: [raKsh2, raKsh3] });
@@ -160,25 +139,11 @@ describe('TreeWalker/helpers', () => {
     expect(fetch.mock.calls).toEqual([
       [
         'https://reveal-stage.smartregister.org/opensrp/rest/location/findByJurisdictionIds?is_jurisdiction=true&properties_filter=status%3AActive%2CparentId%3A8d44d54e-8b4c-465c-9e93-364a25739a6d&return_geometry=false&jurisdiction_ids=fca0d71d-0410-45d3-8305-a9f092a150b8',
-        {
-          headers: {
-            accept: 'application/json',
-            authorization: 'Bearer null',
-            'content-type': 'application/json;charset=UTF-8',
-          },
-          method: 'GET',
-        },
+        partOfResult,
       ],
       [
         'https://reveal-stage.smartregister.org/opensrp/rest/location/findByJurisdictionIds?is_jurisdiction=true&properties_filter=status%3AActive%2CparentId%3A8d44d54e-8b4c-465c-9e93-364a25739a6d&return_geometry=false&jurisdiction_ids=xyz0d71d-0410-45d3-8305-a9f092a150b8',
-        {
-          headers: {
-            accept: 'application/json',
-            authorization: 'Bearer null',
-            'content-type': 'application/json;charset=UTF-8',
-          },
-          method: 'GET',
-        },
+        partOfResult,
       ],
     ]);
     expect(result2).toEqual({ error: null, value: [raKsh2, raKsh3] });
@@ -197,14 +162,7 @@ describe('TreeWalker/helpers', () => {
     expect(fetch.mock.calls).toEqual([
       [
         'https://reveal-stage.smartregister.org/opensrp/rest/location/findByProperties?is_jurisdiction=true&properties_filter=status%3AActive%2CparentId%3A8d44d54e-8b4c-465c-9e93-364a25739a6d&return_geometry=false',
-        {
-          headers: {
-            accept: 'application/json',
-            authorization: 'Bearer null',
-            'content-type': 'application/json;charset=UTF-8',
-          },
-          method: 'GET',
-        },
+        partOfResult,
       ],
     ]);
     expect(result).toEqual({ error: null, value: [raKsh2, raKsh3] });

--- a/src/components/TreeWalker/tests/helpers.test.ts
+++ b/src/components/TreeWalker/tests/helpers.test.ts
@@ -1,0 +1,168 @@
+import flushPromises from 'flush-promises';
+import { getChildren } from '../helpers';
+import { limitTree, raKsh2, raKsh3, raZambia } from './fixtures';
+
+/* tslint:disable-next-line no-var-requires */
+const fetch = require('jest-fetch-mock');
+
+describe('TreeWalker/helpers', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    fetchMock.mockClear();
+    fetchMock.resetMocks();
+  });
+
+  it('getChildren works for getting root jurisdictions', async () => {
+    fetch.mockResponseOnce(JSON.stringify([raZambia]), { status: 200 });
+
+    const params = {
+      is_jurisdiction: true,
+      properties_filter: 'status:Active,geographicLevel:0',
+      return_geometry: false,
+    };
+    const result = await getChildren(params, null, limitTree);
+    await flushPromises();
+    expect(fetch.mock.calls).toEqual([
+      [
+        'https://reveal-stage.smartregister.org/opensrp/rest/location/findByJurisdictionIds?is_jurisdiction=true&properties_filter=status%3AActive%2CgeographicLevel%3A0&return_geometry=false&jurisdiction_ids=0ddd9ad1-452b-4825-a92a-49cb9fc82d18',
+        {
+          headers: {
+            accept: 'application/json',
+            authorization: 'Bearer null',
+            'content-type': 'application/json;charset=UTF-8',
+          },
+          method: 'GET',
+        },
+      ],
+    ]);
+    expect(result).toEqual({ error: null, value: [raZambia] });
+  });
+
+  it('getChildren works for getting root jurisdictions with limitTree not set', async () => {
+    fetch.mockResponseOnce(JSON.stringify([raZambia]), { status: 200 });
+
+    const params = {
+      is_jurisdiction: true,
+      properties_filter: 'status:Active,geographicLevel:0',
+      return_geometry: false,
+    };
+    const result = await getChildren(params, null);
+    await flushPromises();
+    expect(fetch.mock.calls).toEqual([
+      [
+        'https://reveal-stage.smartregister.org/opensrp/rest/location/findByProperties?is_jurisdiction=true&properties_filter=status%3AActive%2CgeographicLevel%3A0&return_geometry=false',
+        {
+          headers: {
+            accept: 'application/json',
+            authorization: 'Bearer null',
+            'content-type': 'application/json;charset=UTF-8',
+          },
+          method: 'GET',
+        },
+      ],
+    ]);
+    expect(result).toEqual({ error: null, value: [raZambia] });
+  });
+
+  it('getChildren does not return duplicate jurisdictions', async () => {
+    fetch.mockResponseOnce(JSON.stringify([raZambia, raZambia]), { status: 200 });
+
+    const params = {
+      is_jurisdiction: true,
+      properties_filter: 'status:Active,geographicLevel:0',
+      return_geometry: false,
+    };
+    const result = await getChildren(params, null, limitTree);
+    await flushPromises();
+    expect(result).toEqual({ error: null, value: [raZambia] });
+  });
+
+  it('getChildren works for getting non-root jurisdictions', async () => {
+    fetch.mockResponseOnce(JSON.stringify([raKsh2, raKsh3]), { status: 200 });
+
+    const params = {
+      is_jurisdiction: true,
+      properties_filter: `status:Active,parentId:${limitTree[1].jurisdiction_id}`,
+      return_geometry: false,
+    };
+    const result = await getChildren(params, limitTree[1].jurisdiction_id, limitTree);
+    await flushPromises();
+    expect(fetch.mock.calls).toEqual([
+      [
+        'https://reveal-stage.smartregister.org/opensrp/rest/location/findByJurisdictionIds?is_jurisdiction=true&properties_filter=status%3AActive%2CparentId%3A8d44d54e-8b4c-465c-9e93-364a25739a6d&return_geometry=false&jurisdiction_ids=fca0d71d-0410-45d3-8305-a9f092a150b8%2Cxyz0d71d-0410-45d3-8305-a9f092a150b8',
+        {
+          headers: {
+            accept: 'application/json',
+            authorization: 'Bearer null',
+            'content-type': 'application/json;charset=UTF-8',
+          },
+          method: 'GET',
+        },
+      ],
+    ]);
+    expect(result).toEqual({ error: null, value: [raKsh2, raKsh3] });
+
+    // Same data as the above but now test that it will work when chunkSize requires multiple fetches from the API
+    fetchMock.mockClear();
+    fetchMock.resetMocks();
+
+    fetch.mockResponses(
+      [JSON.stringify([raKsh2]), { status: 200 }],
+      [JSON.stringify([raKsh3]), { status: 200 }]
+    );
+
+    const result2 = await getChildren(params, limitTree[1].jurisdiction_id, limitTree, 1);
+    await flushPromises();
+    expect(fetch.mock.calls).toEqual([
+      [
+        'https://reveal-stage.smartregister.org/opensrp/rest/location/findByJurisdictionIds?is_jurisdiction=true&properties_filter=status%3AActive%2CparentId%3A8d44d54e-8b4c-465c-9e93-364a25739a6d&return_geometry=false&jurisdiction_ids=fca0d71d-0410-45d3-8305-a9f092a150b8',
+        {
+          headers: {
+            accept: 'application/json',
+            authorization: 'Bearer null',
+            'content-type': 'application/json;charset=UTF-8',
+          },
+          method: 'GET',
+        },
+      ],
+      [
+        'https://reveal-stage.smartregister.org/opensrp/rest/location/findByJurisdictionIds?is_jurisdiction=true&properties_filter=status%3AActive%2CparentId%3A8d44d54e-8b4c-465c-9e93-364a25739a6d&return_geometry=false&jurisdiction_ids=xyz0d71d-0410-45d3-8305-a9f092a150b8',
+        {
+          headers: {
+            accept: 'application/json',
+            authorization: 'Bearer null',
+            'content-type': 'application/json;charset=UTF-8',
+          },
+          method: 'GET',
+        },
+      ],
+    ]);
+    expect(result2).toEqual({ error: null, value: [raKsh2, raKsh3] });
+  });
+
+  it('getChildren works for getting non-root jurisdictions with limitTree not set', async () => {
+    fetch.mockResponseOnce(JSON.stringify([raKsh2, raKsh3]), { status: 200 });
+
+    const params = {
+      is_jurisdiction: true,
+      properties_filter: `status:Active,parentId:${limitTree[1].jurisdiction_id}`,
+      return_geometry: false,
+    };
+    const result = await getChildren(params, limitTree[1].jurisdiction_id);
+    await flushPromises();
+    expect(fetch.mock.calls).toEqual([
+      [
+        'https://reveal-stage.smartregister.org/opensrp/rest/location/findByProperties?is_jurisdiction=true&properties_filter=status%3AActive%2CparentId%3A8d44d54e-8b4c-465c-9e93-364a25739a6d&return_geometry=false',
+        {
+          headers: {
+            accept: 'application/json',
+            authorization: 'Bearer null',
+            'content-type': 'application/json;charset=UTF-8',
+          },
+          method: 'GET',
+        },
+      ],
+    ]);
+    expect(result).toEqual({ error: null, value: [raKsh2, raKsh3] });
+  });
+});

--- a/src/components/TreeWalker/tests/index.test.tsx
+++ b/src/components/TreeWalker/tests/index.test.tsx
@@ -74,6 +74,9 @@ describe('PlanAssignment/withTreeWalker', () => {
       getChildrenFunc: getChildren,
       hierarchy: [],
       jurisdictionId: raNchelenge.id,
+      labels: {
+        loadAncestorsError: 'Could not load parents',
+      },
       limits: limitTree,
       loadChildren: expect.any(Function),
       params: defaultLocationParams,

--- a/src/components/TreeWalker/tests/index.test.tsx
+++ b/src/components/TreeWalker/tests/index.test.tsx
@@ -1,0 +1,151 @@
+import { mount } from 'enzyme';
+import flushPromises from 'flush-promises';
+import React from 'react';
+import { OpenSRPService } from '../../../services/opensrp';
+import {
+  defaultLocationParams,
+  defaultLocationPropertyFilters,
+  getAncestors,
+  getChildren,
+} from '../helpers';
+import { withTreeWalker, WithWalkerProps } from '../index';
+import {
+  limitTree,
+  raKashikishiHAHC,
+  raKsh2,
+  raKsh3,
+  raLuapula,
+  raNchelenge,
+  raZambia,
+} from './fixtures';
+
+/* tslint:disable-next-line no-var-requires */
+const fetch = require('jest-fetch-mock');
+
+describe('PlanAssignment/withTreeWalker', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    fetchMock.mockClear();
+    fetchMock.resetMocks();
+  });
+
+  const partOfResult = {
+    headers: {
+      accept: 'application/json',
+      authorization: 'Bearer null',
+      'content-type': 'application/json;charset=UTF-8',
+    },
+    method: 'GET',
+  };
+
+  it('TreeWalker receives the expected props', async () => {
+    fetch.mockResponses(
+      [JSON.stringify(raNchelenge), { status: 200 }],
+      [JSON.stringify([raKashikishiHAHC]), { status: 200 }],
+      [JSON.stringify(raLuapula), { status: 200 }],
+      [JSON.stringify(raZambia), { status: 200 }],
+      [JSON.stringify([raKsh2, raKsh3]), { status: 200 }]
+    );
+
+    interface SomeProps extends WithWalkerProps {
+      smile: string;
+    }
+
+    const SomeComponent = withTreeWalker<SomeProps>(() => <div>I Love Oov</div>);
+
+    const wrapper = mount(
+      <SomeComponent jurisdictionId={raNchelenge.id} limits={limitTree} smile=":-)" />
+    );
+
+    // initially shows loading
+    expect(wrapper.find('LoadingIndicator').length).toEqual(1);
+
+    await flushPromises();
+    wrapper.update();
+
+    // then shows the actual content
+    expect(wrapper.find('LoadingIndicator').length).toEqual(0);
+
+    const expectedProps = {
+      LoadingIndicator: expect.any(Function),
+      currentChildren: [],
+      currentNode: null,
+      getAncestorsFunc: getAncestors,
+      getChildrenFunc: getChildren,
+      hierarchy: [],
+      jurisdictionId: raNchelenge.id,
+      limits: limitTree,
+      loadChildren: expect.any(Function),
+      params: defaultLocationParams,
+      propertyFilters: defaultLocationPropertyFilters,
+      readAPIEndpoint: 'location',
+      serviceClass: OpenSRPService,
+      smile: ':-)',
+    };
+
+    expect(wrapper.find('TreeWalker').props()).toEqual(expectedProps);
+
+    // for some reason we cant select the wrapped component directly, so we get it
+    // through the div (that we know is there) and its parent
+    expect(
+      wrapper
+        .find('div')
+        .parent()
+        .props()
+    ).toEqual({
+      ...expectedProps,
+      currentChildren: [raKashikishiHAHC],
+      currentNode: raNchelenge,
+      hierarchy: [raZambia, raLuapula, raNchelenge],
+    });
+
+    expect(fetch.mock.calls).toEqual([
+      [
+        'https://reveal-stage.smartregister.org/opensrp/rest/location/dfb858b5-b3e5-4871-9d1c-ae2f3fa83b63?is_jurisdiction=true&return_geometry=false',
+        partOfResult,
+      ],
+      [
+        'https://reveal-stage.smartregister.org/opensrp/rest/location/findByJurisdictionIds?is_jurisdiction=true&return_geometry=false&properties_filter=status%3AActive%2CparentId%3Adfb858b5-b3e5-4871-9d1c-ae2f3fa83b63&jurisdiction_ids=8d44d54e-8b4c-465c-9e93-364a25739a6d',
+        partOfResult,
+      ],
+      [
+        'https://reveal-stage.smartregister.org/opensrp/rest/location/cec79f21-33c3-43f5-a8af-59a47aa61b84?is_jurisdiction=true&return_geometry=false',
+        partOfResult,
+      ],
+      [
+        'https://reveal-stage.smartregister.org/opensrp/rest/location/0ddd9ad1-452b-4825-a92a-49cb9fc82d18?is_jurisdiction=true&return_geometry=false',
+        partOfResult,
+      ],
+    ]);
+
+    // now lets try and call loadChildren (to, well, load children of raKashikishiHAHC)
+    const loadChildrenFunc = (wrapper
+      .find('div')
+      .parent()
+      .props() as WithWalkerProps).loadChildren;
+    loadChildrenFunc(raKashikishiHAHC, {} as any);
+
+    await flushPromises();
+    wrapper.update();
+
+    // the props change to reflect this
+    expect(
+      wrapper
+        .find('div')
+        .parent()
+        .props()
+    ).toEqual({
+      ...expectedProps,
+      currentChildren: [raKsh2, raKsh3],
+      currentNode: raKashikishiHAHC,
+      hierarchy: [raZambia, raLuapula, raNchelenge, raKashikishiHAHC],
+    });
+
+    expect(fetch.mock.calls[4]).toEqual([
+      'https://reveal-stage.smartregister.org/opensrp/rest/location/findByJurisdictionIds?is_jurisdiction=true&return_geometry=false&properties_filter=status%3AActive%2CparentId%3A8d44d54e-8b4c-465c-9e93-364a25739a6d&jurisdiction_ids=fca0d71d-0410-45d3-8305-a9f092a150b8%2Cxyz0d71d-0410-45d3-8305-a9f092a150b8',
+      partOfResult,
+    ]);
+
+    wrapper.unmount();
+  });
+});

--- a/src/components/TreeWalker/types.ts
+++ b/src/components/TreeWalker/types.ts
@@ -1,0 +1,12 @@
+export interface OpenSRPJurisdiction {
+  id: string;
+  properties: {
+    status: string;
+    name: string;
+    geographicLevel: number;
+    parentId?: string;
+    version: string | number;
+  };
+  serverVersion: number;
+  type: 'Feature';
+}

--- a/src/components/TreeWalker/types.ts
+++ b/src/components/TreeWalker/types.ts
@@ -2,10 +2,11 @@
 export interface OpenSRPJurisdiction {
   id: string;
   properties: {
-    status: string;
-    name: string;
+    code?: string;
     geographicLevel: number;
+    name: string;
     parentId?: string;
+    status: string;
     version: string | number;
   };
   serverVersion: number;

--- a/src/components/TreeWalker/types.ts
+++ b/src/components/TreeWalker/types.ts
@@ -1,3 +1,4 @@
+/** The shape of a jurisdiction received from the OpenSRP API */
 export interface OpenSRPJurisdiction {
   id: string;
   properties: {
@@ -9,4 +10,15 @@ export interface OpenSRPJurisdiction {
   };
   serverVersion: number;
   type: 'Feature';
+}
+
+/** Used to describe OpenSRP jurisdictions in short form */
+export interface SimpleJurisdicion {
+  id: string;
+  parentId: string;
+}
+
+/** Object containing known API endpoints by name */
+export interface APIEndpoints {
+  [key: string]: string;
 }

--- a/src/components/TreeWalker/types.ts
+++ b/src/components/TreeWalker/types.ts
@@ -14,8 +14,8 @@ export interface OpenSRPJurisdiction {
 
 /** Used to describe OpenSRP jurisdictions in short form */
 export interface SimpleJurisdiction {
-  id: string;
-  parentId: string;
+  jurisdiction_id: string;
+  jurisdiction_parent_id: string;
 }
 
 /** Object containing known API endpoints by name */

--- a/src/components/TreeWalker/types.ts
+++ b/src/components/TreeWalker/types.ts
@@ -13,7 +13,7 @@ export interface OpenSRPJurisdiction {
 }
 
 /** Used to describe OpenSRP jurisdictions in short form */
-export interface SimpleJurisdicion {
+export interface SimpleJurisdiction {
   id: string;
   parentId: string;
 }

--- a/src/components/tree.tsx
+++ b/src/components/tree.tsx
@@ -1,0 +1,134 @@
+import React, { Fragment, useEffect, useState } from 'react';
+import { displayError } from '../helpers/errors';
+import { getFilterParams, OpenSRPService, URLParams } from '../services/opensrp';
+
+/** interface for jurisdiction options
+ * These are received from the OpenSRP API
+ */
+interface OpenSRPJurisdiction {
+  id: string;
+  properties: {
+    status: string;
+    name: string;
+    geographicLevel: number;
+    version: string | number;
+  };
+  serverVersion: number;
+  type: 'Feature';
+}
+
+interface SimpleProps {
+  apiEndpoint: string;
+  jurisdictionId: string;
+  params: URLParams;
+  serviceClass: typeof OpenSRPService;
+}
+
+const defaultSimpleProps: SimpleProps = {
+  apiEndpoint: 'location/findByProperties',
+  jurisdictionId: '', // '3019',
+  params: {
+    is_jurisdiction: true,
+    return_geometry: false,
+  },
+  serviceClass: OpenSRPService,
+};
+
+const Simple = (props: SimpleProps) => {
+  // const [root, setRoot] = useState<OpenSRPJurisdiction | null>(null);
+  const [current, setCurrent] = useState<OpenSRPJurisdiction[]>([]);
+  const [selectedJurisdiction, setSelectedJurisdiction] = useState<OpenSRPJurisdiction | null>(
+    null
+  );
+  const [hierarchy, setHierarchy] = useState<OpenSRPJurisdiction[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const { apiEndpoint, jurisdictionId, params, serviceClass } = props;
+
+  const service = new serviceClass(apiEndpoint);
+
+  const parentId = selectedJurisdiction ? selectedJurisdiction.id : jurisdictionId;
+
+  const propertiesToFilter = {
+    status: 'Active',
+    ...(parentId === '' && { geographicLevel: 0 }),
+    ...(parentId !== '' && { parentId }),
+  };
+
+  const paramsToUse = {
+    ...params,
+    ...(Object.keys(propertiesToFilter).length > 0 && {
+      properties_filter: getFilterParams(propertiesToFilter),
+    }),
+  };
+
+  // const backFill = () => {
+  //   const newParams = {
+  //     ...params,
+  //     properties_filter: getFilterParams({
+  //       status: 'Active',
+  //       id: jurisdictionId
+  //     })
+  //   }
+  //   while (root === null) {
+  //     service.list(paramsToUse).then((response: OpenSRPJurisdiction[]) => {
+  //       setCurrent(response);
+  //     }).catch((error: Error) => displayError(error));
+  //   }
+  // }
+
+  useEffect(() => {
+    service
+      .list(paramsToUse)
+      .then((response: OpenSRPJurisdiction[]) => {
+        setCurrent(response);
+      })
+      .finally(() => setLoading(false))
+      .catch((error: Error) => displayError(error));
+  }, [parentId]);
+
+  if (loading === true) {
+    return <Fragment>Loading...</Fragment>;
+  }
+
+  const loadMore = (item: OpenSRPJurisdiction, _: Event | React.MouseEvent) => {
+    hierarchy.push(item);
+    setHierarchy(hierarchy);
+    setSelectedJurisdiction(item);
+  };
+
+  if (current.length > 0 || selectedJurisdiction !== null) {
+    return (
+      <Fragment>
+        {selectedJurisdiction && (
+          <Fragment>
+            <h4>Currently Selected</h4>
+            <span>{selectedJurisdiction.properties.name}</span>
+          </Fragment>
+        )}
+        <h4>Path</h4>
+        {hierarchy.map((item: OpenSRPJurisdiction, index: number) => (
+          <span key={`jzz-${index}`} onClick={e => loadMore(item, e)}>
+            {' '}
+            {item.properties.name}
+            {'>> '}
+          </span>
+        ))}
+        <h4>Current children</h4>
+        <ul>
+          {current.map((item: OpenSRPJurisdiction, index: number) => (
+            <li key={`jxx-${index}`} onClick={e => loadMore(item, e)}>
+              {item.properties.name}
+            </li>
+          ))}
+        </ul>
+        ;
+      </Fragment>
+    );
+  } else {
+    return <Fragment>No Options</Fragment>;
+  }
+};
+
+Simple.defaultProps = defaultSimpleProps;
+
+export { Simple };

--- a/src/components/tree.tsx
+++ b/src/components/tree.tsx
@@ -37,7 +37,7 @@ const defaultSimpleProps: SimpleProps = {
   serviceClass: OpenSRPService,
 };
 
-const getPath = async (
+const getAncestors = async (
   jurisdiction: OpenSRPJurisdiction,
   path: OpenSRPJurisdiction[] = []
 ): Promise<OpenSRPJurisdiction[] | null> => {
@@ -62,7 +62,7 @@ const getPath = async (
   if (!parentJurisdiction) {
     return null;
   } else {
-    return getPath(parentJurisdiction, path);
+    return getAncestors(parentJurisdiction, path);
   }
 };
 
@@ -100,7 +100,7 @@ const Simple = (props: SimpleProps) => {
         .then((response: OpenSRPJurisdiction) => {
           if (response) {
             setSelectedJurisdiction(response);
-            getPath(response)
+            getAncestors(response)
               .then((path: OpenSRPJurisdiction[] | null) => {
                 if (path) {
                   setHierarchy(path);


### PR DESCRIPTION
This PR adds a higher order component and its associated helper functions that allow for easily building components that traverse the OpenSRP jurisdiction tree.

This is built off of the ideas in the [JurisdictionSelect component](https://github.com/onaio/reveal-frontend/blob/72abd6d96d181d2b2c4d8d722fdf49355096322d/src/components/forms/JurisdictionSelect/index.tsx), and is eventually meant to replace the tree traversal parts of JurisdictionSelect.

Finally, this is meant to be an OpenSRP package, [but that work will be done later](https://github.com/OpenSRP/opensrp-web/issues/255).

Fix: #918 Fix: #951 and is part of #892 and #788