### PR TITLE
Allow saving of plans only when a jurisdiction is selected

### DIFF
--- a/src/configs/lang.ts
+++ b/src/configs/lang.ts
@@ -804,3 +804,8 @@ export const TARGETED_STATUS = translate('TARGETED_STATUS', 'Target Status');
 export const TARGETED = translate('TARGETED', 'Targeted');
 
 export const NOT_TARGETED = translate('NOT_TARGETED', 'Not Targeted');
+
+export const SELECT_JURISDICTION = translate(
+  'SELECT_JURISDICTION',
+  'Please select atleast one jurisdiction'
+);

--- a/src/configs/lang.ts
+++ b/src/configs/lang.ts
@@ -807,5 +807,5 @@ export const NOT_TARGETED = translate('NOT_TARGETED', 'Not Targeted');
 
 export const SELECT_JURISDICTION = translate(
   'SELECT_JURISDICTION',
-  'Please select atleast one jurisdiction'
+  'Please select at least one jurisdiction'
 );

--- a/src/configs/strings/en.json
+++ b/src/configs/strings/en.json
@@ -1186,5 +1186,9 @@
   "ERROR_PERMISSION_DENIED": {
     "message": "This user does not have permissions to access this page",
     "description": "Error message displayed if user does not have permission to access the page"
+  },
+  "SELECT_JURISDICTION": {
+    "message": "Please select atleast one jurisdiction",
+    "description": "Popup message displayed when user tries to save plan without selecting a jurisdiction"
   }
 }

--- a/src/configs/strings/en.json
+++ b/src/configs/strings/en.json
@@ -1188,7 +1188,7 @@
     "description": "Error message displayed if user does not have permission to access the page"
   },
   "SELECT_JURISDICTION": {
-    "message": "Please select atleast one jurisdiction",
+    "message": "Please select at least one jurisdiction",
     "description": "Popup message displayed when user tries to save plan without selecting a jurisdiction"
   }
 }

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.css
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.css
@@ -1,0 +1,4 @@
+/* allows tooltip to show */
+.btn[disabled] {
+  pointer-events: none;
+}

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.css
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.css
@@ -1,4 +1,4 @@
-/* allows tooltip to show */
+/* allows tooltip to show on disabled button */
 .btn[disabled] {
   pointer-events: none;
 }

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.tsx
@@ -1,7 +1,7 @@
 import ElementMap from '@onaio/element-map';
 import ListView, { renderHeadersFuncType } from '@onaio/list-view';
 import reducerRegistry from '@onaio/redux-reducer-registry';
-import React, { useState } from 'react';
+import React, { Fragment, useState } from 'react';
 import { connect } from 'react-redux';
 import { useHistory } from 'react-router';
 import { Button, Tooltip } from 'reactstrap';
