### PR TITLE
AutoSelecting top node should cascade the selection to child nodes

### DIFF
--- a/src/store/ducks/opensrp/hierarchies/tests/index.test.tsx
+++ b/src/store/ducks/opensrp/hierarchies/tests/index.test.tsx
@@ -88,7 +88,7 @@ describe('reducers/opensrp/hierarchies', () => {
   it('auto selecting nodes works', () => {
     // checking that dispatching actions has desired effect
     const rootJurisdictionId = '2942';
-    const nodeIdToAutoSelect = '3951';
+    const nodeIdToAutoSelect = '2942';
     const callback = (node: TreeNode) => node.model.id === nodeIdToAutoSelect;
     const filters = {
       rootJurisdictionId,

--- a/src/store/ducks/opensrp/hierarchies/utils.tsx
+++ b/src/store/ducks/opensrp/hierarchies/utils.tsx
@@ -169,7 +169,11 @@ export const autoSelectNodesAndCascade = (
   const parentNodes: TreeNode[] = [];
   treeClone.walk(node => {
     if (callback(node)) {
-      node.model[META_FIELD_NAME][SELECT_KEY] = true;
+      node.walk(nd => {
+        nd.model[META_FIELD_NAME][SELECT_KEY] = true;
+        // removing this return cause a type error, that's its sole purpose
+        return true;
+      });
       parentNodes.push(node);
     }
     return true;


### PR DESCRIPTION
Bug Description

Earlier autoselecting a node worked fine for just that one node, hence if you autoselected a node that wasn't a leaf node you would have a selected parent node with unselected child nodes, now autoselecting any node makes sure the selection cascades to the children of that node.