### PR TITLE
Refactor hierarchies reducer structure

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -536,13 +536,6 @@ const App = (props: AppProps) => {
                   redirectPath={APP_CALLBACK_URL}
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
-                  path={`${MANUAL_ASSIGN_JURISDICTIONS_URL}/:planId`}
-                  component={ConnectedJurisdictionAssignmentView}
-                />
-                <ConnectedPrivateRoute
-                  redirectPath={APP_CALLBACK_URL}
-                  disableLoginProtection={DISABLE_LOGIN_PROTECTION}
-                  exact={true}
                   path={`${AUTO_ASSIGN_JURISDICTIONS_URL}/:planId/:rootId/:parentId`}
                   component={ConnectedAutoSelectView}
                 />
@@ -551,13 +544,6 @@ const App = (props: AppProps) => {
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${AUTO_ASSIGN_JURISDICTIONS_URL}/:planId/:rootId`}
-                  component={ConnectedAutoSelectView}
-                />
-                <ConnectedPrivateRoute
-                  redirectPath={APP_CALLBACK_URL}
-                  disableLoginProtection={DISABLE_LOGIN_PROTECTION}
-                  exact={true}
-                  path={`${AUTO_ASSIGN_JURISDICTIONS_URL}/:planId`}
                   component={ConnectedAutoSelectView}
                 />
                 <ConnectedPrivateRoute

--- a/src/containers/pages/JurisdictionAssignment/AutoSelectJurisdictions/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/AutoSelectJurisdictions/index.tsx
@@ -128,7 +128,7 @@ export const AutoSelectView = (props: JurisdictionAssignmentViewFullProps) => {
 
   React.useEffect(() => {
     const metadataLoadingKey = 'metadata';
-    startLoading(metadataLoadingKey);
+    startLoading(metadataLoadingKey, jurisdictionsMetadata.length === 0);
     loadJurisdictionsMetadata(
       JURISDICTION_METADATA_RISK,
       OpenSRPService,

--- a/src/containers/pages/JurisdictionAssignment/AutoSelectJurisdictions/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/pages/JurisdictionAssignment/AutoSelectJurisdictions/tests/__snapshots__/index.test.tsx.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src/containers/JurisdictionView/AutoSelect View getting root jurisdiction error Message: should also be jurisdiction error page 1`] = `"An error ocurred. Please try and refresh the page.The specific error is: Could not load jurisdiction"`;
+exports[`src/containers/JurisdictionView/AutoSelect View getting root jurisdiction error Message: should also be jurisdiction error page 1`] = `"An error ocurred. Please try and refresh the page.The specific error is: Failed to load Jurisdiction hierarchy"`;
 
 exports[`src/containers/JurisdictionView/AutoSelect View plan error Message: should be plan error page 1`] = `"An error ocurred. Please try and refresh the page.The specific error is: Unable to load plan"`;
-
-exports[`src/containers/JurisdictionView/AutoSelect View single jurisdiction error Message: should be jurisdiction error page 1`] = `"An error ocurred. Please try and refresh the page.The specific error is: Could not load jurisdiction"`;
 
 exports[`src/containers/JurisdictionView/AutoSelect View works correctly with store: should be about oov 1`] = `"Planning toolA2-Lusaka Akros Test Focus 2A2-Lusaka Akros Test Focus 2Auto target jurisdictions by riskRefine selected jurisdictionsDraggable slider"`;

--- a/src/containers/pages/JurisdictionAssignment/AutoSelectJurisdictions/tests/index.test.tsx
+++ b/src/containers/pages/JurisdictionAssignment/AutoSelectJurisdictions/tests/index.test.tsx
@@ -56,6 +56,44 @@ describe('src/containers/JurisdictionView/AutoSelect View', () => {
     fetch.resetMocks();
   });
 
+  it('shows loader', async () => {
+    const plan = plans[0];
+    fetch
+      .once(JSON.stringify(jurisdictionsMetadataArray), { status: 200 })
+      .once(JSON.stringify(plan), { status: 200 })
+      .once(JSON.stringify(sampleHierarchy), { status: 200 });
+
+    const props = {
+      history,
+      location: {
+        hash: '',
+        pathname: `${AUTO_ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
+        search: '',
+        state: {},
+      },
+      match: {
+        isExact: true,
+        params: { planId: plan.identifier, rootId: '2942' },
+        path: `${AUTO_ASSIGN_JURISDICTIONS_URL}/:planId`,
+        url: `${AUTO_ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
+      },
+    };
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <ConnectedAutoSelectView {...props} />
+        </Router>
+      </Provider>
+    );
+
+    await act(async () => {
+      wrapper.update();
+    });
+
+    expect(wrapper.find('Ripple').length).toEqual(1);
+  });
+
   it('works correctly with store', async () => {
     const plan = plans[0];
     fetch
@@ -103,44 +141,6 @@ describe('src/containers/JurisdictionView/AutoSelect View', () => {
 
     // rendered component
     expect(wrapper.text()).toMatchSnapshot('should be about oov');
-  });
-
-  it('shows loader', async () => {
-    const plan = plans[0];
-    fetch
-      .once(JSON.stringify(jurisdictionsMetadataArray), { status: 200 })
-      .once(JSON.stringify(plan), { status: 200 })
-      .once(JSON.stringify(sampleHierarchy), { status: 200 });
-
-    const props = {
-      history,
-      location: {
-        hash: '',
-        pathname: `${AUTO_ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
-        search: '',
-        state: {},
-      },
-      match: {
-        isExact: true,
-        params: { planId: plan.identifier, rootId: '2942' },
-        path: `${AUTO_ASSIGN_JURISDICTIONS_URL}/:planId`,
-        url: `${AUTO_ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
-      },
-    };
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <Router history={history}>
-          <ConnectedAutoSelectView {...props} />
-        </Router>
-      </Provider>
-    );
-
-    await act(async () => {
-      wrapper.update();
-    });
-
-    expect(wrapper.find('Ripple').length).toEqual(1);
   });
 
   it('plan error Message', async () => {

--- a/src/containers/pages/JurisdictionAssignment/AutoSelectJurisdictions/tests/index.test.tsx
+++ b/src/containers/pages/JurisdictionAssignment/AutoSelectJurisdictions/tests/index.test.tsx
@@ -15,7 +15,6 @@ import { sampleHierarchy } from '../../../../../store/ducks/opensrp/hierarchies/
 import plansReducer, { reducerName } from '../../../../../store/ducks/opensrp/PlanDefinition';
 import { plans } from '../../../../../store/ducks/opensrp/PlanDefinition/tests/fixtures';
 import { jurisdictionsMetadataArray } from '../../../../../store/ducks/tests/fixtures';
-import { akros2, lusaka, mtendere } from '../../JurisdictionAssignmentView/tests/fixtures';
 
 reducerRegistry.register(reducerName, plansReducer);
 reducerRegistry.register(hierarchiesReducerName, hierarchiesReducer);
@@ -62,9 +61,6 @@ describe('src/containers/JurisdictionView/AutoSelect View', () => {
     fetch
       .once(JSON.stringify(jurisdictionsMetadataArray), { status: 200 })
       .once(JSON.stringify(plan), { status: 200 })
-      .once(JSON.stringify([akros2]), { status: 200 })
-      .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
       .once(JSON.stringify(sampleHierarchy), { status: 200 });
 
     const props = {
@@ -77,7 +73,7 @@ describe('src/containers/JurisdictionView/AutoSelect View', () => {
       },
       match: {
         isExact: true,
-        params: { planId: plan.identifier },
+        params: { planId: plan.identifier, rootId: '2942' },
         path: `${AUTO_ASSIGN_JURISDICTIONS_URL}/:planId`,
         url: `${AUTO_ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
       },
@@ -114,10 +110,8 @@ describe('src/containers/JurisdictionView/AutoSelect View', () => {
     fetch
       .once(JSON.stringify(jurisdictionsMetadataArray), { status: 200 })
       .once(JSON.stringify(plan), { status: 200 })
-      .once(JSON.stringify([akros2]), { status: 200 })
-      .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
       .once(JSON.stringify(sampleHierarchy), { status: 200 });
+
     const props = {
       history,
       location: {
@@ -128,7 +122,7 @@ describe('src/containers/JurisdictionView/AutoSelect View', () => {
       },
       match: {
         isExact: true,
-        params: { planId: plan.identifier },
+        params: { planId: plan.identifier, rootId: '2942' },
         path: `${AUTO_ASSIGN_JURISDICTIONS_URL}/:planId`,
         url: `${AUTO_ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
       },
@@ -152,12 +146,10 @@ describe('src/containers/JurisdictionView/AutoSelect View', () => {
   it('plan error Message', async () => {
     const plan = plans[0];
     fetch
-      .once(JSON.stringify([]), { status: 500 })
+      .once(JSON.stringify([]), { status: 200 })
       .once(JSON.stringify({}), { status: 500 })
-      .once(JSON.stringify([akros2]), { status: 200 })
-      .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
       .once(JSON.stringify(sampleHierarchy), { status: 200 });
+
     const props = {
       history,
       location: {
@@ -168,7 +160,7 @@ describe('src/containers/JurisdictionView/AutoSelect View', () => {
       },
       match: {
         isExact: true,
-        params: { planId: plan.identifier },
+        params: { planId: plan.identifier, rootId: '2942' },
         path: `${AUTO_ASSIGN_JURISDICTIONS_URL}/:planId`,
         url: `${AUTO_ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
       },
@@ -191,57 +183,12 @@ describe('src/containers/JurisdictionView/AutoSelect View', () => {
     expect(wrapper.text()).toMatchSnapshot('should be plan error page');
   });
 
-  it('single jurisdiction error Message', async () => {
-    const plan = plans[0];
-    fetch
-      .once(JSON.stringify(jurisdictionsMetadataArray), { status: 200 })
-      .once(JSON.stringify(plan), { status: 200 })
-      .once(JSON.stringify([]), { status: 500 })
-      .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
-      .once(JSON.stringify(sampleHierarchy), { status: 200 });
-    const props = {
-      history,
-      location: {
-        hash: '',
-        pathname: `${AUTO_ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
-        search: '',
-        state: {},
-      },
-      match: {
-        isExact: true,
-        params: { planId: plan.identifier },
-        path: `${AUTO_ASSIGN_JURISDICTIONS_URL}/:planId`,
-        url: `${AUTO_ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
-      },
-    };
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <Router history={history}>
-          <ConnectedAutoSelectView {...props} />
-        </Router>
-      </Provider>
-    );
-
-    await act(async () => {
-      await new Promise(resolve => setImmediate(resolve));
-      wrapper.update();
-    });
-
-    // check renderer error message
-    expect(wrapper.text()).toMatchSnapshot('should be jurisdiction error page');
-  });
-
   it('getting root jurisdiction error Message', async () => {
     const plan = plans[0];
     fetch
       .once(JSON.stringify(jurisdictionsMetadataArray), { status: 200 })
       .once(JSON.stringify(plan), { status: 200 })
-      .once(JSON.stringify([akros2]), { status: 200 })
-      .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify({}), { status: 500 })
-      .once(JSON.stringify(sampleHierarchy), { status: 200 });
+      .once(JSON.stringify(sampleHierarchy), { status: 500 });
 
     const props = {
       history,
@@ -253,7 +200,7 @@ describe('src/containers/JurisdictionView/AutoSelect View', () => {
       },
       match: {
         isExact: true,
-        params: { planId: plan.identifier },
+        params: { planId: plan.identifier, rootId: '2942' },
         path: `${AUTO_ASSIGN_JURISDICTIONS_URL}/:planId`,
         url: `${AUTO_ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
       },

--- a/src/containers/pages/JurisdictionAssignment/EntryView/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/EntryView/index.tsx
@@ -2,7 +2,7 @@
  * it makes service calls for the information that is required to make a decision on whether
  * to got to autoSelection or manual jurisdiction selection. This are:
  *  - the plan
- *  - the hierarchy
+ *  - the rootJurisdiction id - this is used by the child component to service call for the hierarchy
  */
 
 import reducerRegistry from '@onaio/redux-reducer-registry';
@@ -29,7 +29,7 @@ import planDefinitionReducer, {
 } from '../../../../store/ducks/opensrp/PlanDefinition';
 import { useHandleBrokenPage } from '../helpers/utils';
 import { ConnectedJurisdictionAssignmentReRouting } from './JurisdictionAssignmentReRouting';
-import { useGetJurisdictionTree, useGetRootJurisdictionId, usePlanEffect } from './utils';
+import { useGetRootJurisdictionId, usePlanEffect } from './utils';
 
 reducerRegistry.register(planReducerName, planDefinitionReducer);
 reducerRegistry.register(hierarchyReducerName, hierarchyReducer);
@@ -82,13 +82,6 @@ const EntryView = (props: FullEntryViewProps) => {
     stopLoading,
     startLoading
   );
-  useGetJurisdictionTree(
-    rootJurisdictionId,
-    startLoading,
-    treeFetchedCreator,
-    stopLoading,
-    handleBrokenPage
-  );
 
   if (loading()) {
     return <Ripple />;
@@ -108,6 +101,7 @@ const EntryView = (props: FullEntryViewProps) => {
   const reRoutingProps = {
     plan,
     rootJurisdictionId,
+    treeFetchedCreator,
   };
 
   return <ConnectedJurisdictionAssignmentReRouting {...reRoutingProps} />;

--- a/src/containers/pages/JurisdictionAssignment/EntryView/tests/index.test.tsx
+++ b/src/containers/pages/JurisdictionAssignment/EntryView/tests/index.test.tsx
@@ -11,7 +11,6 @@ import store from '../../../../../store';
 import hierarchyReducer, {
   reducerName as hierarchyReducerName,
 } from '../../../../../store/ducks/opensrp/hierarchies';
-import { sampleHierarchy } from '../../../../../store/ducks/opensrp/hierarchies/tests/fixtures';
 import planDefinitionReducer, {
   reducerName as planDefinitionReducerName,
 } from '../../../../../store/ducks/opensrp/PlanDefinition';
@@ -47,8 +46,7 @@ describe('JurisdictionAssignment/JurisdictionEntry', () => {
       .once(JSON.stringify(plan), { status: 200 })
       .once(JSON.stringify([akros2]), { status: 200 })
       .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
-      .once(JSON.stringify(sampleHierarchy));
+      .once(JSON.stringify(lusaka), { status: 200 });
 
     const props = {
       history,
@@ -125,17 +123,6 @@ describe('JurisdictionAssignment/JurisdictionEntry', () => {
           method: 'GET',
         },
       ],
-      [
-        'https://reveal-stage.smartregister.org/opensrp/rest/location/hierarchy/2942?return_structure_count=true',
-        {
-          headers: {
-            accept: 'application/json',
-            authorization: 'Bearer null',
-            'content-type': 'application/json;charset=UTF-8',
-          },
-          method: 'GET',
-        },
-      ],
     ]);
 
     expect(wrapper.text()).toMatchInlineSnapshot(`"I love oov"`);
@@ -148,8 +135,7 @@ describe('JurisdictionAssignment/JurisdictionEntry', () => {
       .once(JSON.stringify(plan), { status: 500 })
       .once(JSON.stringify([akros2]), { status: 200 })
       .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
-      .once(JSON.stringify(sampleHierarchy));
+      .once(JSON.stringify(lusaka), { status: 200 });
 
     const props = {
       history,
@@ -192,8 +178,7 @@ describe('JurisdictionAssignment/JurisdictionEntry', () => {
       .once(JSON.stringify(plan), { status: 200 })
       .once(JSON.stringify([akros2]), { status: 500 })
       .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
-      .once(JSON.stringify(sampleHierarchy));
+      .once(JSON.stringify(lusaka), { status: 200 });
 
     const props = {
       history,
@@ -236,9 +221,7 @@ describe('JurisdictionAssignment/JurisdictionEntry', () => {
       .once(JSON.stringify(plan), { status: 200 })
       .once(JSON.stringify([akros2]), { status: 200 })
       .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
-      .once(JSON.stringify(sampleHierarchy), { status: 500 });
-
+      .once(JSON.stringify(lusaka), { status: 200 });
     const props = {
       history,
       location: {

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionAssignmentView/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionAssignmentView/index.tsx
@@ -40,8 +40,8 @@ import hierarchyReducer, {
   getTreeById,
   reducerName as hierarchyReducerName,
 } from '../../../../store/ducks/opensrp/hierarchies';
+import { SELECTION_REASON } from '../../../../store/ducks/opensrp/hierarchies/constants';
 import { RawOpenSRPHierarchy, TreeNode } from '../../../../store/ducks/opensrp/hierarchies/types';
-import { selectionReason } from '../../../../store/ducks/opensrp/hierarchies/utils';
 import jurisdictionMetadataReducer, {
   fetchJurisdictionsMetadata,
   FetchJurisdictionsMetadataAction,
@@ -169,7 +169,7 @@ export const JurisdictionAssignmentView = (props: JurisdictionAssignmentViewFull
           if (apiResponse.value) {
             const responseData = apiResponse.value;
             treeFetchedCreator(responseData);
-            autoSelectNodesCreator(rootJurisdictionId, callback, selectionReason.NOT_CHANGED);
+            autoSelectNodesCreator(rootJurisdictionId, callback, SELECTION_REASON.NOT_CHANGED);
           }
           if (apiResponse.error) {
             throw new Error(COULD_NOT_LOAD_JURISDICTION_HIERARCHY);

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionAssignmentView/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionAssignmentView/tests/__snapshots__/index.test.tsx.snap
@@ -1,11 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src/containers/JurisdictionView getting root jurisdiction error Message: should also be jurisdiction error page 1`] = `"An error ocurred. Please try and refresh the page.The specific error is: Could not load jurisdiction"`;
+exports[`src/containers/JurisdictionView getting hierarchy error Message: should also be jurisdiction error page 1`] = `"An error ocurred. Please try and refresh the page.The specific error is: Failed to load Jurisdiction hierarchy"`;
 
 exports[`src/containers/JurisdictionView plan error Message: should be plan error page 1`] = `"An error ocurred. Please try and refresh the page.The specific error is: Unable to load plan"`;
 
 exports[`src/containers/JurisdictionView renders correctly: should be about oov 1`] = `"Planning toolA2-Lusaka Akros Test Focus 2Assign JurisdictionsI love oov"`;
-
-exports[`src/containers/JurisdictionView single jurisdiction error Message: should be jurisdiction error page 1`] = `"An error ocurred. Please try and refresh the page.The specific error is: Could not load jurisdiction"`;
 
 exports[`src/containers/JurisdictionView works correctly with store: should be about oov 1`] = `"Planning toolA2-Lusaka Akros Test Focus 2Assign JurisdictionsI love oov"`;

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionAssignmentView/tests/fixtures.ts
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionAssignmentView/tests/fixtures.ts
@@ -41,51 +41,7 @@ export const lusaka = {
 
 export const fetchCalls = [
   [
-    'https://reveal-stage.smartregister.org/opensrp/rest/v2/settings//?serverVersion=0&identifier=jurisdiction_metadata-risk',
-    {
-      headers: {
-        accept: 'application/json',
-        authorization: 'Bearer null',
-        'content-type': 'application/json;charset=UTF-8',
-      },
-      method: 'GET',
-    },
-  ],
-  [
     'https://reveal-stage.smartregister.org/opensrp/rest/plans/356b6b84-fc36-4389-a44a-2b038ed2f38d',
-    {
-      headers: {
-        accept: 'application/json',
-        authorization: 'Bearer null',
-        'content-type': 'application/json;charset=UTF-8',
-      },
-      method: 'GET',
-    },
-  ],
-  [
-    'https://reveal-stage.smartregister.org/opensrp/rest/location/findByJurisdictionIds?is_jurisdiction=true&return_geometry=false&jurisdiction_ids=3952',
-    {
-      headers: {
-        accept: 'application/json',
-        authorization: 'Bearer null',
-        'content-type': 'application/json;charset=UTF-8',
-      },
-      method: 'GET',
-    },
-  ],
-  [
-    'https://reveal-stage.smartregister.org/opensrp/rest/location/3019?is_jurisdiction=true&return_geometry=false',
-    {
-      headers: {
-        accept: 'application/json',
-        authorization: 'Bearer null',
-        'content-type': 'application/json;charset=UTF-8',
-      },
-      method: 'GET',
-    },
-  ],
-  [
-    'https://reveal-stage.smartregister.org/opensrp/rest/location/2942?is_jurisdiction=true&return_geometry=false',
     {
       headers: {
         accept: 'application/json',

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionAssignmentView/tests/index.test.tsx
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionAssignmentView/tests/index.test.tsx
@@ -6,16 +6,18 @@ import { act } from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router';
 import ConnectedJurisdictionAssignmentView, { JurisdictionAssignmentView } from '..';
-import { ASSIGN_JURISDICTIONS_URL } from '../../../../../constants';
+import { ASSIGN_JURISDICTIONS_URL as MANUAL_JURISDICTIONS_URL } from '../../../../../constants';
 import store from '../../../../../store';
 import hierarchiesReducer, {
+  deforest,
   reducerName as hierarchiesReducerName,
 } from '../../../../../store/ducks/opensrp/hierarchies';
 import { sampleHierarchy } from '../../../../../store/ducks/opensrp/hierarchies/tests/fixtures';
+import { generateJurisdictionTree } from '../../../../../store/ducks/opensrp/hierarchies/utils';
 import plansReducer, { reducerName } from '../../../../../store/ducks/opensrp/PlanDefinition';
 import { plans } from '../../../../../store/ducks/opensrp/PlanDefinition/tests/fixtures';
 import { jurisdictionsMetadataArray } from '../../../../../store/ducks/tests/fixtures';
-import { akros2, fetchCalls, lusaka, mtendere } from './fixtures';
+import { fetchCalls } from './fixtures';
 
 reducerRegistry.register(reducerName, plansReducer);
 reducerRegistry.register(hierarchiesReducerName, hierarchiesReducer);
@@ -48,33 +50,33 @@ describe('src/containers/JurisdictionView', () => {
     jest.clearAllMocks();
     jest.resetAllMocks();
     fetch.resetMocks();
+    store.dispatch(deforest());
   });
 
   it('renders correctly', async () => {
     const plan = plans[0];
+    const rootId = '2942';
     fetch
-      .once(JSON.stringify(jurisdictionsMetadataArray), { status: 200 })
       .once(JSON.stringify(plan), { status: 200 })
-      .once(JSON.stringify([akros2]), { status: 200 })
-      .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
       .once(JSON.stringify(sampleHierarchy), { status: 200 });
+
     const props = {
       history,
       jurisdictionsMetadata: jurisdictionsMetadataArray,
       location: {
         hash: '',
-        pathname: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
+        pathname: `${MANUAL_JURISDICTIONS_URL}/${plan.identifier}`,
         search: '',
         state: {},
       },
       match: {
         isExact: true,
-        params: { planId: plan.identifier },
-        path: `${ASSIGN_JURISDICTIONS_URL}/:planId`,
-        url: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
+        params: { planId: plan.identifier, rootId },
+        path: `${MANUAL_JURISDICTIONS_URL}/:planId`,
+        url: `${MANUAL_JURISDICTIONS_URL}/${plan.identifier}`,
       },
       plan: plans[0],
+      tree: generateJurisdictionTree(sampleHierarchy),
     };
 
     const wrapper = mount(
@@ -101,27 +103,24 @@ describe('src/containers/JurisdictionView', () => {
 
   it('works correctly with store', async () => {
     const plan = plans[0];
+    const rootId = '2942';
     fetch
-      .once(JSON.stringify(jurisdictionsMetadataArray), { status: 200 })
       .once(JSON.stringify(plan), { status: 200 })
-      .once(JSON.stringify([akros2]), { status: 200 })
-      .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
-      .once(JSON.stringify(sampleHierarchy), { status: 200 })
-      .once(JSON.stringify(jurisdictionsMetadataArray), { status: 200 });
+      .once(JSON.stringify(sampleHierarchy), { status: 200 });
+
     const props = {
       history,
       location: {
         hash: '',
-        pathname: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
+        pathname: `${MANUAL_JURISDICTIONS_URL}/${plan.identifier}`,
         search: '',
         state: {},
       },
       match: {
         isExact: true,
-        params: { planId: plan.identifier },
-        path: `${ASSIGN_JURISDICTIONS_URL}/:planId`,
-        url: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
+        params: { planId: plan.identifier, rootId },
+        path: `${MANUAL_JURISDICTIONS_URL}/:planId`,
+        url: `${MANUAL_JURISDICTIONS_URL}/${plan.identifier}`,
       },
     };
 
@@ -138,10 +137,6 @@ describe('src/containers/JurisdictionView', () => {
       wrapper.update();
     });
 
-    expect(wrapper.text()).toMatchInlineSnapshot(
-      `"Planning toolA2-Lusaka Akros Test Focus 2Assign JurisdictionsI love oov"`
-    );
-
     // check props given to mock component
     const passedProps: any = wrapper.find('mockComponent').props();
     expect(passedProps.plan.identifier).toEqual(plan.identifier);
@@ -153,26 +148,24 @@ describe('src/containers/JurisdictionView', () => {
 
   it('shows loader', async () => {
     const plan = plans[0];
+    const rootId = '2942';
     fetch
-      .once(JSON.stringify(jurisdictionsMetadataArray), { status: 200 })
       .once(JSON.stringify(plan), { status: 200 })
-      .once(JSON.stringify([akros2]), { status: 200 })
-      .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
       .once(JSON.stringify(sampleHierarchy), { status: 200 });
+
     const props = {
       history,
       location: {
         hash: '',
-        pathname: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
+        pathname: `${MANUAL_JURISDICTIONS_URL}/${plan.identifier}`,
         search: '',
         state: {},
       },
       match: {
         isExact: true,
-        params: { planId: plan.identifier },
-        path: `${ASSIGN_JURISDICTIONS_URL}/:planId`,
-        url: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
+        params: { planId: plan.identifier, rootId },
+        path: `${MANUAL_JURISDICTIONS_URL}/:planId`,
+        url: `${MANUAL_JURISDICTIONS_URL}/${plan.identifier}`,
       },
     };
 
@@ -193,26 +186,24 @@ describe('src/containers/JurisdictionView', () => {
 
   it('plan error Message', async () => {
     const plan = plans[0];
+    const rootId = '2942';
     fetch
-      .once(JSON.stringify([]), { status: 500 })
-      .once(JSON.stringify({}), { status: 500 })
-      .once(JSON.stringify([akros2]), { status: 200 })
-      .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
+      .once(JSON.stringify(plan), { status: 500 })
       .once(JSON.stringify(sampleHierarchy), { status: 200 });
+
     const props = {
       history,
       location: {
         hash: '',
-        pathname: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
+        pathname: `${MANUAL_JURISDICTIONS_URL}/${plan.identifier}`,
         search: '',
         state: {},
       },
       match: {
         isExact: true,
-        params: { planId: plan.identifier },
-        path: `${ASSIGN_JURISDICTIONS_URL}/:planId`,
-        url: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
+        params: { planId: plan.identifier, rootId },
+        path: `${MANUAL_JURISDICTIONS_URL}/:planId`,
+        url: `${MANUAL_JURISDICTIONS_URL}/${plan.identifier}`,
       },
     };
 
@@ -232,71 +223,28 @@ describe('src/containers/JurisdictionView', () => {
     // check renderer error message
     expect(wrapper.text()).toMatchSnapshot('should be plan error page');
   });
-  it('single jurisdiction error Message', async () => {
+
+  it('getting hierarchy error Message', async () => {
     const plan = plans[0];
+    const rootId = '2942';
+
     fetch
-      .once(JSON.stringify(jurisdictionsMetadataArray), { status: 200 })
       .once(JSON.stringify(plan), { status: 200 })
-      .once(JSON.stringify([]), { status: 500 })
-      .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
-      .once(JSON.stringify(sampleHierarchy), { status: 200 });
-    const props = {
-      history,
-      location: {
-        hash: '',
-        pathname: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
-        search: '',
-        state: {},
-      },
-      match: {
-        isExact: true,
-        params: { planId: plan.identifier },
-        path: `${ASSIGN_JURISDICTIONS_URL}/:planId`,
-        url: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
-      },
-    };
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <Router history={history}>
-          <ConnectedJurisdictionAssignmentView {...props} />
-        </Router>
-      </Provider>
-    );
-
-    await act(async () => {
-      await new Promise(resolve => setImmediate(resolve));
-      wrapper.update();
-    });
-
-    // check renderer error message
-    expect(wrapper.text()).toMatchSnapshot('should be jurisdiction error page');
-  });
-
-  it('getting root jurisdiction error Message', async () => {
-    const plan = plans[0];
-    fetch
-      .once(JSON.stringify(jurisdictionsMetadataArray), { status: 200 })
-      .once(JSON.stringify(plan), { status: 200 })
-      .once(JSON.stringify([akros2]), { status: 200 })
-      .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify({}), { status: 500 })
-      .once(JSON.stringify(sampleHierarchy), { status: 200 });
+      .once(JSON.stringify(sampleHierarchy), { status: 500 });
 
     const props = {
       history,
       location: {
         hash: '',
-        pathname: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
+        pathname: `${MANUAL_JURISDICTIONS_URL}/${plan.identifier}`,
         search: '',
         state: {},
       },
       match: {
         isExact: true,
-        params: { planId: plan.identifier },
-        path: `${ASSIGN_JURISDICTIONS_URL}/:planId`,
-        url: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
+        params: { planId: plan.identifier, rootId },
+        path: `${MANUAL_JURISDICTIONS_URL}/:planId`,
+        url: `${MANUAL_JURISDICTIONS_URL}/${plan.identifier}`,
       },
     };
 

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionCell/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionCell/index.tsx
@@ -5,7 +5,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { TreeNode } from '../../../../store/ducks/opensrp/hierarchies/types';
-import { nodeHasChildren } from '../../../../store/ducks/opensrp/hierarchies/utils';
 
 /**
  * Props for NodeCell
@@ -27,7 +26,7 @@ const NodeCell = (props: NodeCellProps) => {
   const { node, baseUrl } = props;
 
   // isLeafNode if node does not have children
-  const isLeafNode = !nodeHasChildren(node);
+  const isLeafNode = !node.hasChildren();
 
   if (isLeafNode) {
     return <span key={`${node.model.id}-span`}>{node.model.label}</span>;

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionCell/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionCell/tests/__snapshots__/index.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`src/pages/JurisdictionAssignment/JurisdictionCell renders correctly by 
       "children": Object {
         "length": 1,
       },
+      "hasChildren": [Function],
       "model": Object {
         "label": "Gaz",
       },
@@ -41,6 +42,7 @@ exports[`src/pages/JurisdictionAssignment/JurisdictionCell renders correctly whe
       "children": Object {
         "length": 0,
       },
+      "hasChildren": [Function],
       "model": Object {
         "label": "Gaz",
       },

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionCell/tests/index.test.tsx
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionCell/tests/index.test.tsx
@@ -15,6 +15,7 @@ describe('src/pages/JurisdictionAssignment/JurisdictionCell', () => {
   it('renders correctly by default', () => {
     const mockNode: any = {
       children: { length: 1 },
+      hasChildren: () => true,
       model: { label: 'Gaz' },
     };
     const props = {
@@ -33,6 +34,7 @@ describe('src/pages/JurisdictionAssignment/JurisdictionCell', () => {
   it('renders correctly when node does not have children', () => {
     const mockNode: any = {
       children: { length: 0 },
+      hasChildren: () => false,
       model: { label: 'Gaz' },
     };
     const props = {

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.tsx
@@ -54,8 +54,9 @@ import hierarchyReducer, {
   selectNode,
   SelectNodeAction,
 } from '../../../../store/ducks/opensrp/hierarchies';
+import { SELECTION_REASON } from '../../../../store/ducks/opensrp/hierarchies/constants';
 import { TreeNode } from '../../../../store/ducks/opensrp/hierarchies/types';
-import { nodeIsSelected, selectionReason } from '../../../../store/ducks/opensrp/hierarchies/utils';
+import { nodeIsSelected } from '../../../../store/ducks/opensrp/hierarchies/utils';
 import { JurisdictionsMetadata } from '../../../../store/ducks/opensrp/jurisdictionsMetadata';
 import {
   addPlanDefinition,
@@ -157,9 +158,9 @@ const JurisdictionTable = (props: JurisdictionSelectorTableProps) => {
       if (singleSelect) {
         deselectAllNodesCreator(rootJurisdictionId);
       }
-      selectNodeCreator(rootJurisdictionId, nodeId, selectionReason.USER_CHANGE);
+      selectNodeCreator(rootJurisdictionId, nodeId, SELECTION_REASON.USER_CHANGE);
     } else {
-      deselectNodeCreator(rootJurisdictionId, nodeId, selectionReason.USER_CHANGE);
+      deselectNodeCreator(rootJurisdictionId, nodeId, SELECTION_REASON.USER_CHANGE);
     }
   }
 

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionTable/tests/index.test.tsx
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionTable/tests/index.test.tsx
@@ -36,9 +36,12 @@ describe('src/containers/pages/jurisdictionView/jurisdictionTable', () => {
     fetch.resetMocks();
   });
 
+  beforeAll(() => {
+    store.dispatch(fetchTree(sampleHierarchy));
+  });
+
   it('works correctly through a full render cycle', () => {
     const plan = irsPlans[0];
-    store.dispatch(fetchTree(sampleHierarchy));
 
     /** current architecture does not use the Jurisdiction table as a view
      * it is seen as a controlled component that is feed some data from controlling component

--- a/src/containers/pages/JurisdictionAssignment/helpers/Slider/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/helpers/Slider/index.tsx
@@ -29,7 +29,8 @@ import hierarchyReducer, {
   reducerName as hierarchyReducerName,
 } from '../../../../../store/ducks/opensrp/hierarchies';
 import { TreeNode } from '../../../../../store/ducks/opensrp/hierarchies/types';
-import { selectionReason } from '../../../../../store/ducks/opensrp/hierarchies/utils';
+
+import { SELECTION_REASON } from '../../../../../store/ducks/opensrp/hierarchies/constants';
 import jurisdictionMetadataReducer, {
   fetchJurisdictionsMetadata,
   FetchJurisdictionsMetadataAction,
@@ -93,7 +94,7 @@ export const JurisdictionSelectionsSlider = (props: Props) => {
         !node.hasChildren() && jurisdictionsIdsMeta.includes(node.model.id);
       return isLeafNodePastThreshHold;
     };
-    autoSelectCreator(rootJurisdictionId, callback, selectionReason.AUTO_SELECTION);
+    autoSelectCreator(rootJurisdictionId, callback, SELECTION_REASON.AUTO_SELECTION);
   };
 
   React.useEffect(() => {

--- a/src/containers/pages/JurisdictionAssignment/helpers/Slider/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/helpers/Slider/index.tsx
@@ -21,16 +21,13 @@ import { PlanDefinition } from '../../../../../configs/settings';
 import { RISK_LABEL } from '../../../../../constants';
 import hierarchyReducer, {
   autoSelectNodes,
-  AutoSelectNodesAction,
-  FetchedTreeAction,
   fetchTree,
   getStructuresCount,
   getTreeById,
   reducerName as hierarchyReducerName,
 } from '../../../../../store/ducks/opensrp/hierarchies';
-import { TreeNode } from '../../../../../store/ducks/opensrp/hierarchies/types';
-
 import { SELECTION_REASON } from '../../../../../store/ducks/opensrp/hierarchies/constants';
+import { TreeNode } from '../../../../../store/ducks/opensrp/hierarchies/types';
 import jurisdictionMetadataReducer, {
   fetchJurisdictionsMetadata,
   FetchJurisdictionsMetadataAction,
@@ -50,13 +47,13 @@ interface Props {
   structuresCount: number;
   fetchJurisdictionsMetadataCreator: ActionCreator<FetchJurisdictionsMetadataAction>;
   jurisdictionsMetadata: JurisdictionsMetadata[];
-  autoSelectCreator: ActionCreator<AutoSelectNodesAction>;
-  fetchTreeCreator: ActionCreator<FetchedTreeAction>;
-  plan: PlanDefinition | null;
+  autoSelectCreator: typeof autoSelectNodes;
+  fetchTreeCreator: typeof fetchTree;
+  plan: PlanDefinition;
   onClickNext: () => void;
 }
 
-const defaultProps: Props = {
+const defaultProps = {
   autoSelectCreator: autoSelectNodes,
   fetchJurisdictionsMetadataCreator: fetchJurisdictionsMetadata,
   fetchTreeCreator: fetchTree,
@@ -64,7 +61,6 @@ const defaultProps: Props = {
   onClickNext: () => {
     return;
   },
-  plan: null,
   rootJurisdictionId: '',
   structuresCount: 0,
 };
@@ -84,6 +80,8 @@ export const JurisdictionSelectionsSlider = (props: Props) => {
     tree,
   } = props;
 
+  const planId = plan.identifier;
+
   const onChangeComplete = (val: number | Range) => {
     const metaJurOfInterest = jurisdictionsMetadata.filter(
       metaObject => parseInt(metaObject.value, 10) > val
@@ -94,7 +92,7 @@ export const JurisdictionSelectionsSlider = (props: Props) => {
         !node.hasChildren() && jurisdictionsIdsMeta.includes(node.model.id);
       return isLeafNodePastThreshHold;
     };
-    autoSelectCreator(rootJurisdictionId, callback, SELECTION_REASON.AUTO_SELECTION);
+    autoSelectCreator(rootJurisdictionId, callback, planId, SELECTION_REASON.AUTO_SELECTION);
   };
 
   React.useEffect(() => {
@@ -159,6 +157,7 @@ const treeSelector = getTreeById();
 
 const mapStateToProps = (state: Partial<Store>, ownProps: Props): MapStateToProps => {
   const filters = {
+    planId: ownProps.plan.identifier,
     rootJurisdictionId: ownProps.rootJurisdictionId,
   };
   const structuresCount = structureCountSelector(state, filters);

--- a/src/containers/pages/JurisdictionAssignment/helpers/Slider/tests/slider.test.tsx
+++ b/src/containers/pages/JurisdictionAssignment/helpers/Slider/tests/slider.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from 'enzyme';
 import { cloneDeep } from 'lodash';
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
 import { ConnectedJurisdictionSelectionsSlider } from '..';
 import store from '../../../../../../store';
@@ -9,6 +10,7 @@ import { sampleHierarchy } from '../../../../../../store/ducks/opensrp/hierarchi
 import { fetchJurisdictionsMetadata } from '../../../../../../store/ducks/opensrp/jurisdictionsMetadata';
 import { plans } from '../../../../../../store/ducks/opensrp/PlanDefinition/tests/fixtures';
 import { jurisdictionsMetadataArray } from '../../../../../../store/ducks/tests/fixtures';
+
 /** tests for slider view
  * : need to know that changes on the slider are rendered on the ui
  * : need to know that changes on the slider cause the correct changes in the backend
@@ -49,7 +51,9 @@ describe('JurisdictionAssignment/Slider', () => {
     /** we really should not be doing this, but I am currently unable to simulate
      * the change event
      */
-    (wrapper.find('InputRange').props() as any).onChange(81);
+    act(() => {
+      (wrapper.find('InputRange').props() as any).onChange(81);
+    });
 
     // the risk value should be now different 2
     expect(wrapper.find('.risk-label').text()).toMatchInlineSnapshot(`"81%"`);

--- a/src/store/ducks/opensrp/hierarchies/constants.tsx
+++ b/src/store/ducks/opensrp/hierarchies/constants.tsx
@@ -1,0 +1,12 @@
+import { AUTO_SELECTION, USER_CHANGE } from '../../../../configs/lang';
+
+export const META_FIELD_NAME = 'meta';
+export const SELECTION_KEY = 'selected';
+export const ACTION_BY = 'actionBy';
+export const META_STRUCTURE_COUNT = 'metaStructureCount';
+
+export const SELECTION_REASON = {
+  AUTO_SELECTION,
+  NOT_CHANGED: '',
+  USER_CHANGE,
+};

--- a/src/store/ducks/opensrp/hierarchies/index.tsx
+++ b/src/store/ducks/opensrp/hierarchies/index.tsx
@@ -377,13 +377,20 @@ export const getTreeById = () =>
     return treesByIds[rootId];
   });
 
+/** returns metaData for tree with the specified rootJurisdictionId
+ * @param state - the store
+ * @param props - the filterProps
+ */
 export const getMetaForTree = () => {
   return createSelector(getMetaData, getRootJurisdictionId, (metaData, rootId) => {
     return metaData[rootId] || {};
   });
 };
 
-/** combine tree with metaData */
+/** combine tree with metaData
+ * @param state - the store
+ * @param props - the filterProps
+ */
 export const getTreeWithMeta = () => {
   return createSelector(getTreeById(), getMetaForTree(), (origTree, metaForTree) => {
     // walk the tree and update meta field.

--- a/src/store/ducks/opensrp/hierarchies/index.tsx
+++ b/src/store/ducks/opensrp/hierarchies/index.tsx
@@ -379,7 +379,7 @@ export const getTreeById = () =>
 
 export const getMetaForTree = () => {
   return createSelector(getMetaData, getRootJurisdictionId, (metaData, rootId) => {
-    return metaData[rootId];
+    return metaData[rootId] || {};
   });
 };
 

--- a/src/store/ducks/opensrp/hierarchies/index.tsx
+++ b/src/store/ducks/opensrp/hierarchies/index.tsx
@@ -296,7 +296,7 @@ export default function reducer(state = initialState, action: TreeActionTypes) {
           [rootJurisdictionId]: {
             ...state.metaData[rootJurisdictionId],
             [planId]: {
-              ...state.metaData[rootJurisdictionId][planId],
+              ...(state.metaData[rootJurisdictionId] || {})[planId],
               ...res.metaByJurisdiction,
             },
           },
@@ -321,7 +321,7 @@ export default function reducer(state = initialState, action: TreeActionTypes) {
           [rootJurisdictionId]: {
             ...state.metaData[rootJurisdictionId],
             [planId]: {
-              ...state.metaData[rootJurisdictionId][planId],
+              ...(state.metaData[rootJurisdictionId] || {})[planId],
               ...metaByJurisdictionId,
             },
           },

--- a/src/store/ducks/opensrp/hierarchies/tests/index.test.tsx
+++ b/src/store/ducks/opensrp/hierarchies/tests/index.test.tsx
@@ -22,7 +22,7 @@ import reducer, {
 } from '..';
 import store from '../../../../index';
 import { TreeNode } from '../types';
-import { nodeIsSelected } from '../utils';
+import { generateJurisdictionTree, nodeIsSelected } from '../utils';
 import { anotherHierarchy, raZambiaHierarchy, sampleHierarchy } from './fixtures';
 
 reducerRegistry.register(reducerName, reducer);
@@ -49,6 +49,41 @@ describe('reducers/opensrp/hierarchies', () => {
     // what do we expect returned from selectors for an unpopulated store
     expect(childrenSelector(store.getState(), { rootJurisdictionId: '' })).toEqual([]);
     expect(parentNodeSelector(store.getState(), { rootJurisdictionId: '' })).toBeUndefined();
+  });
+
+  it('works with custom tree id', () => {
+    store.dispatch(fetchTree(sampleHierarchy, '1337'));
+    expect(treeByIdSelector(store.getState(), { rootJurisdictionId: '1337' })).toEqual(
+      generateJurisdictionTree(sampleHierarchy)
+    );
+  });
+
+  it('should fetch tree', () => {
+    // checking that dispatching actions has desired effect
+    let filters: Filters = {
+      rootJurisdictionId: '2942',
+    };
+    store.dispatch(fetchTree(sampleHierarchy));
+    // when the parent node is undefined; current children is set to an array of the rootNode
+    expect(childrenSelector(store.getState(), filters).length).toEqual(1);
+    const parentNode = parentNodeSelector(store.getState(), filters);
+    if (!parentNode) {
+      fail();
+    }
+    expect(parentNode.model.id).toEqual('2942');
+
+    filters = {
+      ...filters,
+      currentParentId: '2942',
+    };
+
+    expect(childrenSelector(store.getState(), filters).length).toEqual(1);
+
+    const node = parentNodeSelector(store.getState(), filters);
+    if (!node) {
+      fail();
+    }
+    expect(node.model.label).toEqual('Lusaka');
   });
 
   it('selecting & unselecting a node works', () => {

--- a/src/store/ducks/opensrp/hierarchies/tests/utils.test.tsx
+++ b/src/store/ducks/opensrp/hierarchies/tests/utils.test.tsx
@@ -1,12 +1,13 @@
+import { META_STRUCTURE_COUNT, SELECTION_REASON } from '../constants';
 import { TreeNode } from '../types';
 import {
   generateJurisdictionTree,
-  META_STRUCTURE_COUNT,
   preOrderStructureCountComputation,
+  setSelectOnNode,
 } from '../utils';
 import { raZambiaHierarchy, sampleHierarchy, sampleHierarchyWithoutStructures } from './fixtures';
 
-describe('hierarchyReducer.utils', () => {
+describe('reducer/hierarchies.utils', () => {
   it('generates a jurisdiction tree model correctly', () => {
     const root = generateJurisdictionTree(sampleHierarchy);
     expect(root.hasChildren()).toBeTruthy();
@@ -72,5 +73,55 @@ describe('hierarchyReducer.utils', () => {
       expect(node.model.meta[META_STRUCTURE_COUNT]).toEqual(0);
       return true;
     });
+  });
+  it('select node helper function works correctly', () => {
+    const tree = generateJurisdictionTree(sampleHierarchy);
+    const res = setSelectOnNode(tree, '3951', SELECTION_REASON.USER_CHANGE, true, false, false);
+    const expected = {
+      '3951': {
+        actionBy: 'User Change',
+        selected: true,
+      },
+    };
+    expect(res.metaByJurisdiction).toEqual(expected);
+  });
+  it('cascade up select node helper function works correctly', () => {
+    const tree = generateJurisdictionTree(sampleHierarchy);
+    const res = setSelectOnNode(tree, '3951', SELECTION_REASON.USER_CHANGE, true, true, false);
+    const expected = {
+      '2942': {
+        actionBy: 'User Change',
+        selected: true,
+      },
+      '3019': {
+        actionBy: 'User Change',
+        selected: true,
+      },
+      '3951': {
+        actionBy: 'User Change',
+        selected: true,
+      },
+    };
+    expect(res.metaByJurisdiction).toEqual(expected);
+  });
+
+  it('cascade down select node helper function works correctly', () => {
+    const tree = generateJurisdictionTree(sampleHierarchy);
+    const res = setSelectOnNode(tree, '2942', SELECTION_REASON.USER_CHANGE, true, false, true);
+    const expected = {
+      '2942': {
+        actionBy: 'User Change',
+        selected: true,
+      },
+      '3019': {
+        actionBy: 'User Change',
+        selected: true,
+      },
+      '3951': {
+        actionBy: 'User Change',
+        selected: true,
+      },
+    };
+    expect(res.metaByJurisdiction).toEqual(expected);
   });
 });

--- a/src/store/ducks/opensrp/hierarchies/types.ts
+++ b/src/store/ducks/opensrp/hierarchies/types.ts
@@ -62,4 +62,5 @@ export interface RawOpenSRPHierarchy {
 /** helper type, shortened form */
 export type TreeNode = TreeModel.Node<ParsedHierarchySingleNode>;
 
+/** describes callback used by the autoSelect functionality */
 export type AutoSelectCallback = (node: TreeNode) => boolean;

--- a/src/store/ducks/opensrp/hierarchies/types.ts
+++ b/src/store/ducks/opensrp/hierarchies/types.ts
@@ -21,12 +21,18 @@ export interface HierarchySingleNode<TChild> {
   children?: TChild;
   parent?: string;
 }
+/** properties that will be added to meta field */
+export interface Meta {
+  selected?: boolean;
+  actionBy?: string;
+  metaStructureCount?: number;
+}
 
 /** field that we will use to add ad-hoc information to a node
  * this field will be added to each node during parsing the raw data from the api
  */
 export interface MetaField {
-  meta: { selected: boolean };
+  meta: Meta;
 }
 
 /** single node description after coming in from the api */


### PR DESCRIPTION
Moves the meta field out of the tree

Meta is saved alongside the tree, we use the jurisdiction Id to know which meta object belongs to  which node in tree.

during selection the final tree is computed(the meta fields are added to thier respective nodes) such that the final tree is similar in structure to how it was previously stored

This means we can update the tree in several service calls without overriding meta information such as to which node has been selected.