### PR TITLE
Show appropriate error message if user has no superset permissions

### DIFF
--- a/src/configs/lang.ts
+++ b/src/configs/lang.ts
@@ -771,3 +771,7 @@ export const CANNOT_ASSIGN_TEAM_LABEL = translate(
   'CANNOT_ASSIGN_TEAM',
   'Cannot assign teams for expired plans'
 );
+export const ERROR_PERMISSION_DENIED = translate(
+  'ERROR_PERMISSION_DENIED',
+  'This user does not have permissions to access this page'
+);

--- a/src/configs/strings/en.json
+++ b/src/configs/strings/en.json
@@ -1182,5 +1182,9 @@
   "CANNOT_ASSIGN_TEAM_LABEL": {
     "message": "Cannot assign teams for expired plans",
     "description": "label, on team assignment button when plan end date is past"
+  },
+  "ERROR_PERMISSION_DENIED": {
+    "message": "This user does not have permissions to access this page",
+    "description": "Error message displayed if user does not have permission to access the page"
   }
 }

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -233,3 +233,6 @@ export const APPLICATION_X_CSV = 'application/x-csv';
 export const TEXT_COMMA_SEPARATED_VALUES = 'text/comma-separated-values';
 export const TEXT_X_COMMA_SEPARATED_VALUES = 'text/x-comma-separated-values';
 export const TEXT_TAB_SEPARATED_VALUES = 'text/tab-separated-values';
+
+/** Superset API strings */
+export const SUPERSET_ACCESS_DENIED_MESSAGE = 'Access is Denied';

--- a/src/containers/pages/FocusInvestigation/active/index.tsx
+++ b/src/containers/pages/FocusInvestigation/active/index.tsx
@@ -22,7 +22,6 @@ import Loading from '../../../../components/page/Loading';
 import { SUPERSET_PLANS_SLICE } from '../../../../configs/env';
 import {
   ADD_FOCUS_INVESTIGATION,
-  AN_ERROR_OCCURRED,
   CASE_CLASSIFICATION_HEADER,
   CASE_NOTIF_DATE_HEADER,
   CURRENT_FOCUS_INVESTIGATION,
@@ -147,8 +146,6 @@ class ActiveFocusInvestigation extends React.Component<
       .then((result: Plan[]) => {
         if (result) {
           fetchPlansActionCreator(result);
-        } else {
-          displayError(new Error(AN_ERROR_OCCURRED));
         }
       })
       .finally(() => {

--- a/src/containers/pages/FocusInvestigation/active/tests/index.test.tsx
+++ b/src/containers/pages/FocusInvestigation/active/tests/index.test.tsx
@@ -13,7 +13,6 @@ import { Provider } from 'react-redux';
 import { Router } from 'react-router';
 import { CURRENT_FOCUS_INVESTIGATION } from '../../../../../configs/lang';
 import { FI_URL, REACTIVE_QUERY_PARAM, ROUTINE_QUERY_PARAM } from '../../../../../constants';
-import * as helperErrors from '../../../../../helpers/errors';
 import store from '../../../../../store';
 import * as planDefFixtures from '../../../../../store/ducks/opensrp/PlanDefinition/tests/fixtures';
 import { fetchPlansByUser } from '../../../../../store/ducks/opensrp/planIdsByUser';
@@ -440,7 +439,7 @@ describe('containers/pages/ActiveFocusInvestigation', () => {
     const supersetServiceMock: any = jest
       .fn(() => Promise.resolve(fixtures.plans))
       .mockImplementationOnce(async () => null);
-    const displayErrorMock = jest.spyOn(helperErrors, 'displayError');
+
     const mock: any = jest.fn();
     const props = {
       caseTriggeredPlans: [fixtures.plan2],
@@ -462,7 +461,7 @@ describe('containers/pages/ActiveFocusInvestigation', () => {
     await new Promise(resolve => setImmediate(resolve));
     wrapper.update();
     expect(props.fetchPlansActionCreator).not.toHaveBeenCalled();
-    expect(displayErrorMock).toHaveBeenCalled();
+
     // now you dont see the ripple
     expect(wrapper.find('Ripple').length).toEqual(0);
     wrapper.unmount();

--- a/src/services/superset/index.ts
+++ b/src/services/superset/index.ts
@@ -2,6 +2,9 @@ import reducerRegistry from '@onaio/redux-reducer-registry';
 import superset, { SupersetConnectorConfig } from '@onaio/superset-connector';
 import { Dictionary } from '@onaio/utils';
 import { OPENSRP_OAUTH_STATE, SUPERSET_API_BASE, SUPERSET_API_ENDPOINT } from '../../configs/env';
+import { ERROR_PERMISSION_DENIED } from '../../configs/lang';
+import { SUPERSET_ACCESS_DENIED_MESSAGE } from '../../constants';
+import { displayError } from '../../helpers/errors';
 import store from '../../store';
 import supersetReducer, {
   authorizeSuperset,
@@ -15,6 +18,11 @@ reducerRegistry.register(supersetReducerName, supersetReducer);
 
 /** middleware for fetching from Superset */
 export const fetchMiddleware = (res: { [key: string]: any }) => {
+  const { message } = res;
+
+  if (message === SUPERSET_ACCESS_DENIED_MESSAGE) {
+    displayError(new Error(ERROR_PERMISSION_DENIED));
+  }
   return res;
 };
 


### PR DESCRIPTION
Closes #1084 

Show an appropriate error message if a user with no superset permissions accesses a page that makes a superset API call