### PR TITLE
Show all plans if enabled plan types not defined

### DIFF
--- a/src/configs/env.ts
+++ b/src/configs/env.ts
@@ -302,7 +302,9 @@ export const REACT_APP_NAME = process.env.REACT_APP_NAME;
 export type REACT_APP_NAME = typeof REACT_APP_NAME;
 
 /** list of plan types to be added to intervention type field when adding plans */
-export const ENABLED_PLAN_TYPES = String(process.env.REACT_APP_ENABLED_PLAN_TYPES || '').split(',');
+export const ENABLED_PLAN_TYPES = String(
+  process.env.REACT_APP_ENABLED_PLAN_TYPES || 'FI,IRS,MDA,MDA-Point'
+).split(',');
 export type ENABLED_PLAN_TYPES = typeof ENABLED_PLAN_TYPES;
 
 /** list of FI reasons enabled */


### PR DESCRIPTION
Provides default fall back plans types if enabled plan types are not defined.
issue #915 