### PR TITLE
Jurisdiction assignment page optimizations

### DIFF
--- a/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.tsx
@@ -230,10 +230,10 @@ const JurisdictionTable = (props: JurisdictionSelectorTableProps) => {
       node.hasChildren() ? '' : nodeIsSelected(node) ? TARGETED : NOT_TARGETED,
       node.model.meta.actionBy,
       <ConnectedSelectedJurisdictionsCount
-        key={`selected-jurisdictions-txt`}
+        key={`${node.model.id}-selected-jurisdictions-txt`}
         parentNode={node}
-        id={node.model.id}
-        jurisdictions={selectedLeafNodes}
+        planId={plan.identifier}
+        rootId={rootJurisdictionId}
       />,
     ];
   });

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.tsx
@@ -56,7 +56,7 @@ import { JurisdictionsMetadata } from '../../../../store/ducks/opensrp/jurisdict
 import { addPlanDefinition } from '../../../../store/ducks/opensrp/PlanDefinition';
 import { PlanStatus } from '../../../../store/ducks/plans';
 import { RiskLabel } from '../helpers/RiskLabel';
-import { ConnectedSelectedJurisdictionsCount } from '../helpers/SelectedJurisdictionsCount';
+import { SelectedJurisdictionsCount } from '../helpers/SelectedJurisdictionsCount';
 import { checkParentCheckbox, useHandleBrokenPage } from '../helpers/utils';
 import { NodeCell } from '../JurisdictionCell';
 
@@ -229,11 +229,10 @@ const JurisdictionTable = (props: JurisdictionSelectorTableProps) => {
         : []),
       node.hasChildren() ? '' : nodeIsSelected(node) ? TARGETED : NOT_TARGETED,
       node.model.meta.actionBy,
-      <ConnectedSelectedJurisdictionsCount
+      <SelectedJurisdictionsCount
         key={`${node.model.id}-selected-jurisdictions-txt`}
         parentNode={node}
-        planId={plan.identifier}
-        rootId={rootJurisdictionId}
+        selectedNodes={selectedLeafNodes}
       />,
     ];
   });

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionTable/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionTable/tests/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`src/containers/pages/jurisdictionView/jurisdictionTable selects and deselect nodes: should be now checked 1`] = `
 <input
-  checked={false}
+  checked={true}
   disabled={false}
   key="2942-check-jurisdiction"
   onChange={[Function]}
@@ -40,7 +40,7 @@ exports[`src/containers/pages/jurisdictionView/jurisdictionTable works correctly
 
 exports[`src/containers/pages/jurisdictionView/jurisdictionTable works correctly through a full render cycle: input checked 1`] = `"NameStructures CountTarget StatusStatus setting by...Selected Jurisdictions"`;
 
-exports[`src/containers/pages/jurisdictionView/jurisdictionTable works correctly through a full render cycle: input checked 2`] = `"Lusaka1591"`;
+exports[`src/containers/pages/jurisdictionView/jurisdictionTable works correctly through a full render cycle: input checked 2`] = `"Lusaka159User Change1"`;
 
 exports[`src/containers/pages/jurisdictionView/jurisdictionTable works correctly through a full render cycle: should have single node(parent node) 1`] = `"NameStructures CountTarget StatusStatus setting by...Selected Jurisdictions"`;
 

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionTable/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionTable/tests/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`src/containers/pages/jurisdictionView/jurisdictionTable selects and deselect nodes: should be now checked 1`] = `
 <input
-  checked={true}
+  checked={false}
   disabled={false}
   key="2942-check-jurisdiction"
   onChange={[Function]}
@@ -22,7 +22,7 @@ exports[`src/containers/pages/jurisdictionView/jurisdictionTable selects and des
 
 exports[`src/containers/pages/jurisdictionView/jurisdictionTable selects and deselect nodes: should be unchecked 1`] = `
 <input
-  checked={true}
+  checked={false}
   disabled={false}
   key="2942-check-jurisdiction"
   onChange={[Function]}
@@ -32,7 +32,7 @@ exports[`src/containers/pages/jurisdictionView/jurisdictionTable selects and des
 
 exports[`src/containers/pages/jurisdictionView/jurisdictionTable works correctly through a full render cycle: after first click 1`] = `"NameStructures CountTarget StatusStatus setting by...Selected Jurisdictions"`;
 
-exports[`src/containers/pages/jurisdictionView/jurisdictionTable works correctly through a full render cycle: after first click 2`] = `"Mtendere1User Change1"`;
+exports[`src/containers/pages/jurisdictionView/jurisdictionTable works correctly through a full render cycle: after first click 2`] = `"Mtendere159User Change1"`;
 
 exports[`src/containers/pages/jurisdictionView/jurisdictionTable works correctly through a full render cycle: after second click 1`] = `"NameStructures CountTarget StatusStatus setting by...Selected Jurisdictions"`;
 
