### PR TITLE
Show root Hierarchy level on initial load of the plan assignment page

### DIFF
--- a/src/components/TreeWalker/helpers.ts
+++ b/src/components/TreeWalker/helpers.ts
@@ -111,14 +111,18 @@ export const getChildren = (
   tree: TreeNode,
   doFormat: boolean = true
 ): Result<TreeNodeType[]> => {
-  let children: OpenSRPJurisdiction[] = [];
+  let children: TreeNode[] = [];
   const nodeFromTree = tree.first(treeNode => treeNode.model.id === nodeId);
-  if (nodeFromTree && nodeFromTree.model.children) {
-    children = doFormat
-      ? nodeFromTree.model.children.map((nodeModel: ParsedHierarchySingleNode) =>
-          formatJurisdiction(nodeModel)
-        )
-      : nodeFromTree.children;
+  if (nodeFromTree && nodeFromTree.hasChildren()) {
+    children = nodeFromTree.children;
+  } else {
+    children = [tree];
+  }
+  if (doFormat) {
+    const formattedChildren = children.map((nodeModel: TreeNode) =>
+      formatJurisdiction(nodeModel.model)
+    );
+    return success(formattedChildren);
   }
   return success(children);
 };

--- a/src/components/TreeWalker/helpers.ts
+++ b/src/components/TreeWalker/helpers.ts
@@ -112,10 +112,16 @@ export const getChildren = (
   doFormat: boolean = true
 ): Result<TreeNodeType[]> => {
   let children: TreeNode[] = [];
+  // if nodeId is not an empty string search for node and return its children
   const nodeFromTree = tree.first(treeNode => treeNode.model.id === nodeId);
+
   if (nodeFromTree && nodeFromTree.hasChildren()) {
     children = nodeFromTree.children;
   } else {
+    children = [];
+  }
+  // if nodeId was an empty string, set current children to an array of the single node
+  if (nodeId === '') {
     children = [tree];
   }
   if (doFormat) {

--- a/src/components/TreeWalker/index.tsx
+++ b/src/components/TreeWalker/index.tsx
@@ -127,7 +127,7 @@ export function withTreeWalker<T>(WrappedComponent: React.FC<T>) {
           jurisdictionId && jurisdictionId !== ''
             ? tree.first(treeNode => treeNode.model.id === jurisdictionId)
             : tree.isRoot()
-            ? tree
+            ? tree // TODO -review: if node is not root, then no node in its structure will be root
             : tree.first(treeNode => treeNode.isRoot());
 
         if (nodeFromTree) {
@@ -137,15 +137,8 @@ export function withTreeWalker<T>(WrappedComponent: React.FC<T>) {
             parentNode = formatJurisdiction(parentNode.model);
             pedigree = nodeFromTree.getPath().map(item => formatJurisdiction(item.model));
           }
-          // if there is no jurisdictionId, then drilling down has not begun, we set
-          // the currentParent node to null since the root node will be  the current child derivatively
-          if (jurisdictionId === '') {
-            setCurrentNode(null);
-            setHierarchy([]);
-          } else {
-            setCurrentNode(parentNode);
-            setHierarchy(pedigree);
-          }
+          setCurrentNode(parentNode);
+          setHierarchy(pedigree);
           // we can also get current children here but that's handled below to keep code DRY
         }
       }

--- a/src/components/TreeWalker/tests/index.test.tsx
+++ b/src/components/TreeWalker/tests/index.test.tsx
@@ -92,11 +92,11 @@ describe('PlanAssignment/withTreeWalker', () => {
         .props()
     ).toEqual({
       ...expectedProps,
-      currentChildren: currentTreeNode.model.children.map((child: ParsedHierarchySingleNode) =>
+      currentChildren: [currentTreeNode.model].map((child: ParsedHierarchySingleNode) =>
         formatJurisdiction(child)
       ),
-      currentNode: formatJurisdiction(currentTreeNode.model),
-      hierarchy: [formatJurisdiction(currentTreeNode.model)],
+      currentNode: null,
+      hierarchy: [],
     });
 
     expect(fetch.mock.calls).toEqual([]);

--- a/src/components/TreeWalker/tests/index.test.tsx
+++ b/src/components/TreeWalker/tests/index.test.tsx
@@ -92,11 +92,11 @@ describe('PlanAssignment/withTreeWalker', () => {
         .props()
     ).toEqual({
       ...expectedProps,
-      currentChildren: [currentTreeNode.model].map((child: ParsedHierarchySingleNode) =>
+      currentChildren: currentTreeNode.model.children.map((child: ParsedHierarchySingleNode) =>
         formatJurisdiction(child)
       ),
-      currentNode: null,
-      hierarchy: [],
+      currentNode: formatJurisdiction(currentTreeNode.model),
+      hierarchy: [formatJurisdiction(currentTreeNode.model)],
     });
 
     expect(fetch.mock.calls).toEqual([]);

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionAssignmentView/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionAssignmentView/index.tsx
@@ -70,8 +70,8 @@ export const defaultProps = {
 /** view will require a planId from the url */
 export interface RouteParams {
   planId: string;
-  rootId: string;
-  parentId: string;
+  rootId?: string;
+  parentId?: string;
 }
 
 /** full props with route props added for JurisdictionAssignmentView */
@@ -94,7 +94,6 @@ export const JurisdictionAssignmentView = (props: JurisdictionAssignmentViewFull
 
   const [rootJurisdictionId, setRootJurisdictionId] = React.useState<string>('');
   const [loading, setLoading] = React.useState<boolean>(!plan);
-
   const { errorMessage, handleBrokenPage, broken } = useHandleBrokenPage();
 
   React.useEffect(() => {

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.tsx
@@ -217,8 +217,17 @@ const JurisdictionTable = (props: JurisdictionSelectorTableProps) => {
     return <ErrorPage errorMessage={errorMessage} />;
   }
 
-  if (currentChildren.length === 0) {
+  if (!currentParentNode) {
     handleBrokenPage(NO_DATA_FOUND);
+  }
+
+  // we will use the currentParentId prop to know if the parent node has
+  // been set, if drilling down has begun.
+  let derivedParentNode = currentParentNode;
+  let derivedChildrenNodes = currentChildren;
+  if (!props.currentParentId) {
+    derivedParentNode = undefined;
+    derivedChildrenNodes = currentParentNode ? [currentParentNode] : [];
   }
 
   /** creating breadCrumb props */
@@ -229,8 +238,8 @@ const JurisdictionTable = (props: JurisdictionSelectorTableProps) => {
   };
   const pages: Page[] = [];
 
-  if (currentParentNode) {
-    const path = currentParentNode.getPath();
+  if (derivedParentNode) {
+    const path = derivedParentNode.getPath();
     const lastNode = path.pop();
 
     pages.push(currentPage);
@@ -251,7 +260,7 @@ const JurisdictionTable = (props: JurisdictionSelectorTableProps) => {
     currentPage,
     pages,
   };
-  const data = currentChildren.map(node => {
+  const data = derivedChildrenNodes.map(node => {
     const isLeafNode: boolean = leafNodes.map(leaf => leaf.model.id).includes(node.model.id);
     const metaObj = jurisdictionsMetadata.find(
       (m: JurisdictionsMetadata) => m.key === node.model.id

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.tsx
@@ -388,6 +388,11 @@ type DispatchToProps = Pick<
   'treeFetchedCreator' | 'selectNodeCreator' | 'deselectNodeCreator' | 'autoSelectNodesCreator'
 >;
 
+const childrenSelector = getCurrentChildren();
+const parentNodeSelector = getCurrentParentNode();
+const leafNodesSelector = getLeafNodes();
+const selectedLeafNodesSelector = getAllSelectedNodes();
+
 /** maps props to store state */
 const mapStateToProps = (
   state: Partial<Store>,
@@ -399,10 +404,10 @@ const mapStateToProps = (
     rootJurisdictionId: ownProps.rootJurisdictionId,
   };
   return {
-    currentChildren: getCurrentChildren()(state, filters),
-    currentParentNode: getCurrentParentNode()(state, filters),
-    leafNodes: getLeafNodes()(state, filters),
-    selectedLeafNodes: getAllSelectedNodes()(state, filters),
+    currentChildren: childrenSelector(state, filters),
+    currentParentNode: parentNodeSelector(state, filters),
+    leafNodes: leafNodesSelector(state, filters),
+    selectedLeafNodes: selectedLeafNodesSelector(state, filters),
   };
 };
 

--- a/src/store/ducks/opensrp/hierarchies/index.ts
+++ b/src/store/ducks/opensrp/hierarchies/index.ts
@@ -352,6 +352,10 @@ export const getAncestors = () =>
     return [];
   });
 
+/** caveat: parentId is dictated by the jurisdictionId in the url, if parentId is undefined
+ * it means drilling down has not begun, so we return the root of the tree as the parentNode as
+ * opposed to returning undefined
+ */
 /** retrieve the node designated as the current Parent id
  * @param state - the store
  * @param props -  the filterProps
@@ -360,6 +364,9 @@ export const getCurrentParentNode = () =>
   createSelector(getTreeById(), getCurrentParentId, (tree, parentId) => {
     if (!tree) {
       return;
+    }
+    if (parentId === undefined) {
+      return tree;
     }
     return tree.first(node => node.model.id === parentId);
   });

--- a/src/store/ducks/opensrp/hierarchies/tests/index.test.tsx
+++ b/src/store/ducks/opensrp/hierarchies/tests/index.test.tsx
@@ -61,7 +61,11 @@ describe('reducers/opensrp/hierarchies', () => {
     store.dispatch(fetchTree(sampleHierarchy));
     // when the parent node is undefined; current children is set to an array of the rootNode
     expect(childrenSelector(store.getState(), filters).length).toEqual(1);
-    expect(parentNodeSelector(store.getState(), filters)).toBeUndefined();
+    const parentNode = parentNodeSelector(store.getState(), filters);
+    if (!parentNode) {
+      fail();
+    }
+    expect(parentNode.model.id).toEqual('2942');
 
     filters = {
       ...filters,


### PR DESCRIPTION
fix #1024

changes to Jurisdiction Assignment:
 - at the root level as oppposed to having the currentParentNode as undefined, it will now be the root Node in the tree.

changes to both Jurisdiction and PlanAssignment:
 - refactored how the breadCrumbs were displayed as well as the rendered children.
    if we have not started drilling down the the currentParentNode is assumed to be the currentChildren. the changes makes it possible to have the original current children in scope