@@ -340,7 +340,7 @@ const JurisdictionTable = (props: JurisdictionSelectorTableProps) => {
         </div>
       )}
       {!!data.length && (
-        <>
+        <Fragment>
           <hr />
 
           <span id="save-draft-wrapper" className="float-right">
@@ -367,10 +367,10 @@ const JurisdictionTable = (props: JurisdictionSelectorTableProps) => {
               {SAVE_AND_ACTIVATE}
             </Button>
           </span>
-        </>
+        </Fragment>
       )}
       {!hasSelectedNode && (
-        <>
+        <Fragment>
           <Tooltip
             placement="top"
             isOpen={activateTooltipOpen}
@@ -387,7 +387,7 @@ const JurisdictionTable = (props: JurisdictionSelectorTableProps) => {
           >
             {SELECT_JURISDICTION}
           </Tooltip>
-        </>
+        </Fragment>
       )}
     </div>
   );

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.tsx
@@ -60,6 +60,7 @@ import { RiskLabel } from '../helpers/RiskLabel';
 import { ConnectedSelectedJurisdictionsCount } from '../helpers/SelectedJurisdictionsCount';
 import { checkParentCheckbox, useHandleBrokenPage } from '../helpers/utils';
 import { NodeCell } from '../JurisdictionCell';
+import './index.css';
 
 reducerRegistry.register(hierarchyReducerName, hierarchyReducer);
 
@@ -342,28 +343,30 @@ const JurisdictionTable = (props: JurisdictionSelectorTableProps) => {
         <>
           <hr />
 
-          <Button
-            disabled={!hasSelectedNode}
-            id="save-draft"
-            className="float-right"
-            color="primary"
-            // tslint:disable-next-line: jsx-no-lambda
-            onClick={() => commitJurisdictions(plan)}
-            size="xs"
-          >
-            {SAVE_DRAFT}
-          </Button>
+          <span id="save-draft-wrapper" className="float-right">
+            <Button
+              disabled={!hasSelectedNode}
+              id="save-draft"
+              color="primary"
+              // tslint:disable-next-line: jsx-no-lambda
+              onClick={() => commitJurisdictions(plan)}
+              size="xs"
+            >
+              {SAVE_DRAFT}
+            </Button>
+          </span>
 
-          <Button
-            disabled={!hasSelectedNode}
-            id="save-and-activate"
-            className="float-right mr-3"
-            color="success"
-            onClick={onSaveAndActivate}
-            size="xs"
-          >
-            {SAVE_AND_ACTIVATE}
-          </Button>
+          <span id="save-and-activate-wrapper" className="float-right mr-3">
+            <Button
+              disabled={!hasSelectedNode}
+              id="save-and-activate"
+              color="success"
+              onClick={onSaveAndActivate}
+              size="xs"
+            >
+              {SAVE_AND_ACTIVATE}
+            </Button>
+          </span>
         </>
       )}
       {!hasSelectedNode && (
@@ -371,7 +374,7 @@ const JurisdictionTable = (props: JurisdictionSelectorTableProps) => {
           <Tooltip
             placement="top"
             isOpen={activateTooltipOpen}
-            target="save-and-activate"
+            target="save-and-activate-wrapper"
             toggle={toggleActivateToolTip}
           >
             {SELECT_JURISDICTION}
@@ -379,7 +382,7 @@ const JurisdictionTable = (props: JurisdictionSelectorTableProps) => {
           <Tooltip
             placement="top"
             isOpen={draftTooltipOpen}
-            target="save-draft"
+            target="save-draft-wrapper"
             toggle={toggleDraftToolTip}
           >
             {SELECT_JURISDICTION}

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.tsx
@@ -1,10 +1,11 @@
 import ElementMap from '@onaio/element-map';
 import ListView, { renderHeadersFuncType } from '@onaio/list-view';
 import reducerRegistry from '@onaio/redux-reducer-registry';
-import React from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { useHistory } from 'react-router';
 import Button from 'reactstrap/lib/Button';
+import Tooltip from 'reactstrap/lib/Tooltip';
 import { Store } from 'redux';
 import { ErrorPage } from '../../../../components/page/ErrorPage';
 import HeaderBreadcrumb, {
@@ -20,6 +21,7 @@ import {
   RISK_LABEL,
   SAVE_AND_ACTIVATE,
   SAVE_DRAFT,
+  SELECT_JURISDICTION,
   SELECTED_JURISDICTIONS,
   STATUS_SETTING,
   STRUCTURES_COUNT,
@@ -120,6 +122,9 @@ const JurisdictionTable = (props: JurisdictionSelectorTableProps) => {
     autoSelectionFlow,
     deselectAllNodesCreator,
   } = props;
+
+  const [activateTooltipOpen, setActivateTooltipOpen] = useState(false);
+  const [draftTooltipOpen, setDraftTooltipOpen] = useState(false);
 
   /** function for determining whether the jurisdiction assignment table allows for
    * multiple selection or single selection based on the plan intervention type
@@ -316,6 +321,11 @@ const JurisdictionTable = (props: JurisdictionSelectorTableProps) => {
       .catch(err => displayError(err));
   };
 
+  /** toggle save & activate button tooltip */
+  const toggleActivateToolTip = () => setActivateTooltipOpen(!activateTooltipOpen);
+  /** toggle save draft button tooltip */
+  const toggleDraftToolTip = () => setDraftTooltipOpen(!draftTooltipOpen);
+
   // check if there is any selected node
   const hasSelectedNode: boolean = selectedLeafNodes.length > 0;
 
@@ -355,6 +365,26 @@ const JurisdictionTable = (props: JurisdictionSelectorTableProps) => {
           >
             {SAVE_AND_ACTIVATE}
           </Button>
+        </>
+      )}
+      {!hasSelectedNode && (
+        <>
+          <Tooltip
+            placement="top"
+            isOpen={activateTooltipOpen}
+            target="save-and-activate"
+            toggle={toggleActivateToolTip}
+          >
+            {SELECT_JURISDICTION}
+          </Tooltip>
+          <Tooltip
+            placement="top"
+            isOpen={draftTooltipOpen}
+            target="save-draft"
+            toggle={toggleDraftToolTip}
+          >
+            {SELECT_JURISDICTION}
+          </Tooltip>
         </>
       )}
     </div>

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.tsx
@@ -316,6 +316,9 @@ const JurisdictionTable = (props: JurisdictionSelectorTableProps) => {
       .catch(err => displayError(err));
   };
 
+  // check if there is any selected node
+  const hasSelectedNode: boolean = selectedLeafNodes.length > 0;
+
   return (
     <div>
       <HeaderBreadcrumb {...breadCrumbProps} />
@@ -331,6 +334,7 @@ const JurisdictionTable = (props: JurisdictionSelectorTableProps) => {
           <hr />
 
           <Button
+            disabled={!hasSelectedNode}
             id="save-draft"
             className="float-right"
             color="primary"
@@ -342,6 +346,7 @@ const JurisdictionTable = (props: JurisdictionSelectorTableProps) => {
           </Button>
 
           <Button
+            disabled={!hasSelectedNode}
             id="save-and-activate"
             className="float-right mr-3"
             color="success"

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionTable/index.tsx
@@ -4,8 +4,7 @@ import reducerRegistry from '@onaio/redux-reducer-registry';
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { useHistory } from 'react-router';
-import Button from 'reactstrap/lib/Button';
-import Tooltip from 'reactstrap/lib/Tooltip';
+import { Button, Tooltip } from 'reactstrap';
 import { Store } from 'redux';
 import { ErrorPage } from '../../../../components/page/ErrorPage';
 import HeaderBreadcrumb, {

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionTable/tests/fixtures.ts
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionTable/tests/fixtures.ts
@@ -8,7 +8,7 @@ export const afterDraftSave = [
   {
     'Cache-Control': 'no-cache',
     Pragma: 'no-cache',
-    body: JSON.stringify({ ...plan, jurisdiction: [], status: PlanStatus.DRAFT }),
+    body: JSON.stringify({ ...plan, jurisdiction: [{ code: '3951' }], status: PlanStatus.DRAFT }),
     headers: {
       accept: 'application/json',
       authorization: 'Bearer null',
@@ -23,7 +23,7 @@ export const afterSaveAndActivate = [
   {
     'Cache-Control': 'no-cache',
     Pragma: 'no-cache',
-    body: JSON.stringify({ ...plan, jurisdiction: [], status: PlanStatus.ACTIVE }),
+    body: JSON.stringify({ ...plan, jurisdiction: [{ code: '3951' }], status: PlanStatus.ACTIVE }),
     headers: {
       accept: 'application/json',
       authorization: 'Bearer null',

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionTable/tests/index.test.tsx
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionTable/tests/index.test.tsx
@@ -43,6 +43,14 @@ describe('src/containers/pages/jurisdictionView/jurisdictionTable', () => {
   it('works correctly through a full render cycle', () => {
     const plan = irsPlans[0];
 
+    const activateDiv = document.createElement('div');
+    activateDiv.setAttribute('id', 'save-and-activate-wrapper');
+    document.body.appendChild(activateDiv);
+
+    const draftDiv = document.createElement('div');
+    draftDiv.setAttribute('id', 'save-draft-wrapper');
+    document.body.appendChild(draftDiv);
+
     /** current architecture does not use the Jurisdiction table as a view
      * it is seen as a controlled component that is feed some data from controlling component
      * That's why there was a need to have this custom view and a mock routing system.
@@ -348,6 +356,13 @@ describe('src/containers/pages/jurisdictionView/jurisdictionTable', () => {
         </MemoryRouter>
       </Provider>
     );
+    // save draft button is disabled
+    expect(wrapper.find('#save-draft button').prop('disabled')).toEqual(true);
+    // select a jurisdiction
+    const tbodyRow = wrapper.find('tbody tr');
+    tbodyRow.find('input').simulate('change', { target: { name: '', checked: true } });
+    // save draft button is enabled
+    expect(wrapper.find('#save-draft button').prop('disabled')).toEqual(false);
 
     // simulate a click on draft
     wrapper.find('#save-draft button').simulate('click');

--- a/src/containers/pages/JurisdictionAssignment/JurisdictionTable/tests/index.test.tsx
+++ b/src/containers/pages/JurisdictionAssignment/JurisdictionTable/tests/index.test.tsx
@@ -473,6 +473,14 @@ describe('src/containers/pages/jurisdictionView/jurisdictionTable', () => {
       wrapper.update();
     });
 
+    // save & activate button is disabled
+    expect(wrapper.find('#save-and-activate button').prop('disabled')).toEqual(true);
+    // select a jurisdiction
+    const tbodyRow = wrapper.find('tbody tr');
+    tbodyRow.find('input').simulate('change', { target: { name: '', checked: true } });
+    // save & activate button is enabled
+    expect(wrapper.find('#save-and-activate button').prop('disabled')).toEqual(false);
+
     // simulate a click on draft
     wrapper.find('#save-and-activate button').simulate('click');
 


### PR DESCRIPTION
part of #1101 

Ensures a plan can not be saved without selecting a jurisdiction by:
- Disabling action buttons (`Save & Activate` and `Save Draft`) if no jurisdiction is selected
- Also adds a tool tip to indicate no jurisdiction selected when the action buttons are disabled.

It is also partial fix for #1124