### PR TITLE
Add ability to get missing jurisdiction ids

### DIFF
--- a/src/store/ducks/opensrp/jurisdictions/index.ts
+++ b/src/store/ducks/opensrp/jurisdictions/index.ts
@@ -148,3 +148,32 @@ export const getJurisdictionsFC = () =>
       };
     }
   );
+
+/** Get Missing Jurisdiction Ids
+ *
+ * This is a convenient selector that takes an array of jurisdiction ids and then
+ * returns the ones that are not already existing in the Redux store.
+ *
+ * Passing filterGeom === true will additionally return ids of jurisdictions that have
+ * no geometry field.
+ *
+ * The initial use-case of this is to provide the ability to figure out which jurisdiction
+ * ids are missing from a known list of ids; and which are both missing and have no
+ * geometry.
+ *
+ * ^^ Might be useful when we are trying to figure out which jurisdictions to fetch from
+ * OpenSRP API when we need geometries.
+ *
+ * @param state - the store
+ * @param props -  the filterProps
+ */
+export const getMissingJurisdictionIds = () =>
+  createSelector(
+    [getJurisdictionIds(), getJurisdictionIdsArray],
+    (jurisdictionIds, inputJurisdictionIdsArray): string[] => {
+      if (!inputJurisdictionIdsArray) {
+        return jurisdictionIds;
+      }
+      return inputJurisdictionIdsArray.filter(id => !jurisdictionIds.includes(id));
+    }
+  );

