### PR TITLE
Fix wrapping text on customise columns in the manage plans page

### DIFF
--- a/src/containers/pages/InterventionPlan/PlanDefinitionList/index.css
+++ b/src/containers/pages/InterventionPlan/PlanDefinitionList/index.css
@@ -1,0 +1,3 @@
+.p-3.column-hider.dropdown-menu.show {
+  min-width: 270px !important;
+}

--- a/src/containers/pages/InterventionPlan/PlanDefinitionList/index.tsx
+++ b/src/containers/pages/InterventionPlan/PlanDefinitionList/index.tsx
@@ -36,6 +36,7 @@ import plansByUserReducer, {
   makePlansByUserNamesSelector,
   reducerName as plansByUserReducerName,
 } from '../../../../store/ducks/opensrp/planIdsByUser';
+import './index.css';
 import { TableColumns } from './utils';
 
 /** register the plan definitions reducer */


### PR DESCRIPTION
resolves #932
<img width="873" alt="Screenshot 2020-06-23 at 23 44 58" src="https://user-images.githubusercontent.com/9564887/85460135-99a53e80-b5ab-11ea-9bef-6e0c7517f2b2.png">
