### PR TITLE
Enable plans submit button after an error

### DIFF
--- a/src/components/forms/PlanForm/index.tsx
+++ b/src/components/forms/PlanForm/index.tsx
@@ -264,6 +264,7 @@ const PlanForm = (props: PlanFormProps) => {
                 onSubmitSuccess(setSubmitting, setAreWeDoneHere, payload, addPlan);
               })
               .catch((e: Error) => {
+                setSubmitting(false);
                 displayError(e, AN_ERROR_OCCURRED, false);
               });
           } else {
@@ -273,6 +274,7 @@ const PlanForm = (props: PlanFormProps) => {
                 onSubmitSuccess(setSubmitting, setAreWeDoneHere, payload, addPlan);
               })
               .catch((e: Error) => {
+                setSubmitting(false);
                 displayError(e, AN_ERROR_OCCURRED, false);
               });
           }

--- a/src/components/forms/PlanForm/tests/index.test.tsx
+++ b/src/components/forms/PlanForm/tests/index.test.tsx
@@ -1200,5 +1200,10 @@ describe('containers/forms/PlanForm - Submission', () => {
 
     expect(addPlanMock.mock.calls.length).toEqual(0);
     expect(displayErrorMock).toHaveBeenCalledWith('API is down', AN_ERROR_OCCURRED, false);
+
+    // submit button is enabled after an error
+    wrapper.update();
+    expect(wrapper.find('#planform-submit-button button').prop('disabled')).toEqual(false);
+    expect(wrapper.find('#planform-submit-button button').text()).toEqual('Save Plan');
   });
 });


### PR DESCRIPTION
Part of #1115 
Enables submit button once an error occurs when creating or editing a plan.