--- a/src/store/ducks/opensrp/jurisdictions/index.ts
+++ b/src/store/ducks/opensrp/jurisdictions/index.ts
@@ -40,6 +40,7 @@ export const removeJurisdictions = removeActionCreatorFactory(reducerName);
 // selectors
 /** prop filters to customize selector queries */
 export interface Filters {
+  filterGeom?: boolean /** whether to filter jurisdictions that have geometry field */;
   jurisdictionId?: string /** jurisdiction id */;
   jurisdictionIdsArray?: string[] /** array of jurisdiction ids */;
   parentId?: string /** parent id */;
@@ -63,6 +64,12 @@ export const getParentId = (_: Partial<Store>, props: Filters) => props.parentId
  */
 export const getJurisdictionIdsArray = (_: Partial<Store>, props: Filters) =>
   props.jurisdictionIdsArray;
+
+/** retrieve the filterGeom value
+ * @param state - the store
+ * @param props -  the filterProps
+ */
+export const getFilterGeom = (_: Partial<Store>, props: Filters) => props.filterGeom;
 
 /** gets all jurisdictions keyed by id
  * @param state - the store
@@ -92,9 +99,19 @@ export const getJurisdictionById = () =>
  * @param props -  the filterProps
  */
 export const getJurisdictionIds = () =>
-  createSelector([getJurisdictionsById], (jurisdictionsById): string[] => {
-    return Object.keys(jurisdictionsById);
-  });
+  createSelector(
+    [getJurisdictionsById, getFilterGeom],
+    (jurisdictionsById, filterGeom): string[] => {
+      if (filterGeom === undefined) {
+        return Object.keys(jurisdictionsById);
+      }
+      return values(jurisdictionsById)
+        .filter(item => {
+          return 'geometry' in item === filterGeom;
+        })
+        .map(item => item.id);
+    }
+  );
 
 /**
  * retrieve jurisdictions as an array

--- a/src/store/ducks/opensrp/jurisdictions/index.ts
+++ b/src/store/ducks/opensrp/jurisdictions/index.ts
@@ -87,6 +87,16 @@ export const getJurisdictionById = () =>
   );
 
 /**
+ * Get jurisdiction ids
+ * @param state - the store
+ * @param props -  the filterProps
+ */
+export const getJurisdictionIds = () =>
+  createSelector([getJurisdictionsById], (jurisdictionsById): string[] => {
+    return Object.keys(jurisdictionsById);
+  });
+
+/**
  * retrieve jurisdictions as an array
  * @param state - the store
  * @param props -  the filterProps

--- a/src/store/ducks/opensrp/jurisdictions/tests/index.test.ts
+++ b/src/store/ducks/opensrp/jurisdictions/tests/index.test.ts
@@ -40,9 +40,14 @@ describe('reducers/opensrp/hierarchies', () => {
 
   it('should be able to store and retrieve jurisdictions', () => {
     store.dispatch(fetchJurisdictions(data));
-    expect(arraySelector(store.getState(), {})).toEqual(data);
+    // idsSelector
     expect(idsSelector(store.getState(), {})).toEqual(data.map(e => e.id));
+    expect(idsSelector(store.getState(), { filterGeom: false })).toEqual([raKashikishiHAHC.id]);
+    expect(idsSelector(store.getState(), { filterGeom: true })).toEqual([raKsh2.id, raKsh3.id]);
+    // jurisdictionSelector
     expect(jurisdictionSelector(store.getState(), { jurisdictionId: raKsh2.id })).toEqual(raKsh2);
+    // arraySelector
+    expect(arraySelector(store.getState(), {})).toEqual(data);
     expect(arraySelector(store.getState(), { parentId: raKashikishiHAHC.id })).toEqual([
       raKsh2,
       raKsh3,
@@ -50,6 +55,7 @@ describe('reducers/opensrp/hierarchies', () => {
     expect(
       arraySelector(store.getState(), { jurisdictionIdsArray: [raKashikishiHAHC.id, raKsh3.id] })
     ).toEqual([raKashikishiHAHC, raKsh3]);
+    // fcSelector
     expect(fcSelector(store.getState(), { parentId: raKashikishiHAHC.id })).toEqual({
       features: [raKsh2, raKsh3],
       type: 'FeatureCollection',

--- a/src/store/ducks/opensrp/jurisdictions/tests/index.test.ts
+++ b/src/store/ducks/opensrp/jurisdictions/tests/index.test.ts
@@ -6,6 +6,7 @@ import reducer, {
   getJurisdictionIds,
   getJurisdictionsArray,
   getJurisdictionsFC,
+  getMissingJurisdictionIds,
   reducerName,
   removeJurisdictions,
 } from '..';
@@ -22,6 +23,7 @@ const arraySelector = getJurisdictionsArray();
 const jurisdictionSelector = getJurisdictionById();
 const fcSelector = getJurisdictionsFC();
 const idsSelector = getJurisdictionIds();
+const missingIdsSelector = getMissingJurisdictionIds();
 const data = [raKashikishiHAHC, raKsh2, raKsh3];
 
 describe('reducers/opensrp/hierarchies', () => {
@@ -44,6 +46,20 @@ describe('reducers/opensrp/hierarchies', () => {
     expect(idsSelector(store.getState(), {})).toEqual(data.map(e => e.id));
     expect(idsSelector(store.getState(), { filterGeom: false })).toEqual([raKashikishiHAHC.id]);
     expect(idsSelector(store.getState(), { filterGeom: true })).toEqual([raKsh2.id, raKsh3.id]);
+    // getMissingJurisdictionIds
+    expect(missingIdsSelector(store.getState(), { filterGeom: false })).toEqual([
+      raKashikishiHAHC.id,
+    ]);
+    expect(missingIdsSelector(store.getState(), { filterGeom: true })).toEqual([
+      raKsh2.id,
+      raKsh3.id,
+    ]);
+    expect(
+      missingIdsSelector(store.getState(), {
+        filterGeom: true,
+        jurisdictionIdsArray: ['1337', '7331', raKashikishiHAHC.id, raKsh2.id, raKsh3.id],
+      })
+    ).toEqual(['1337', '7331', raKashikishiHAHC.id]);
     // jurisdictionSelector
     expect(jurisdictionSelector(store.getState(), { jurisdictionId: raKsh2.id })).toEqual(raKsh2);
     // arraySelector

--- a/src/store/ducks/opensrp/jurisdictions/tests/index.test.ts
+++ b/src/store/ducks/opensrp/jurisdictions/tests/index.test.ts
@@ -3,6 +3,7 @@ import { FlushThunks } from 'redux-testkit';
 import reducer, {
   fetchJurisdictions,
   getJurisdictionById,
+  getJurisdictionIds,
   getJurisdictionsArray,
   getJurisdictionsFC,
   reducerName,
@@ -20,6 +21,7 @@ reducerRegistry.register(reducerName, reducer);
 const arraySelector = getJurisdictionsArray();
 const jurisdictionSelector = getJurisdictionById();
 const fcSelector = getJurisdictionsFC();
+const idsSelector = getJurisdictionIds();
 const data = [raKashikishiHAHC, raKsh2, raKsh3];
 
 describe('reducers/opensrp/hierarchies', () => {
@@ -33,11 +35,13 @@ describe('reducers/opensrp/hierarchies', () => {
 
   it('should have initial state', () => {
     expect(arraySelector(store.getState(), {})).toEqual([]);
+    expect(idsSelector(store.getState(), {})).toEqual([]);
   });
 
   it('should be able to store and retrieve jurisdictions', () => {
     store.dispatch(fetchJurisdictions(data));
     expect(arraySelector(store.getState(), {})).toEqual(data);
+    expect(idsSelector(store.getState(), {})).toEqual(data.map(e => e.id));
     expect(jurisdictionSelector(store.getState(), { jurisdictionId: raKsh2.id })).toEqual(raKsh2);
     expect(arraySelector(store.getState(), { parentId: raKashikishiHAHC.id })).toEqual([
       raKsh2,


### PR DESCRIPTION
This is a follow-up to https://github.com/onaio/reveal-frontend/pull/1006.  It adds selectors to help in getting missing jurisdiction ids.