### PR TITLE
Prevent infinite loading

### DIFF
--- a/src/containers/pages/MDAPoint/ClientListView/helpers/serviceHooks.ts
+++ b/src/containers/pages/MDAPoint/ClientListView/helpers/serviceHooks.ts
@@ -12,12 +12,19 @@ import store from '../../../../../store';
 import { fetchFiles, File } from '../../../../../store/ducks/opensrp/clientfiles';
 import { getAccessToken } from '../../../../../store/selectors';
 
+/** useState function type for setting loader on and off */
+type SetIsLoading = ((status: boolean) => void) | null;
+
 /** loads and persists to store files data from upload/history endpoint
  */
 export const loadFiles = async (
+  setLoading: SetIsLoading = null,
   fetchFileAction = fetchFiles,
   serviceClass: any = OpenSRPService
 ) => {
+  if (setLoading) {
+    setLoading(true);
+  }
   const serve = new serviceClass(OPENSRP_FILE_UPLOAD_HISTORY_ENDPOINT);
   serve
     .list()
@@ -26,7 +33,8 @@ export const loadFiles = async (
     })
     .catch((err: Error) => {
       growl(err.message, { type: toast.TYPE.ERROR });
-    });
+    })
+    .finally(() => setLoading && setLoading(false));
 };
 /**
  * Posts uploaded file to opensrp

--- a/src/containers/pages/MDAPoint/ClientListView/helpers/serviceHooks.ts
+++ b/src/containers/pages/MDAPoint/ClientListView/helpers/serviceHooks.ts
@@ -18,15 +18,15 @@ type SetIsLoading = React.Dispatch<React.SetStateAction<boolean>> | null;
 /** loads and persists to store files data from upload/history endpoint
  */
 export const loadFiles = async (
-  setLoading: SetIsLoading = null,
   fetchFileAction = fetchFiles,
-  serviceClass: any = OpenSRPService
+  serviceClass: typeof OpenSRPService = OpenSRPService,
+  setLoading: SetIsLoading = null
 ) => {
   if (setLoading) {
     setLoading(true);
   }
   const serve = new serviceClass(OPENSRP_FILE_UPLOAD_HISTORY_ENDPOINT);
-  serve
+  await serve
     .list()
     .then((response: File[]) => {
       store.dispatch(fetchFileAction(response, true));

--- a/src/containers/pages/MDAPoint/ClientListView/helpers/serviceHooks.ts
+++ b/src/containers/pages/MDAPoint/ClientListView/helpers/serviceHooks.ts
@@ -13,7 +13,7 @@ import { fetchFiles, File } from '../../../../../store/ducks/opensrp/clientfiles
 import { getAccessToken } from '../../../../../store/selectors';
 
 /** useState function type for setting loader on and off */
-type SetIsLoading = ((status: boolean) => void) | null;
+type SetIsLoading = React.Dispatch<React.SetStateAction<boolean>> | null;
 
 /** loads and persists to store files data from upload/history endpoint
  */

--- a/src/containers/pages/MDAPoint/ClientListView/helpers/tests/serviceHooks.test.tsx
+++ b/src/containers/pages/MDAPoint/ClientListView/helpers/tests/serviceHooks.test.tsx
@@ -9,6 +9,7 @@ import { handleDownload, loadFiles, postUploadedFile } from '../serviceHooks';
 
 describe('src/containers/pages/ClientListView/helpers/servicehooks', () => {
   it('loadOrganization works correctly', async () => {
+    const mockSetLoader = jest.fn();
     const mockList = jest.fn(async () => fixtures.files);
     const mockActionCreator = jest.fn();
     const mockClass = jest.fn().mockImplementation(() => {
@@ -17,7 +18,7 @@ describe('src/containers/pages/ClientListView/helpers/servicehooks', () => {
       };
     });
 
-    loadFiles(mockActionCreator, mockClass).catch(e => {
+    loadFiles(mockSetLoader, mockActionCreator, mockClass).catch(e => {
       throw e;
     });
     await flushPromises();
@@ -30,6 +31,10 @@ describe('src/containers/pages/ClientListView/helpers/servicehooks', () => {
 
     // calls action creator correctly.
     expect(mockActionCreator).toHaveBeenCalledWith(fixtures.files, true);
+    // should set and uset loader
+    expect(mockSetLoader).toHaveBeenCalledTimes(2);
+    expect(mockSetLoader.mock.calls[0][0]).toEqual(true);
+    expect(mockSetLoader.mock.calls[1][0]).toEqual(false);
   });
 
   it('loadOrgPractitioners works correctly', async () => {

--- a/src/containers/pages/MDAPoint/ClientListView/helpers/tests/serviceHooks.test.tsx
+++ b/src/containers/pages/MDAPoint/ClientListView/helpers/tests/serviceHooks.test.tsx
@@ -18,7 +18,7 @@ describe('src/containers/pages/ClientListView/helpers/servicehooks', () => {
       };
     });
 
-    loadFiles(mockSetLoader, mockActionCreator, mockClass).catch(e => {
+    loadFiles(mockActionCreator, mockClass as any, mockSetLoader).catch(e => {
       throw e;
     });
     await flushPromises();

--- a/src/containers/pages/MDAPoint/ClientListView/index.tsx
+++ b/src/containers/pages/MDAPoint/ClientListView/index.tsx
@@ -89,7 +89,7 @@ export const ClientListView = (props: ClientListViewProps & RouteComponentProps)
       /**
        * Fetch files incase the files are not available e.g when page is refreshed
        */
-      loadFiles(setLoading).catch(err => displayError(err));
+      loadFiles(fetchFiles, OpenSRPService, setLoading).catch(err => displayError(err));
     }
     /**
      * We do not need to re-run since this effect doesn't depend on any values from api yet

--- a/src/containers/pages/MDAPoint/ClientListView/index.tsx
+++ b/src/containers/pages/MDAPoint/ClientListView/index.tsx
@@ -84,15 +84,12 @@ export const ClientListView = (props: ClientListViewProps & RouteComponentProps)
 
   const [loading, setLoading] = useState(false);
 
-  // update loading status
-  const isLoading = (status: boolean) => setLoading(status);
-
   React.useEffect(() => {
     if (!(files && files.length)) {
       /**
        * Fetch files incase the files are not available e.g when page is refreshed
        */
-      loadFiles(isLoading).catch(err => displayError(err));
+      loadFiles(setLoading).catch(err => displayError(err));
     }
     /**
      * We do not need to re-run since this effect doesn't depend on any values from api yet

--- a/src/containers/pages/MDAPoint/ClientListView/index.tsx
+++ b/src/containers/pages/MDAPoint/ClientListView/index.tsx
@@ -1,6 +1,6 @@
-import ListView from '@onaio/list-view';
+import ListView, { ListViewProps } from '@onaio/list-view';
 import reducerRegistry from '@onaio/redux-reducer-registry';
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useState } from 'react';
 import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
 import { RouteComponentProps } from 'react-router';
@@ -19,6 +19,7 @@ import {
   DOWNLOAD,
   FILE_NAME,
   HOME,
+  NO_DATA_FOUND,
   OWNER,
   STUDENTS_TITLE,
   UPLOAD_DATE,
@@ -80,25 +81,31 @@ export const buildListViewData: (rowData: File[]) => ReactNode[][] | undefined =
 
 export const ClientListView = (props: ClientListViewProps & RouteComponentProps) => {
   const { location, files, clientLabel } = props;
+
+  const [loading, setLoading] = useState(false);
+
+  // update loading status
+  const isLoading = (status: boolean) => setLoading(status);
+
   React.useEffect(() => {
     if (!(files && files.length)) {
       /**
        * Fetch files incase the files are not available e.g when page is refreshed
        */
-      loadFiles().catch(err => displayError(err));
+      loadFiles(isLoading).catch(err => displayError(err));
     }
     /**
      * We do not need to re-run since this effect doesn't depend on any values from api yet
      */
   }, []);
   /** Overide renderRows to render html inside td */
-  let listViewProps;
+  const listViewProps: Pick<ListViewProps, 'data' | 'headerItems' | 'tableClass'> = {
+    data: [],
+    headerItems: [FILE_NAME, OWNER, UPLOAD_DATE],
+    tableClass: TABLE_BORDERED_CLASS,
+  };
   if (files && files.length) {
-    listViewProps = {
-      data: buildListViewData(files),
-      headerItems: [FILE_NAME, OWNER, UPLOAD_DATE],
-      tableClass: TABLE_BORDERED_CLASS,
-    };
+    listViewProps.data = buildListViewData(files) || [];
   }
   /** Load Modal once we hit this route */
   if (location.pathname === UPLOAD_CLIENT_CSV_URL) {
@@ -123,6 +130,12 @@ export const ClientListView = (props: ClientListViewProps & RouteComponentProps)
     text: ADD_NEW_CSV,
     to: UPLOAD_CLIENT_CSV_URL,
   };
+
+  /** show loader */
+  if (loading) {
+    return <Loading />;
+  }
+
   return (
     <div>
       <Helmet>
@@ -141,7 +154,8 @@ export const ClientListView = (props: ClientListViewProps & RouteComponentProps)
       </Row>
       <Row id="table-row">
         <Col>
-          {listViewProps && files && files.length ? <ListView {...listViewProps} /> : <Loading />}
+          <ListView {...listViewProps} />
+          {!(files && files.length) && <div>{NO_DATA_FOUND}</div>}
         </Col>
       </Row>
       <hr />

--- a/src/containers/pages/MDAPoint/ClientListView/tests/index.test.tsx
+++ b/src/containers/pages/MDAPoint/ClientListView/tests/index.test.tsx
@@ -1,5 +1,6 @@
 import reducerRegistry from '@onaio/redux-reducer-registry';
 import { mount, shallow } from 'enzyme';
+import flushPromises from 'flush-promises';
 import { createBrowserHistory } from 'history';
 import React from 'react';
 import { Helmet } from 'react-helmet';
@@ -91,7 +92,7 @@ describe('containers/pages/MDAPoints/ClientListView', () => {
     wrapper.unmount();
   });
 
-  it('renders ClientListView correctly for null files', () => {
+  it('renders ClientListView correctly for null files', async () => {
     const mock: any = jest.fn();
     // mock.mockImplementation(() => Promise.resolve(fixtures.plans));
     const props = {
@@ -107,9 +108,12 @@ describe('containers/pages/MDAPoints/ClientListView', () => {
         <ClientListView {...props} />
       </Router>
     );
+    await flushPromises();
+    wrapper.update();
+
     expect(wrapper.find(ClientListView).props().files).toEqual(null);
     expect(wrapper.find('HeaderBreadcrumb').length).toEqual(1);
-    expect(wrapper.find('.listview-thead').length).toEqual(0);
+    expect(wrapper.find('.listview-thead').length).toEqual(1);
     expect(wrapper.find('HeaderBreadcrumb').props()).toEqual({
       currentPage: {
         label: 'Students',
@@ -122,6 +126,7 @@ describe('containers/pages/MDAPoints/ClientListView', () => {
         },
       ],
     });
+    expect(wrapper.find('#table-row .col div').text()).toEqual('No Data Found');
     wrapper.unmount();
   });
 


### PR DESCRIPTION
Closes #890
Disables loader when API doesn't return data or store doesn't have data for `Admin > Clients` page.