@@ -40,11 +40,11 @@ exports[`src/containers/pages/jurisdictionView/jurisdictionTable works correctly
 
 exports[`src/containers/pages/jurisdictionView/jurisdictionTable works correctly through a full render cycle: input checked 1`] = `"NameStructures CountTarget StatusStatus setting by...Selected Jurisdictions"`;
 
-exports[`src/containers/pages/jurisdictionView/jurisdictionTable works correctly through a full render cycle: input checked 2`] = `"LusakaUser Change1"`;
+exports[`src/containers/pages/jurisdictionView/jurisdictionTable works correctly through a full render cycle: input checked 2`] = `"Lusaka1591"`;
 
 exports[`src/containers/pages/jurisdictionView/jurisdictionTable works correctly through a full render cycle: should have single node(parent node) 1`] = `"NameStructures CountTarget StatusStatus setting by...Selected Jurisdictions"`;
 
-exports[`src/containers/pages/jurisdictionView/jurisdictionTable works correctly through a full render cycle: should have single node(parent node) 2`] = `"Lusaka"`;
+exports[`src/containers/pages/jurisdictionView/jurisdictionTable works correctly through a full render cycle: should have single node(parent node) 2`] = `"Lusaka1590"`;
 
 exports[`src/containers/pages/jurisdictionView/jurisdictionTable works correctly through a full render cycle: should not have btn-link or onClick handler 1`] = `
 <span

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionTable/tests/index.test.tsx
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionTable/tests/index.test.tsx
@@ -54,7 +54,7 @@ describe('src/containers/pages/jurisdictionView/jurisdictionTable', () => {
     store.dispatch(deforest());
   });
 
-  it('works correctly through a full render cycle', () => {
+  it('works correctly through a full render cycle', async () => {
     const plan = irsPlans[0];
 
     /** current architecture does not use the Jurisdiction table as a view
@@ -105,6 +105,11 @@ describe('src/containers/pages/jurisdictionView/jurisdictionTable', () => {
       </Provider>
     );
 
+    await act(async () => {
+      await new Promise(resolve => setImmediate(resolve));
+      wrapper.update();
+    });
+
     renderTable(wrapper, 'should have single node(parent node)');
     const tbodyRow = wrapper.find('tbody tr');
     expect(tbodyRow.length).toEqual(1);
@@ -117,7 +122,10 @@ describe('src/containers/pages/jurisdictionView/jurisdictionTable', () => {
 
     // simulate click on checkbox to check
     tbodyRow.find('input').simulate('change', { target: { name: '', checked: true } });
-    wrapper.update();
+    await act(async () => {
+      await new Promise(resolve => setImmediate(resolve));
+      wrapper.update();
+    });
     renderTable(wrapper, 'input checked');
 
     expect(
@@ -134,7 +142,10 @@ describe('src/containers/pages/jurisdictionView/jurisdictionTable', () => {
       .find('NodeCell Link a')
       .simulate('click', { button: 0 });
 
-    wrapper.update();
+    await act(async () => {
+      await new Promise(resolve => setImmediate(resolve));
+      wrapper.update();
+    });
     renderTable(wrapper, 'after first click');
 
     expect(
@@ -151,7 +162,10 @@ describe('src/containers/pages/jurisdictionView/jurisdictionTable', () => {
       .find('NodeCell a')
       .simulate('click', { button: 0 });
 
-    wrapper.update();
+    await act(async () => {
+      await new Promise(resolve => setImmediate(resolve));
+      wrapper.update();
+    });
     renderTable(wrapper, 'after second click');
     expect(
       wrapper
@@ -167,7 +181,7 @@ describe('src/containers/pages/jurisdictionView/jurisdictionTable', () => {
     );
   });
 
-  it('selects and deselect nodes', () => {
+  it('selects and deselect nodes', async () => {
     const plan = irsPlans[0];
     const props = {
       plan,
@@ -181,13 +195,21 @@ describe('src/containers/pages/jurisdictionView/jurisdictionTable', () => {
       </Provider>
     );
 
+    await act(async () => {
+      await new Promise(resolve => setImmediate(resolve));
+      wrapper.update();
+    });
+
     const parentNodeRow = wrapper.find('tbody tr').at(0);
     // create snapshot of checkbox before getting checked
     expect(toJson(parentNodeRow.find('input'))).toMatchSnapshot('should be unchecked');
 
     // simulate click on checkbox to check
     parentNodeRow.find('input').simulate('change', { target: { name: '', checked: true } });
-    wrapper.update();
+    await act(async () => {
+      await new Promise(resolve => setImmediate(resolve));
+      wrapper.update();
+    });
 
     expect(
       toJson(
@@ -204,7 +226,11 @@ describe('src/containers/pages/jurisdictionView/jurisdictionTable', () => {
       .at(0)
       .find('input')
       .simulate('change', { target: { name: '', checked: false } });
-    wrapper.update();
+
+    await act(async () => {
+      await new Promise(resolve => setImmediate(resolve));
+      wrapper.update();
+    });
 
     // checkbox is now deselected again
     expect(
@@ -217,7 +243,7 @@ describe('src/containers/pages/jurisdictionView/jurisdictionTable', () => {
     ).toMatchSnapshot('should be now deselected');
   });
 
-  it('disables and enables checkbox for FI plans', () => {
+  it('disables and enables checkbox for FI plans', async () => {
     const plan = plans[0];
     const CustomView = (props: RouteComponentProps<Dictionary>) => {
       const mockProps = {
@@ -261,6 +287,10 @@ describe('src/containers/pages/jurisdictionView/jurisdictionTable', () => {
         </MemoryRouter>
       </Provider>
     );
+    await act(async () => {
+      await new Promise(resolve => setImmediate(resolve));
+      wrapper.update();
+    });
 
     const tbodyRow = wrapper.find('tbody tr');
     expect(
@@ -276,8 +306,10 @@ describe('src/containers/pages/jurisdictionView/jurisdictionTable', () => {
       .at(0)
       .find('NodeCell Link a')
       .simulate('click', { button: 0 });
-
-    wrapper.update();
+    await act(async () => {
+      await new Promise(resolve => setImmediate(resolve));
+      wrapper.update();
+    });
 
     expect(
       wrapper
@@ -293,8 +325,10 @@ describe('src/containers/pages/jurisdictionView/jurisdictionTable', () => {
       .at(0)
       .find('NodeCell a')
       .simulate('click', { button: 0 });
-
-    wrapper.update();
+    await act(async () => {
+      await new Promise(resolve => setImmediate(resolve));
+      wrapper.update();
+    });
 
     expect(
       wrapper
@@ -350,6 +384,10 @@ describe('src/containers/pages/jurisdictionView/jurisdictionTable', () => {
         </MemoryRouter>
       </Provider>
     );
+    await act(async () => {
+      await new Promise(resolve => setImmediate(resolve));
+      wrapper.update();
+    });
 
     // simulate a click on draft
     wrapper.find('#save-draft button').simulate('click');
@@ -357,6 +395,7 @@ describe('src/containers/pages/jurisdictionView/jurisdictionTable', () => {
     // flush promises
     await act(async () => {
       await new Promise(resolve => setImmediate(resolve));
+      wrapper.update();
     });
 
     // check fetch request

--- a/src/containers/pages/JurisdictionAssignment/helpers/SelectedJurisdictionsCount/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/helpers/SelectedJurisdictionsCount/index.tsx
@@ -10,17 +10,14 @@ import { TreeNode } from '../../../../../store/ducks/opensrp/hierarchies/types';
 
 /** Props for SelectedJurisdictionsCount  */
 export interface SelectedJurisdictionsCountProps {
-  id: string;
-  jurisdictions: TreeNode[] /** array of jurisdictions */;
-  parentNode: TreeNode | undefined;
+  rootId: string;
+  planId: string;
+  parentNode: TreeNode;
   selectedNodesUnderParent: TreeNode[];
 }
 
 /** default props for SelectedJurisdictionsCount */
-const defaultProps: SelectedJurisdictionsCountProps = {
-  id: '',
-  jurisdictions: [],
-  parentNode: undefined,
+const defaultProps: Partial<SelectedJurisdictionsCountProps> = {
   selectedNodesUnderParent: [],
 };
 
@@ -32,11 +29,8 @@ const defaultProps: SelectedJurisdictionsCountProps = {
  * @param props - the props!
  */
 const SelectedJurisdictionsCount = (props: SelectedJurisdictionsCountProps) => {
-  const { id, jurisdictions, selectedNodesUnderParent } = props;
+  const { parentNode, selectedNodesUnderParent } = props;
 
-  if (!jurisdictions || jurisdictions.length < 1) {
-    return null;
-  }
   const [tooltipOpen, setTooltipOpen] = useState(false);
   const toggleTooltip = () => setTooltipOpen(!tooltipOpen);
   const nodeJurisdictions = selectedNodesUnderParent;
@@ -45,16 +39,18 @@ const SelectedJurisdictionsCount = (props: SelectedJurisdictionsCountProps) => {
   );
   const toolTipDisplay = jurisdictionNames.join(', ');
 
+  const nodeId = parentNode.model.id;
+
   return (
     <Fragment>
-      <span id={`jurisdiction-tooltip-${id}`}>{nodeJurisdictions.length}</span>
+      <span id={`jurisdiction-tooltip-${nodeId}`}>{nodeJurisdictions.length}</span>
       <Tooltip
         placement="top"
         isOpen={tooltipOpen}
-        target={`jurisdiction-tooltip-${id}`}
+        target={`jurisdiction-tooltip-${nodeId}`}
         toggle={toggleTooltip}
       >
-        <span id={`jurisdiction-span-${id}`}>{toolTipDisplay}</span>;
+        <span id={`jurisdiction-span-${nodeId}`}>{toolTipDisplay}</span>;
       </Tooltip>
     </Fragment>
   );
@@ -73,9 +69,9 @@ const mapStateToProps = (
   ownProps: SelectedJurisdictionsCountProps
 ): MapStateToProps => {
   const filters: Filters = {
-    parentNode: ownProps.parentNode,
-    rootJurisdictionId: ownProps.id,
-    selectedLeafNodes: ownProps.jurisdictions,
+    currentParentId: ownProps.parentNode.model.id,
+    planId: ownProps.planId,
+    rootJurisdictionId: ownProps.rootId,
   };
   return {
     selectedNodesUnderParent: getSelectedNodesUnderParentNode()(state, filters),

--- a/src/containers/pages/JurisdictionAssignment/helpers/SelectedJurisdictionsCount/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/helpers/SelectedJurisdictionsCount/index.tsx
@@ -70,6 +70,7 @@ const mapStateToProps = (
 ): MapStateToProps => {
   const filters: Filters = {
     currentParentId: ownProps.parentNode.model.id,
+    leafNodesOnly: true,
     planId: ownProps.planId,
     rootJurisdictionId: ownProps.rootId,
   };

--- a/src/store/ducks/opensrp/hierarchies/index.tsx
+++ b/src/store/ducks/opensrp/hierarchies/index.tsx
@@ -308,12 +308,7 @@ export default function reducer(state = initialState, action: TreeActionTypes) {
       if (!treeOfInterest) {
         return state;
       }
-      const metaByJurisdictionId = autoSelectNodesAndCascade(
-        treeOfInterest,
-        callback,
-        actionBy,
-        thisPlansMetaData
-      );
+      const metaByJurisdictionId = autoSelectNodesAndCascade(treeOfInterest, callback, actionBy);
 
       return {
         ...state,

--- a/src/store/ducks/opensrp/hierarchies/index.tsx
+++ b/src/store/ducks/opensrp/hierarchies/index.tsx
@@ -581,7 +581,7 @@ export const getSelectedHierarchy = () => {
       keyBy(temp, nd => nd.model.id)
     );
 
-    // // flatten it into an array in preparation of creating a nested structure
+    // flatten it into an array in preparation of creating a nested structure
     const normalNodes: TreeNode[] = [];
     values(allNodesInPaths).forEach(node => {
       const data = node.model;

--- a/src/store/ducks/opensrp/hierarchies/index.tsx
+++ b/src/store/ducks/opensrp/hierarchies/index.tsx
@@ -322,7 +322,6 @@ export default function reducer(state = initialState, action: TreeActionTypes) {
           [rootJurisdictionId]: {
             ...state.metaData[rootJurisdictionId],
             [planId]: {
-              ...(state.metaData[rootJurisdictionId] || {})[planId],
               ...metaByJurisdictionId,
             },
           },

--- a/src/store/ducks/opensrp/hierarchies/index.tsx
+++ b/src/store/ducks/opensrp/hierarchies/index.tsx
@@ -414,7 +414,7 @@ export const getTreeById = () =>
   createSelector(getTreesByIds, getRootJurisdictionId, (treesByIds, rootId):
     | TreeNode
     | undefined => {
-    return treesByIds[rootId];
+    return cloneDeep(treesByIds[rootId]);
   });
 
 /** returns metaData for tree with the specified rootJurisdictionId
@@ -530,7 +530,12 @@ export const getAllSelectedNodes = () =>
  * @param props -  the filterProps
  */
 export const getSelectedNodesUnderParentNode = () =>
-  createSelector(getCurrentParentNode(), () => false, getMetaForPlanInTree(), computeSelectedNodes);
+  createSelector(
+    getCurrentParentNode(),
+    getLeafNodesOnly,
+    getMetaForPlanInTree(),
+    computeSelectedNodes
+  );
 
 /** returns the total structure count for all selected nodes in the entire tree
  * requires only the rootJurisdiction id

--- a/src/store/ducks/opensrp/hierarchies/index.tsx
+++ b/src/store/ducks/opensrp/hierarchies/index.tsx
@@ -553,12 +553,7 @@ export const getStructuresCount = () =>
  */
 export const getSelectedHierarchy = () => {
   return createSelector(getTreeById(), getMetaForPlanInTree(), (origTree, metaByJurisdiction) => {
-    /** what if we did a merge sort kind of think */
-    /** bear in mind we have to recompute the structures count */
-
-    /** */
-
-    // need to be very keen not tu mutate the original tree.
+    // need to be very keen not t0 mutate the original tree.
     const tree = cloneDeep(origTree);
     // get selected leaf nodes.
     const allSelectedLeafNodes = computeSelectedNodes(tree, true, metaByJurisdiction);

--- a/src/store/ducks/opensrp/hierarchies/tests/fixtures.ts
+++ b/src/store/ducks/opensrp/hierarchies/tests/fixtures.ts
@@ -1,6 +1,9 @@
 // tslint:disable: object-literal-sort-keys
 import { RawOpenSRPHierarchy } from '../types';
 
+// tslint:disable-next-line: no-var-requires
+export const zambiaHierarchy = require('./ZambiaHierarchy.json');
+
 export const sampleHierarchy: RawOpenSRPHierarchy = {
   locationsHierarchy: {
     map: {

--- a/src/store/ducks/opensrp/hierarchies/tests/fixtures.ts
+++ b/src/store/ducks/opensrp/hierarchies/tests/fixtures.ts
@@ -15,6 +15,7 @@ export const sampleHierarchy: RawOpenSRPHierarchy = {
           name: 'Lusaka',
           attributes: {
             geographicLevel: 0,
+            structureCount: 159,
           },
           voided: false,
         },
@@ -30,7 +31,7 @@ export const sampleHierarchy: RawOpenSRPHierarchy = {
                 voided: false,
               },
               attributes: {
-                structureCount: 1,
+                structureCount: 159,
                 geographicLevel: 1,
               },
               voided: false,

--- a/src/store/ducks/opensrp/hierarchies/tests/stress.test.tsx
+++ b/src/store/ducks/opensrp/hierarchies/tests/stress.test.tsx
@@ -1,0 +1,49 @@
+import { generateJurisdictionTree, setSelectOnNode } from '../utils';
+import { SELECTION_REASON } from '../constants';
+
+const zambiaHierarchy = require('./ZambiaHierarchy.json');
+
+const benchmark = (action: (args?: any) => void, message?: string, ...args: any) => {
+  const start = process.hrtime.bigint();
+  action(args);
+  const end = process.hrtime.bigint();
+
+  const NS_IN_S = 1e-9;
+  const timeDiff = end - start;
+  const seconds = Number(timeDiff) * NS_IN_S;
+
+  console.log(`${message} benchmark took ${timeDiff} nanoseconds (${seconds.toFixed(5)} seconds)`);
+};
+
+describe('reducer/hierarchies#stress', () => {
+  it('generates a jurisdiction tree model correctly', () => {
+    const action = () => {
+      generateJurisdictionTree(zambiaHierarchy);
+    };
+    benchmark(action, 'CreatingTree');
+  });
+
+  it('benchmark to walking the tree', () => {
+    const root = generateJurisdictionTree(zambiaHierarchy);
+    const action = () => {
+      root.walk(node => node.hasChildren());
+    };
+
+    benchmark(action, 'walking the tree');
+  });
+  
+  it('calling selectNode on the root node (worst case)', () => {
+    const tree = generateJurisdictionTree(zambiaHierarchy);
+    
+    const action = () => {
+      const res = setSelectOnNode(tree, tree.model.id, SELECTION_REASON.USER_CHANGE, true, false, false);
+    };
+
+    const anotherAction = () => {
+      const res = setSelectOnNode(tree, tree.model.id, SELECTION_REASON.USER_CHANGE, true, false, true);
+    }
+
+    benchmark(action, 'selecting node without cascade');
+    benchmark(anotherAction, 'selecting node with cascade down');
+  });
+});

--- a/src/store/ducks/opensrp/hierarchies/tests/stress.test.tsx
+++ b/src/store/ducks/opensrp/hierarchies/tests/stress.test.tsx
@@ -1,9 +1,32 @@
-import { generateJurisdictionTree, setSelectOnNode } from '../utils';
+import reducerRegistry from '@onaio/redux-reducer-registry';
+import { FlushThunks } from 'redux-testkit';
+import reducer, {
+  autoSelectNodes,
+  deforest,
+  fetchTree,
+  getAllSelectedNodes,
+  getSelectedHierarchy,
+  reducerName,
+  selectNode,
+} from '..';
+import store from '../../../../index';
 import { SELECTION_REASON } from '../constants';
+import { TreeNode } from '../types';
+import {
+  generateJurisdictionTree,
+  preOrderStructureCountComputation,
+  setSelectOnNode,
+} from '../utils';
+import { zambiaHierarchy } from './fixtures';
 
-const zambiaHierarchy = require('./ZambiaHierarchy.json');
+reducerRegistry.register(reducerName, reducer);
 
-const benchmark = (action: (args?: any) => void, message?: string, ...args: any) => {
+const zambiaId = '22bc44dd-752d-4c20-8761-617361b4f1e7';
+const planId = 'someRandomPlanId';
+
+let flushThunks;
+
+export const benchmark = (action: (args?: any) => void, message?: string, ...args: any) => {
   const start = process.hrtime.bigint();
   action(args);
   const end = process.hrtime.bigint();
@@ -12,10 +35,22 @@ const benchmark = (action: (args?: any) => void, message?: string, ...args: any)
   const timeDiff = end - start;
   const seconds = Number(timeDiff) * NS_IN_S;
 
-  console.log(`${message} benchmark took ${timeDiff} nanoseconds (${seconds.toFixed(5)} seconds)`);
+  // tslint:disable-next-line: no-console
+  console.log(
+    `${message}: {using Zambia} benchmark took ${timeDiff} nanoseconds (${seconds.toFixed(
+      5
+    )} seconds)`
+  );
 };
 
+const selectedHierarchySelector = getSelectedHierarchy();
+
 describe('reducer/hierarchies#stress', () => {
+  beforeEach(() => {
+    flushThunks = FlushThunks.createMiddleware();
+    jest.resetAllMocks();
+    store.dispatch(deforest());
+  });
   it('generates a jurisdiction tree model correctly', () => {
     const action = () => {
       generateJurisdictionTree(zambiaHierarchy);
@@ -31,19 +66,86 @@ describe('reducer/hierarchies#stress', () => {
 
     benchmark(action, 'walking the tree');
   });
-  
+
   it('calling selectNode on the root node (worst case)', () => {
     const tree = generateJurisdictionTree(zambiaHierarchy);
-    
+
     const action = () => {
-      const res = setSelectOnNode(tree, tree.model.id, SELECTION_REASON.USER_CHANGE, true, false, false);
+      setSelectOnNode(tree, tree.model.id, SELECTION_REASON.USER_CHANGE, true, false, false);
     };
 
-    const anotherAction = () => {
-      const res = setSelectOnNode(tree, tree.model.id, SELECTION_REASON.USER_CHANGE, true, false, true);
-    }
+    const cascadeDownAction = () => {
+      setSelectOnNode(tree, tree.model.id, SELECTION_REASON.USER_CHANGE, true, false, true);
+    };
+
+    const cascadeUpAction = () => {
+      setSelectOnNode(
+        tree,
+        '9e1ea1c1-edd7-45cb-99e0-b0bf33fd9ff3',
+        SELECTION_REASON.USER_CHANGE,
+        true,
+        true,
+        false
+      );
+    };
 
     benchmark(action, 'selecting node without cascade');
-    benchmark(anotherAction, 'selecting node with cascade down');
+    benchmark(cascadeDownAction, 'selecting node with cascade down');
+    benchmark(cascadeUpAction, 'selecting node with cascade up');
+  });
+
+  it('benchmarking select node action', () => {
+    store.dispatch(fetchTree(zambiaHierarchy));
+    const selectAction = () => {
+      store.dispatch(selectNode(zambiaId, '2942', planId));
+    };
+
+    benchmark(selectAction, 'calling select action node');
+  });
+
+  it('benchmarking node autoSelection', () => {
+    store.dispatch(fetchTree(zambiaHierarchy));
+    const callback = (node: TreeNode) => !!node.model;
+
+    const autoSelectionAction = () => {
+      store.dispatch(autoSelectNodes(zambiaId, callback, planId));
+    };
+
+    benchmark(autoSelectionAction, 'autoSelect nodes');
+  });
+
+  it('benchmarking tree with meta auto-selection', () => {
+    store.dispatch(fetchTree(zambiaHierarchy));
+    const callback = (node: TreeNode) => !!node.model;
+    store.dispatch(autoSelectNodes(zambiaId, callback, planId));
+
+    const filters = {
+      planId,
+      rootJurisdictionId: zambiaId,
+    };
+
+    const selectorsAction = () => {
+      getAllSelectedNodes()(store.getState(), {
+        ...filters,
+        leafNodesOnly: false,
+      });
+    };
+
+    const selectedHierarchySelectorAction = () => {
+      selectedHierarchySelector(store.getState(), filters);
+    };
+
+    benchmark(selectedHierarchySelectorAction, 'recreating tree');
+    benchmark(selectorsAction, 'allSelectedNodes');
+  });
+
+  it('benchmarking pre order structure computation', () => {
+    const tree = generateJurisdictionTree(zambiaHierarchy);
+
+    const preOrderAction = () => {
+      preOrderStructureCountComputation(tree);
+    };
+
+    benchmark(preOrderAction, 'pre-order structure computation');
   });
 });

--- a/src/store/ducks/opensrp/hierarchies/tests/stress.test.tsx
+++ b/src/store/ducks/opensrp/hierarchies/tests/stress.test.tsx
@@ -13,6 +13,7 @@ import store from '../../../../index';
 import { SELECTION_REASON } from '../constants';
 import { TreeNode } from '../types';
 import {
+  applyMeta,
   generateJurisdictionTree,
   preOrderStructureCountComputation,
   setSelectOnNode,
@@ -135,6 +136,13 @@ describe('reducer/hierarchies#stress', () => {
       selectedHierarchySelector(store.getState(), filters);
     };
 
+    const meta = store.getState()[reducerName].metaData[zambiaId][planId];
+    const nodes = selectedHierarchySelector(store.getState(), filters)!.all(() => true);
+    const applyMetaAction = () => {
+      applyMeta(nodes, meta);
+    };
+
+    benchmark(applyMetaAction, `Applying meta to ${nodes.length}`);
     benchmark(selectedHierarchySelectorAction, 'recreating tree');
     benchmark(selectorsAction, 'allSelectedNodes');
   });

--- a/src/store/ducks/opensrp/hierarchies/tests/stress.test.tsx
+++ b/src/store/ducks/opensrp/hierarchies/tests/stress.test.tsx
@@ -137,7 +137,11 @@ describe('reducer/hierarchies#stress', () => {
     };
 
     const meta = store.getState()[reducerName].metaData[zambiaId][planId];
-    const nodes = selectedHierarchySelector(store.getState(), filters)!.all(() => true);
+    const selectedHierarchy = selectedHierarchySelector(store.getState(), filters);
+    if (!selectedHierarchy) {
+      fail();
+    }
+    const nodes = selectedHierarchy.all(() => true);
     const applyMetaAction = () => {
       applyMeta(nodes, meta);
     };

--- a/src/store/ducks/opensrp/hierarchies/utils.tsx
+++ b/src/store/ducks/opensrp/hierarchies/utils.tsx
@@ -154,18 +154,15 @@ export const setSelectOnNode = (
   }
   // add an entry for this node
   const thisNodesMeta = createSingleMetaData(nodeId, actionBy, true);
-  metaByJurisdiction = {
-    ...metaByJurisdiction,
-    ...thisNodesMeta,
-  };
+  metaByJurisdiction = Object.assign(metaByJurisdiction, thisNodesMeta);
 
   if (cascadeDown) {
     // argNode is part of this walk.
     nodeOfInterest.walk(nd => {
-      metaByJurisdiction = {
-        ...metaByJurisdiction,
-        ...createSingleMetaData(nd.model.id, actionBy, selectValue),
-      };
+      metaByJurisdiction = Object.assign(
+        metaByJurisdiction,
+        createSingleMetaData(nd.model.id, actionBy, selectValue)
+      );
       return true;
     });
   }
@@ -174,10 +171,10 @@ export const setSelectOnNode = (
     // remove the node from path
     parentsPath.pop();
     parentsPath.forEach(parentNode => {
-      metaByJurisdiction = {
-        ...metaByJurisdiction,
-        ...createSingleMetaData(parentNode.model.id, actionBy, selectValue),
-      };
+      metaByJurisdiction = Object.assign(
+        metaByJurisdiction,
+        createSingleMetaData(parentNode.model.id, actionBy, selectValue)
+      );
     });
   }
   return { metaByJurisdiction, nodeOfInterest };
@@ -202,10 +199,10 @@ export function computeParentNodesSelection(
       metaDataByJurisdiction
     );
     if (allChildrenAreSelected) {
-      metaDataByJurisdictionId = {
-        ...metaDataByJurisdictionId,
-        ...createSingleMetaData(parentNode.model.id, actionBy, true),
-      };
+      metaDataByJurisdictionId = Object.assign(
+        metaDataByJurisdictionId,
+        createSingleMetaData(parentNode.model.id, actionBy, true)
+      );
     } else {
       break;
     }
@@ -229,10 +226,10 @@ export const autoSelectNodesAndCascade = (
   tree.walk(node => {
     if (callback(node)) {
       node.walk(nd => {
-        metaByJurisdictionId = {
-          ...createSingleMetaData(nd.model.id, actionBy, true),
-          ...metaByJurisdictionId,
-        };
+        metaByJurisdictionId = Object.assign(
+          metaByJurisdictionId,
+          createSingleMetaData(nd.model.id, actionBy, true)
+        );
         // removing this return cause a type error, that's its sole purpose
         return true;
       });
@@ -246,16 +243,13 @@ export const autoSelectNodesAndCascade = (
 
   // now select parents accordingly
   parentNodesSet.forEach(node => {
-    metaByJurisdictionId = {
-      ...metaByJurisdictionId,
-      ...computeParentNodesSelection(node, actionBy, thisTreeMetaData),
-    };
+    metaByJurisdictionId = Object.assign(
+      metaByJurisdictionId,
+      computeParentNodesSelection(node, actionBy, thisTreeMetaData)
+    );
   });
 
-  return {
-    ...metaByJurisdiction,
-    ...metaByJurisdictionId,
-  };
+  return Object.assign({}, metaByJurisdiction, metaByJurisdictionId);
 };
 
 /** compute Selected nodes from the tree

--- a/src/store/ducks/opensrp/hierarchies/utils.tsx
+++ b/src/store/ducks/opensrp/hierarchies/utils.tsx
@@ -309,7 +309,8 @@ export const applyMeta = (nodes: TreeNode[] | TreeNode | undefined, meta: Dictio
   const localNodes = Array.isArray(nodes) ? [...nodes] : [nodes];
 
   localNodes.forEach(node => {
-    const thisNodesMeta = Object.assign({}, node.model.meta, meta[node.model.id]);
+    const thisNodesMeta = Object.assign({}, meta[node.model.id]);
+    thisNodesMeta[META_STRUCTURE_COUNT] = node.model.meta[META_STRUCTURE_COUNT];
     node.model.meta = thisNodesMeta;
   });
 
@@ -331,13 +332,13 @@ export const findAParentNode = (
   if (parentId === undefined) {
     return tree;
   }
-  const ss: TreeNode | undefined = tree.first(node => node.model.id === parentId);
+  const finalNode: TreeNode | undefined = tree.first(node => node.model.id === parentId);
 
   if (metaData) {
-    return applyMeta(ss, metaData)[0];
+    return applyMeta(finalNode, metaData)[0];
   }
 
-  return ss;
+  return finalNode;
 };
 
 /** find the current children from  a parent node. This is defined here to avoid repetition

--- a/src/store/ducks/opensrp/hierarchies/utils.tsx
+++ b/src/store/ducks/opensrp/hierarchies/utils.tsx
@@ -267,7 +267,8 @@ export const computeSelectedNodes = (
   }
   tree.walk(node => {
     const shouldAddNode =
-      !!metaByJurisdiction[node.model.id] && !(leafNodesOnly && node.hasChildren());
+      !!(metaByJurisdiction[node.model.id] && metaByJurisdiction[node.model.id][SELECTION_KEY]) &&
+      !(leafNodesOnly && node.hasChildren());
     if (shouldAddNode) {
       nodesList.push(node);
     }

--- a/src/store/ducks/opensrp/hierarchies/utils.tsx
+++ b/src/store/ducks/opensrp/hierarchies/utils.tsx
@@ -182,6 +182,8 @@ export const setSelectOnNode = (
 
 /** traverse up and select the parent nodes where necessary
  * @param node a node
+ * @param actionBy - reason by which select changed
+ * @param metaDataByJurisdiction - meta object key'd by jurisdictionId
  */
 export function computeParentNodesSelection(
   node: TreeNode,
@@ -213,6 +215,7 @@ export function computeParentNodesSelection(
 /** compute Selected nodes from the tree
  * @param tree - the whole tree or undefined
  * @param leafNodesOnly - whether to include the leaf nodes only
+ * @param metaByJurisdiction - MetaData object
  */
 export const computeSelectedNodes = (
   tree: TreeNode | undefined,
@@ -236,13 +239,14 @@ export const computeSelectedNodes = (
 };
 
 /** any callback that will take a node and return whether we should select the node
+ * @param tree - the tree
  * @param callback - callback is given each node in a walk and decides whether that node should be selected by returning true or false
+ * @param actionBy - selected by
  */
 export const autoSelectNodesAndCascade = (
   tree: TreeNode,
   callback: (node: TreeNode) => boolean,
-  actionBy: string = SELECTION_REASON.USER_CHANGE,
-  thisTreeMetaData: Dictionary<Meta>
+  actionBy: string = SELECTION_REASON.USER_CHANGE
 ) => {
   let metaByJurisdictionId: Dictionary<Meta> = {};
 
@@ -265,7 +269,7 @@ export const autoSelectNodesAndCascade = (
   selectedChildren.forEach(node => {
     metaByJurisdictionId = Object.assign(
       metaByJurisdictionId,
-      computeParentNodesSelection(node, actionBy, thisTreeMetaData)
+      computeParentNodesSelection(node, actionBy, metaByJurisdictionId)
     );
   });
 
@@ -316,6 +320,7 @@ export const applyMeta = (nodes: TreeNode[] | TreeNode | undefined, meta: Dictio
 /** find the parent node in a tree given the parentId
  * @param tree - the tree
  * @param parentId - id of the parent node
+ * @param metaData - the tree's metaData - used to know which nodes to selected
  */
 export const findAParentNode = (
   tree: TreeNode | undefined,
@@ -343,6 +348,7 @@ export const findAParentNode = (
 
 /** find the current children from  a parent node. This is defined here to avoid repetition
  * @param parentNode -  the parent Node
+ * @param metaData - the tree's metadata; used to know which nodes to select
  */
 export const getChildrenForNode = (
   parentNode: TreeNode | undefined,

--- a/src/store/ducks/opensrp/hierarchies/utils.tsx
+++ b/src/store/ducks/opensrp/hierarchies/utils.tsx
@@ -301,7 +301,7 @@ export const preOrderStructureCountComputation = (node: TreeNode) => {
  * @param nodes - a node or a list of nodes to apply the metadata to
  * @param meta - meta object by jurisdiction
  */
-export const applyMeta = (nodes: TreeNode[] | TreeNode | undefined, meta: Dictionary<Meta>) => {
+export const applyMeta = (nodes?: TreeNode[] | TreeNode, meta: Dictionary<Meta> = {}) => {
   if (!nodes) {
     return [];
   }
@@ -323,8 +323,8 @@ export const applyMeta = (nodes: TreeNode[] | TreeNode | undefined, meta: Dictio
  * @param metaData - the tree's metaData - used to know which nodes to selected
  */
 export const findAParentNode = (
-  tree: TreeNode | undefined,
-  parentId: string | undefined,
+  tree?: TreeNode,
+  parentId?: string,
   metaData?: Dictionary<Meta>
 ) => {
   if (!tree) {
@@ -350,10 +350,7 @@ export const findAParentNode = (
  * @param parentNode -  the parent Node
  * @param metaData - the tree's metadata; used to know which nodes to select
  */
-export const getChildrenForNode = (
-  parentNode: TreeNode | undefined,
-  metaData?: Dictionary<Meta>
-) => {
+export const getChildrenForNode = (parentNode?: TreeNode, metaData?: Dictionary<Meta>) => {
   let children = [];
   if (parentNode) {
     children = parentNode.children;


### PR DESCRIPTION
close #1103 

 - replaced `...` object spread operator with `Object.assign` since its much faster, 
- refactored `.forEach` with the standard `for` loop
- instead of computing another whole tree where we add the metaData to respective nodes; meta is now applied to only nodes that will be returned to selectors.
- added a couple of stress tests along the way, not sure where to place them since they have no assertions.