### PR TITLE
1079 jurisdiction assignment cleanup routing refactors

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -536,13 +536,6 @@ const App = (props: AppProps) => {
                   redirectPath={APP_CALLBACK_URL}
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
-                  path={`${MANUAL_ASSIGN_JURISDICTIONS_URL}/:planId`}
-                  component={ConnectedJurisdictionAssignmentView}
-                />
-                <ConnectedPrivateRoute
-                  redirectPath={APP_CALLBACK_URL}
-                  disableLoginProtection={DISABLE_LOGIN_PROTECTION}
-                  exact={true}
                   path={`${AUTO_ASSIGN_JURISDICTIONS_URL}/:planId/:rootId/:parentId`}
                   component={ConnectedAutoSelectView}
                 />
@@ -551,13 +544,6 @@ const App = (props: AppProps) => {
                   disableLoginProtection={DISABLE_LOGIN_PROTECTION}
                   exact={true}
                   path={`${AUTO_ASSIGN_JURISDICTIONS_URL}/:planId/:rootId`}
-                  component={ConnectedAutoSelectView}
-                />
-                <ConnectedPrivateRoute
-                  redirectPath={APP_CALLBACK_URL}
-                  disableLoginProtection={DISABLE_LOGIN_PROTECTION}
-                  exact={true}
-                  path={`${AUTO_ASSIGN_JURISDICTIONS_URL}/:planId`}
                   component={ConnectedAutoSelectView}
                 />
                 <ConnectedPrivateRoute

--- a/src/containers/pages/JurisdictionAssignment/AutoSelectJurisdictions/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/pages/JurisdictionAssignment/AutoSelectJurisdictions/tests/__snapshots__/index.test.tsx.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src/containers/JurisdictionView/AutoSelect View getting root jurisdiction error Message: should also be jurisdiction error page 1`] = `"An error ocurred. Please try and refresh the page.The specific error is: Could not load jurisdiction"`;
+exports[`src/containers/JurisdictionView/AutoSelect View getting root jurisdiction error Message: should also be jurisdiction error page 1`] = `"An error ocurred. Please try and refresh the page.The specific error is: Failed to load Jurisdiction hierarchy"`;
 
 exports[`src/containers/JurisdictionView/AutoSelect View plan error Message: should be plan error page 1`] = `"An error ocurred. Please try and refresh the page.The specific error is: Unable to load plan"`;
-
-exports[`src/containers/JurisdictionView/AutoSelect View single jurisdiction error Message: should be jurisdiction error page 1`] = `"An error ocurred. Please try and refresh the page.The specific error is: Could not load jurisdiction"`;
 
 exports[`src/containers/JurisdictionView/AutoSelect View works correctly with store: should be about oov 1`] = `"Planning toolA2-Lusaka Akros Test Focus 2A2-Lusaka Akros Test Focus 2Auto target jurisdictions by riskRefine selected jurisdictionsDraggable slider"`;

--- a/src/containers/pages/JurisdictionAssignment/AutoSelectJurisdictions/tests/index.test.tsx
+++ b/src/containers/pages/JurisdictionAssignment/AutoSelectJurisdictions/tests/index.test.tsx
@@ -15,7 +15,6 @@ import { sampleHierarchy } from '../../../../../store/ducks/opensrp/hierarchies/
 import plansReducer, { reducerName } from '../../../../../store/ducks/opensrp/PlanDefinition';
 import { plans } from '../../../../../store/ducks/opensrp/PlanDefinition/tests/fixtures';
 import { jurisdictionsMetadataArray } from '../../../../../store/ducks/tests/fixtures';
-import { akros2, lusaka, mtendere } from '../../JurisdictionAssignmentView/tests/fixtures';
 
 reducerRegistry.register(reducerName, plansReducer);
 reducerRegistry.register(hierarchiesReducerName, hierarchiesReducer);
@@ -111,10 +110,8 @@ describe('src/containers/JurisdictionView/AutoSelect View', () => {
     fetch
       .once(JSON.stringify(jurisdictionsMetadataArray), { status: 200 })
       .once(JSON.stringify(plan), { status: 200 })
-      .once(JSON.stringify([akros2]), { status: 200 })
-      .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
       .once(JSON.stringify(sampleHierarchy), { status: 200 });
+
     const props = {
       history,
       location: {

--- a/src/containers/pages/JurisdictionAssignment/AutoSelectJurisdictions/tests/index.test.tsx
+++ b/src/containers/pages/JurisdictionAssignment/AutoSelectJurisdictions/tests/index.test.tsx
@@ -62,9 +62,6 @@ describe('src/containers/JurisdictionView/AutoSelect View', () => {
     fetch
       .once(JSON.stringify(jurisdictionsMetadataArray), { status: 200 })
       .once(JSON.stringify(plan), { status: 200 })
-      .once(JSON.stringify([akros2]), { status: 200 })
-      .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
       .once(JSON.stringify(sampleHierarchy), { status: 200 });
 
     const props = {
@@ -77,7 +74,7 @@ describe('src/containers/JurisdictionView/AutoSelect View', () => {
       },
       match: {
         isExact: true,
-        params: { planId: plan.identifier },
+        params: { planId: plan.identifier, rootId: '2942' },
         path: `${AUTO_ASSIGN_JURISDICTIONS_URL}/:planId`,
         url: `${AUTO_ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
       },
@@ -128,7 +125,7 @@ describe('src/containers/JurisdictionView/AutoSelect View', () => {
       },
       match: {
         isExact: true,
-        params: { planId: plan.identifier },
+        params: { planId: plan.identifier, rootId: '2942' },
         path: `${AUTO_ASSIGN_JURISDICTIONS_URL}/:planId`,
         url: `${AUTO_ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
       },
@@ -152,12 +149,10 @@ describe('src/containers/JurisdictionView/AutoSelect View', () => {
   it('plan error Message', async () => {
     const plan = plans[0];
     fetch
-      .once(JSON.stringify([]), { status: 500 })
+      .once(JSON.stringify([]), { status: 200 })
       .once(JSON.stringify({}), { status: 500 })
-      .once(JSON.stringify([akros2]), { status: 200 })
-      .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
       .once(JSON.stringify(sampleHierarchy), { status: 200 });
+
     const props = {
       history,
       location: {
@@ -168,7 +163,7 @@ describe('src/containers/JurisdictionView/AutoSelect View', () => {
       },
       match: {
         isExact: true,
-        params: { planId: plan.identifier },
+        params: { planId: plan.identifier, rootId: '2942' },
         path: `${AUTO_ASSIGN_JURISDICTIONS_URL}/:planId`,
         url: `${AUTO_ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
       },
@@ -191,57 +186,12 @@ describe('src/containers/JurisdictionView/AutoSelect View', () => {
     expect(wrapper.text()).toMatchSnapshot('should be plan error page');
   });
 
-  it('single jurisdiction error Message', async () => {
-    const plan = plans[0];
-    fetch
-      .once(JSON.stringify(jurisdictionsMetadataArray), { status: 200 })
-      .once(JSON.stringify(plan), { status: 200 })
-      .once(JSON.stringify([]), { status: 500 })
-      .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
-      .once(JSON.stringify(sampleHierarchy), { status: 200 });
-    const props = {
-      history,
-      location: {
-        hash: '',
-        pathname: `${AUTO_ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
-        search: '',
-        state: {},
-      },
-      match: {
-        isExact: true,
-        params: { planId: plan.identifier },
-        path: `${AUTO_ASSIGN_JURISDICTIONS_URL}/:planId`,
-        url: `${AUTO_ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
-      },
-    };
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <Router history={history}>
-          <ConnectedAutoSelectView {...props} />
-        </Router>
-      </Provider>
-    );
-
-    await act(async () => {
-      await new Promise(resolve => setImmediate(resolve));
-      wrapper.update();
-    });
-
-    // check renderer error message
-    expect(wrapper.text()).toMatchSnapshot('should be jurisdiction error page');
-  });
-
   it('getting root jurisdiction error Message', async () => {
     const plan = plans[0];
     fetch
       .once(JSON.stringify(jurisdictionsMetadataArray), { status: 200 })
       .once(JSON.stringify(plan), { status: 200 })
-      .once(JSON.stringify([akros2]), { status: 200 })
-      .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify({}), { status: 500 })
-      .once(JSON.stringify(sampleHierarchy), { status: 200 });
+      .once(JSON.stringify(sampleHierarchy), { status: 500 });
 
     const props = {
       history,
@@ -253,7 +203,7 @@ describe('src/containers/JurisdictionView/AutoSelect View', () => {
       },
       match: {
         isExact: true,
-        params: { planId: plan.identifier },
+        params: { planId: plan.identifier, rootId: '2942' },
         path: `${AUTO_ASSIGN_JURISDICTIONS_URL}/:planId`,
         url: `${AUTO_ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
       },

--- a/src/containers/pages/JurisdictionAssignment/EntryView/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/EntryView/index.tsx
@@ -2,7 +2,7 @@
  * it makes service calls for the information that is required to make a decision on whether
  * to got to autoSelection or manual jurisdiction selection. This are:
  *  - the plan
- *  - the hierarchy
+ *  - the rootJurisdiction id - this is used by the child component to service call for the hierarchy
  */
 
 import reducerRegistry from '@onaio/redux-reducer-registry';
@@ -29,7 +29,7 @@ import planDefinitionReducer, {
 } from '../../../../store/ducks/opensrp/PlanDefinition';
 import { useHandleBrokenPage } from '../helpers/utils';
 import { ConnectedJurisdictionAssignmentReRouting } from './JurisdictionAssignmentReRouting';
-import { useGetJurisdictionTree, useGetRootJurisdictionId, usePlanEffect } from './utils';
+import { useGetRootJurisdictionId, usePlanEffect } from './utils';
 
 reducerRegistry.register(planReducerName, planDefinitionReducer);
 reducerRegistry.register(hierarchyReducerName, hierarchyReducer);
@@ -82,13 +82,6 @@ const EntryView = (props: FullEntryViewProps) => {
     stopLoading,
     startLoading
   );
-  useGetJurisdictionTree(
-    rootJurisdictionId,
-    startLoading,
-    treeFetchedCreator,
-    stopLoading,
-    handleBrokenPage
-  );
 
   if (loading()) {
     return <Ripple />;
@@ -108,6 +101,7 @@ const EntryView = (props: FullEntryViewProps) => {
   const reRoutingProps = {
     plan,
     rootJurisdictionId,
+    treeFetchedCreator,
   };
 
   return <ConnectedJurisdictionAssignmentReRouting {...reRoutingProps} />;

--- a/src/containers/pages/JurisdictionAssignment/EntryView/tests/index.test.tsx
+++ b/src/containers/pages/JurisdictionAssignment/EntryView/tests/index.test.tsx
@@ -11,7 +11,6 @@ import store from '../../../../../store';
 import hierarchyReducer, {
   reducerName as hierarchyReducerName,
 } from '../../../../../store/ducks/opensrp/hierarchies';
-import { sampleHierarchy } from '../../../../../store/ducks/opensrp/hierarchies/tests/fixtures';
 import planDefinitionReducer, {
   reducerName as planDefinitionReducerName,
 } from '../../../../../store/ducks/opensrp/PlanDefinition';
@@ -47,8 +46,7 @@ describe('JurisdictionAssignment/JurisdictionEntry', () => {
       .once(JSON.stringify(plan), { status: 200 })
       .once(JSON.stringify([akros2]), { status: 200 })
       .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
-      .once(JSON.stringify(sampleHierarchy));
+      .once(JSON.stringify(lusaka), { status: 200 });
 
     const props = {
       history,
@@ -125,17 +123,6 @@ describe('JurisdictionAssignment/JurisdictionEntry', () => {
           method: 'GET',
         },
       ],
-      [
-        'https://reveal-stage.smartregister.org/opensrp/rest/location/hierarchy/2942?return_structure_count=true',
-        {
-          headers: {
-            accept: 'application/json',
-            authorization: 'Bearer null',
-            'content-type': 'application/json;charset=UTF-8',
-          },
-          method: 'GET',
-        },
-      ],
     ]);
 
     expect(wrapper.text()).toMatchInlineSnapshot(`"I love oov"`);
@@ -148,8 +135,7 @@ describe('JurisdictionAssignment/JurisdictionEntry', () => {
       .once(JSON.stringify(plan), { status: 500 })
       .once(JSON.stringify([akros2]), { status: 200 })
       .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
-      .once(JSON.stringify(sampleHierarchy));
+      .once(JSON.stringify(lusaka), { status: 200 });
 
     const props = {
       history,
@@ -192,8 +178,7 @@ describe('JurisdictionAssignment/JurisdictionEntry', () => {
       .once(JSON.stringify(plan), { status: 200 })
       .once(JSON.stringify([akros2]), { status: 500 })
       .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
-      .once(JSON.stringify(sampleHierarchy));
+      .once(JSON.stringify(lusaka), { status: 200 });
 
     const props = {
       history,
@@ -236,9 +221,7 @@ describe('JurisdictionAssignment/JurisdictionEntry', () => {
       .once(JSON.stringify(plan), { status: 200 })
       .once(JSON.stringify([akros2]), { status: 200 })
       .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
-      .once(JSON.stringify(sampleHierarchy), { status: 500 });
-
+      .once(JSON.stringify(lusaka), { status: 200 });
     const props = {
       history,
       location: {

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionAssignmentView/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionAssignmentView/tests/__snapshots__/index.test.tsx.snap
@@ -1,11 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src/containers/JurisdictionView getting root jurisdiction error Message: should also be jurisdiction error page 1`] = `"An error ocurred. Please try and refresh the page.The specific error is: Could not load jurisdiction"`;
+exports[`src/containers/JurisdictionView getting hierarchy error Message: should also be jurisdiction error page 1`] = `"An error ocurred. Please try and refresh the page.The specific error is: Failed to load Jurisdiction hierarchy"`;
 
 exports[`src/containers/JurisdictionView plan error Message: should be plan error page 1`] = `"An error ocurred. Please try and refresh the page.The specific error is: Unable to load plan"`;
 
 exports[`src/containers/JurisdictionView renders correctly: should be about oov 1`] = `"Planning toolA2-Lusaka Akros Test Focus 2Assign JurisdictionsI love oov"`;
-
-exports[`src/containers/JurisdictionView single jurisdiction error Message: should be jurisdiction error page 1`] = `"An error ocurred. Please try and refresh the page.The specific error is: Could not load jurisdiction"`;
 
 exports[`src/containers/JurisdictionView works correctly with store: should be about oov 1`] = `"Planning toolA2-Lusaka Akros Test Focus 2Assign JurisdictionsI love oov"`;

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionAssignmentView/tests/fixtures.ts
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionAssignmentView/tests/fixtures.ts
@@ -41,51 +41,7 @@ export const lusaka = {
 
 export const fetchCalls = [
   [
-    'https://reveal-stage.smartregister.org/opensrp/rest/v2/settings//?serverVersion=0&identifier=jurisdiction_metadata-risk',
-    {
-      headers: {
-        accept: 'application/json',
-        authorization: 'Bearer null',
-        'content-type': 'application/json;charset=UTF-8',
-      },
-      method: 'GET',
-    },
-  ],
-  [
     'https://reveal-stage.smartregister.org/opensrp/rest/plans/356b6b84-fc36-4389-a44a-2b038ed2f38d',
-    {
-      headers: {
-        accept: 'application/json',
-        authorization: 'Bearer null',
-        'content-type': 'application/json;charset=UTF-8',
-      },
-      method: 'GET',
-    },
-  ],
-  [
-    'https://reveal-stage.smartregister.org/opensrp/rest/location/findByJurisdictionIds?is_jurisdiction=true&return_geometry=false&jurisdiction_ids=3952',
-    {
-      headers: {
-        accept: 'application/json',
-        authorization: 'Bearer null',
-        'content-type': 'application/json;charset=UTF-8',
-      },
-      method: 'GET',
-    },
-  ],
-  [
-    'https://reveal-stage.smartregister.org/opensrp/rest/location/3019?is_jurisdiction=true&return_geometry=false',
-    {
-      headers: {
-        accept: 'application/json',
-        authorization: 'Bearer null',
-        'content-type': 'application/json;charset=UTF-8',
-      },
-      method: 'GET',
-    },
-  ],
-  [
-    'https://reveal-stage.smartregister.org/opensrp/rest/location/2942?is_jurisdiction=true&return_geometry=false',
     {
       headers: {
         accept: 'application/json',

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionAssignmentView/tests/index.test.tsx
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionAssignmentView/tests/index.test.tsx
@@ -6,16 +6,18 @@ import { act } from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router';
 import ConnectedJurisdictionAssignmentView, { JurisdictionAssignmentView } from '..';
-import { ASSIGN_JURISDICTIONS_URL } from '../../../../../constants';
+import { ASSIGN_JURISDICTIONS_URL as MANUAL_JURISDICTIONS_URL } from '../../../../../constants';
 import store from '../../../../../store';
 import hierarchiesReducer, {
+  deforest,
   reducerName as hierarchiesReducerName,
 } from '../../../../../store/ducks/opensrp/hierarchies';
 import { sampleHierarchy } from '../../../../../store/ducks/opensrp/hierarchies/tests/fixtures';
+import { generateJurisdictionTree } from '../../../../../store/ducks/opensrp/hierarchies/utils';
 import plansReducer, { reducerName } from '../../../../../store/ducks/opensrp/PlanDefinition';
 import { plans } from '../../../../../store/ducks/opensrp/PlanDefinition/tests/fixtures';
 import { jurisdictionsMetadataArray } from '../../../../../store/ducks/tests/fixtures';
-import { akros2, fetchCalls, lusaka, mtendere } from './fixtures';
+import { fetchCalls } from './fixtures';
 
 reducerRegistry.register(reducerName, plansReducer);
 reducerRegistry.register(hierarchiesReducerName, hierarchiesReducer);
@@ -48,33 +50,33 @@ describe('src/containers/JurisdictionView', () => {
     jest.clearAllMocks();
     jest.resetAllMocks();
     fetch.resetMocks();
+    store.dispatch(deforest());
   });
 
   it('renders correctly', async () => {
     const plan = plans[0];
+    const rootId = '2942';
     fetch
-      .once(JSON.stringify(jurisdictionsMetadataArray), { status: 200 })
       .once(JSON.stringify(plan), { status: 200 })
-      .once(JSON.stringify([akros2]), { status: 200 })
-      .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
       .once(JSON.stringify(sampleHierarchy), { status: 200 });
+
     const props = {
       history,
       jurisdictionsMetadata: jurisdictionsMetadataArray,
       location: {
         hash: '',
-        pathname: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
+        pathname: `${MANUAL_JURISDICTIONS_URL}/${plan.identifier}`,
         search: '',
         state: {},
       },
       match: {
         isExact: true,
-        params: { planId: plan.identifier },
-        path: `${ASSIGN_JURISDICTIONS_URL}/:planId`,
-        url: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
+        params: { planId: plan.identifier, rootId },
+        path: `${MANUAL_JURISDICTIONS_URL}/:planId`,
+        url: `${MANUAL_JURISDICTIONS_URL}/${plan.identifier}`,
       },
       plan: plans[0],
+      tree: generateJurisdictionTree(sampleHierarchy),
     };
 
     const wrapper = mount(
@@ -101,27 +103,24 @@ describe('src/containers/JurisdictionView', () => {
 
   it('works correctly with store', async () => {
     const plan = plans[0];
+    const rootId = '2942';
     fetch
-      .once(JSON.stringify(jurisdictionsMetadataArray), { status: 200 })
       .once(JSON.stringify(plan), { status: 200 })
-      .once(JSON.stringify([akros2]), { status: 200 })
-      .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
-      .once(JSON.stringify(sampleHierarchy), { status: 200 })
-      .once(JSON.stringify(jurisdictionsMetadataArray), { status: 200 });
+      .once(JSON.stringify(sampleHierarchy), { status: 200 });
+
     const props = {
       history,
       location: {
         hash: '',
-        pathname: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
+        pathname: `${MANUAL_JURISDICTIONS_URL}/${plan.identifier}`,
         search: '',
         state: {},
       },
       match: {
         isExact: true,
-        params: { planId: plan.identifier },
-        path: `${ASSIGN_JURISDICTIONS_URL}/:planId`,
-        url: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
+        params: { planId: plan.identifier, rootId },
+        path: `${MANUAL_JURISDICTIONS_URL}/:planId`,
+        url: `${MANUAL_JURISDICTIONS_URL}/${plan.identifier}`,
       },
     };
 
@@ -138,10 +137,6 @@ describe('src/containers/JurisdictionView', () => {
       wrapper.update();
     });
 
-    expect(wrapper.text()).toMatchInlineSnapshot(
-      `"Planning toolA2-Lusaka Akros Test Focus 2Assign JurisdictionsI love oov"`
-    );
-
     // check props given to mock component
     const passedProps: any = wrapper.find('mockComponent').props();
     expect(passedProps.plan.identifier).toEqual(plan.identifier);
@@ -153,26 +148,24 @@ describe('src/containers/JurisdictionView', () => {
 
   it('shows loader', async () => {
     const plan = plans[0];
+    const rootId = '2942';
     fetch
-      .once(JSON.stringify(jurisdictionsMetadataArray), { status: 200 })
       .once(JSON.stringify(plan), { status: 200 })
-      .once(JSON.stringify([akros2]), { status: 200 })
-      .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
       .once(JSON.stringify(sampleHierarchy), { status: 200 });
+
     const props = {
       history,
       location: {
         hash: '',
-        pathname: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
+        pathname: `${MANUAL_JURISDICTIONS_URL}/${plan.identifier}`,
         search: '',
         state: {},
       },
       match: {
         isExact: true,
-        params: { planId: plan.identifier },
-        path: `${ASSIGN_JURISDICTIONS_URL}/:planId`,
-        url: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
+        params: { planId: plan.identifier, rootId },
+        path: `${MANUAL_JURISDICTIONS_URL}/:planId`,
+        url: `${MANUAL_JURISDICTIONS_URL}/${plan.identifier}`,
       },
     };
 
@@ -193,26 +186,24 @@ describe('src/containers/JurisdictionView', () => {
 
   it('plan error Message', async () => {
     const plan = plans[0];
+    const rootId = '2942';
     fetch
-      .once(JSON.stringify([]), { status: 500 })
-      .once(JSON.stringify({}), { status: 500 })
-      .once(JSON.stringify([akros2]), { status: 200 })
-      .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
+      .once(JSON.stringify(plan), { status: 500 })
       .once(JSON.stringify(sampleHierarchy), { status: 200 });
+
     const props = {
       history,
       location: {
         hash: '',
-        pathname: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
+        pathname: `${MANUAL_JURISDICTIONS_URL}/${plan.identifier}`,
         search: '',
         state: {},
       },
       match: {
         isExact: true,
-        params: { planId: plan.identifier },
-        path: `${ASSIGN_JURISDICTIONS_URL}/:planId`,
-        url: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
+        params: { planId: plan.identifier, rootId },
+        path: `${MANUAL_JURISDICTIONS_URL}/:planId`,
+        url: `${MANUAL_JURISDICTIONS_URL}/${plan.identifier}`,
       },
     };
 
@@ -232,71 +223,28 @@ describe('src/containers/JurisdictionView', () => {
     // check renderer error message
     expect(wrapper.text()).toMatchSnapshot('should be plan error page');
   });
-  it('single jurisdiction error Message', async () => {
+
+  it('getting hierarchy error Message', async () => {
     const plan = plans[0];
+    const rootId = '2942';
+
     fetch
-      .once(JSON.stringify(jurisdictionsMetadataArray), { status: 200 })
       .once(JSON.stringify(plan), { status: 200 })
-      .once(JSON.stringify([]), { status: 500 })
-      .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify(lusaka), { status: 200 })
-      .once(JSON.stringify(sampleHierarchy), { status: 200 });
-    const props = {
-      history,
-      location: {
-        hash: '',
-        pathname: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
-        search: '',
-        state: {},
-      },
-      match: {
-        isExact: true,
-        params: { planId: plan.identifier },
-        path: `${ASSIGN_JURISDICTIONS_URL}/:planId`,
-        url: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
-      },
-    };
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <Router history={history}>
-          <ConnectedJurisdictionAssignmentView {...props} />
-        </Router>
-      </Provider>
-    );
-
-    await act(async () => {
-      await new Promise(resolve => setImmediate(resolve));
-      wrapper.update();
-    });
-
-    // check renderer error message
-    expect(wrapper.text()).toMatchSnapshot('should be jurisdiction error page');
-  });
-
-  it('getting root jurisdiction error Message', async () => {
-    const plan = plans[0];
-    fetch
-      .once(JSON.stringify(jurisdictionsMetadataArray), { status: 200 })
-      .once(JSON.stringify(plan), { status: 200 })
-      .once(JSON.stringify([akros2]), { status: 200 })
-      .once(JSON.stringify(mtendere), { status: 200 })
-      .once(JSON.stringify({}), { status: 500 })
-      .once(JSON.stringify(sampleHierarchy), { status: 200 });
+      .once(JSON.stringify(sampleHierarchy), { status: 500 });
 
     const props = {
       history,
       location: {
         hash: '',
-        pathname: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
+        pathname: `${MANUAL_JURISDICTIONS_URL}/${plan.identifier}`,
         search: '',
         state: {},
       },
       match: {
         isExact: true,
-        params: { planId: plan.identifier },
-        path: `${ASSIGN_JURISDICTIONS_URL}/:planId`,
-        url: `${ASSIGN_JURISDICTIONS_URL}/${plan.identifier}`,
+        params: { planId: plan.identifier, rootId },
+        path: `${MANUAL_JURISDICTIONS_URL}/:planId`,
+        url: `${MANUAL_JURISDICTIONS_URL}/${plan.identifier}`,
       },
     };
 

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionCell/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionCell/tests/__snapshots__/index.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`src/pages/JurisdictionAssignment/JurisdictionCell renders correctly by 
       "children": Object {
         "length": 1,
       },
+      "hasChildren": [Function],
       "model": Object {
         "label": "Gaz",
       },
@@ -41,6 +42,7 @@ exports[`src/pages/JurisdictionAssignment/JurisdictionCell renders correctly whe
       "children": Object {
         "length": 0,
       },
+      "hasChildren": [Function],
       "model": Object {
         "label": "Gaz",
       },

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionCell/tests/index.test.tsx
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionCell/tests/index.test.tsx
@@ -15,6 +15,7 @@ describe('src/pages/JurisdictionAssignment/JurisdictionCell', () => {
   it('renders correctly by default', () => {
     const mockNode: any = {
       children: { length: 1 },
+      hasChildren: () => true,
       model: { label: 'Gaz' },
     };
     const props = {
@@ -33,6 +34,7 @@ describe('src/pages/JurisdictionAssignment/JurisdictionCell', () => {
   it('renders correctly when node does not have children', () => {
     const mockNode: any = {
       children: { length: 0 },
+      hasChildren: () => false,
       model: { label: 'Gaz' },
     };
     const props = {

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionTable/tests/index.test.tsx
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionTable/tests/index.test.tsx
@@ -36,9 +36,12 @@ describe('src/containers/pages/jurisdictionView/jurisdictionTable', () => {
     fetch.resetMocks();
   });
 
+  beforeAll(() => {
+    store.dispatch(fetchTree(sampleHierarchy));
+  });
+
   it('works correctly through a full render cycle', () => {
     const plan = irsPlans[0];
-    store.dispatch(fetchTree(sampleHierarchy));
 
     /** current architecture does not use the Jurisdiction table as a view
      * it is seen as a controlled component that is feed some data from controlling component

--- a/src/containers/pages/JurisdictionAssignment/helpers/Slider/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/helpers/Slider/index.tsx
@@ -21,8 +21,6 @@ import { PlanDefinition } from '../../../../../configs/settings';
 import { RISK_LABEL } from '../../../../../constants';
 import hierarchyReducer, {
   autoSelectNodes,
-  AutoSelectNodesAction,
-  FetchedTreeAction,
   fetchTree,
   getStructuresCount,
   getTreeById,
@@ -49,13 +47,13 @@ interface Props {
   structuresCount: number;
   fetchJurisdictionsMetadataCreator: ActionCreator<FetchJurisdictionsMetadataAction>;
   jurisdictionsMetadata: JurisdictionsMetadata[];
-  autoSelectCreator: ActionCreator<AutoSelectNodesAction>;
-  fetchTreeCreator: ActionCreator<FetchedTreeAction>;
-  plan: PlanDefinition | null;
+  autoSelectCreator: typeof autoSelectNodes;
+  fetchTreeCreator: typeof fetchTree;
+  plan: PlanDefinition;
   onClickNext: () => void;
 }
 
-const defaultProps: Props = {
+const defaultProps = {
   autoSelectCreator: autoSelectNodes,
   fetchJurisdictionsMetadataCreator: fetchJurisdictionsMetadata,
   fetchTreeCreator: fetchTree,
@@ -63,7 +61,6 @@ const defaultProps: Props = {
   onClickNext: () => {
     return;
   },
-  plan: null,
   rootJurisdictionId: '',
   structuresCount: 0,
 };
@@ -83,6 +80,8 @@ export const JurisdictionSelectionsSlider = (props: Props) => {
     tree,
   } = props;
 
+  const planId = plan.identifier;
+
   const onChangeComplete = (val: number | Range) => {
     const metaJurOfInterest = jurisdictionsMetadata.filter(
       metaObject => parseInt(metaObject.value, 10) > val
@@ -93,7 +92,7 @@ export const JurisdictionSelectionsSlider = (props: Props) => {
         !node.hasChildren() && jurisdictionsIdsMeta.includes(node.model.id);
       return isLeafNodePastThreshHold;
     };
-    autoSelectCreator(rootJurisdictionId, callback, SELECTION_REASON.AUTO_SELECTION);
+    autoSelectCreator(rootJurisdictionId, callback, planId, SELECTION_REASON.AUTO_SELECTION);
   };
 
   React.useEffect(() => {
@@ -158,6 +157,7 @@ const treeSelector = getTreeById();
 
 const mapStateToProps = (state: Partial<Store>, ownProps: Props): MapStateToProps => {
   const filters = {
+    planId: ownProps.plan.identifier,
     rootJurisdictionId: ownProps.rootJurisdictionId,
   };
   const structuresCount = structureCountSelector(state, filters);

--- a/src/containers/pages/JurisdictionAssignment/helpers/Slider/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/helpers/Slider/index.tsx
@@ -28,9 +28,8 @@ import hierarchyReducer, {
   getTreeById,
   reducerName as hierarchyReducerName,
 } from '../../../../../store/ducks/opensrp/hierarchies';
-import { TreeNode } from '../../../../../store/ducks/opensrp/hierarchies/types';
-
 import { SELECTION_REASON } from '../../../../../store/ducks/opensrp/hierarchies/constants';
+import { TreeNode } from '../../../../../store/ducks/opensrp/hierarchies/types';
 import jurisdictionMetadataReducer, {
   fetchJurisdictionsMetadata,
   FetchJurisdictionsMetadataAction,

--- a/src/containers/pages/JurisdictionAssignment/helpers/Slider/tests/slider.test.tsx
+++ b/src/containers/pages/JurisdictionAssignment/helpers/Slider/tests/slider.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from 'enzyme';
 import { cloneDeep } from 'lodash';
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
 import { ConnectedJurisdictionSelectionsSlider } from '..';
 import store from '../../../../../../store';
@@ -9,6 +10,7 @@ import { sampleHierarchy } from '../../../../../../store/ducks/opensrp/hierarchi
 import { fetchJurisdictionsMetadata } from '../../../../../../store/ducks/opensrp/jurisdictionsMetadata';
 import { plans } from '../../../../../../store/ducks/opensrp/PlanDefinition/tests/fixtures';
 import { jurisdictionsMetadataArray } from '../../../../../../store/ducks/tests/fixtures';
+
 /** tests for slider view
  * : need to know that changes on the slider are rendered on the ui
  * : need to know that changes on the slider cause the correct changes in the backend
@@ -49,7 +51,9 @@ describe('JurisdictionAssignment/Slider', () => {
     /** we really should not be doing this, but I am currently unable to simulate
      * the change event
      */
-    (wrapper.find('InputRange').props() as any).onChange(81);
+    act(() => {
+      (wrapper.find('InputRange').props() as any).onChange(81);
+    });
 
     // the risk value should be now different 2
     expect(wrapper.find('.risk-label').text()).toMatchInlineSnapshot(`"81%"`);


### PR DESCRIPTION
Refactors the containers that are using the previous implementation of the hierarchy reducer structure.

- The biggest change is that the manual and auto-selection pages will be rendered on routes that have the rootJurisdictionId param.
- they will be rendered at a time when we already have the rootId and the tree in store.
- Also the the service call to get the tree in these containers will not keep the page in a loading state while resolving; i.e ofcourse if we already have the tree in store.