### PR TITLE
Solve bug historical indices not showing on empty maps

### DIFF
--- a/src/containers/pages/FocusInvestigation/map/active/index.tsx
+++ b/src/containers/pages/FocusInvestigation/map/active/index.tsx
@@ -453,8 +453,7 @@ const mapStateToProps = (state: Partial<Store>, ownProps: any) => {
     plansByFocusArea.sort((a: Plan, b: Plan) => Date.parse(b.plan_date) - Date.parse(a.plan_date));
   }
 
-  if (plan && jurisdiction && goals && goals.length > 1) {
-    /** include all complete index cases including current index case */
+  if (plan && jurisdiction) {
     historicalPointIndexCases = getTasksFCSelector(state, {
       actionCode: CASE_CONFIRMATION_CODE,
       excludePlanId: plan.plan_id,
@@ -469,7 +468,10 @@ const mapStateToProps = (state: Partial<Store>, ownProps: any) => {
       structureType: [POLYGON, MULTI_POLYGON],
       taskBusinessStatus: 'Complete',
     });
+  }
 
+  if (plan && jurisdiction && goals && goals.length > 1) {
+    /** include all complete index cases including current index case */
     currentPointIndexCases = getTasksFCSelector(state, {
       actionCode: CASE_CONFIRMATION_CODE,
       jurisdictionId: plan.jurisdiction_id,

--- a/src/containers/pages/FocusInvestigation/map/active/tests/__snapshots__/indexCases.test.tsx.snap
+++ b/src/containers/pages/FocusInvestigation/map/active/tests/__snapshots__/indexCases.test.tsx.snap
@@ -1,5 +1,149 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`containers/pages/FocusInvestigation/activeMap displays historical indices for empty map 1`] = `
+Object {
+  "id": "main-plan-layer-3951",
+  "lineLayout": Object {
+    "visibility": "visible",
+  },
+  "linePaint": Object {
+    "line-color": "#FFDC00",
+    "line-opacity": 1,
+    "line-width": 3,
+  },
+  "type": "line",
+}
+`;
+
+exports[`containers/pages/FocusInvestigation/activeMap displays historical indices for empty map 2`] = `
+Object {
+  "circleLayout": Object {
+    "visibility": "visible",
+  },
+  "circlePaint": Object {
+    "circle-color": Array [
+      "get",
+      "color",
+    ],
+    "circle-opacity": 0.7,
+    "circle-radius": Array [
+      "interpolate",
+      Array [
+        "exponential",
+        2,
+      ],
+      Array [
+        "zoom",
+      ],
+      15.75,
+      2.5,
+      20.8,
+      50,
+    ],
+    "circle-stroke-color": Array [
+      "get",
+      "color",
+    ],
+    "circle-stroke-opacity": 1,
+    "circle-stroke-width": 2,
+  },
+  "id": "historical-index-cases-point",
+  "type": "circle",
+}
+`;
+
+exports[`containers/pages/FocusInvestigation/activeMap displays historical indices for empty map 3`] = `
+Object {
+  "id": "historical-index-cases-point-symbol",
+  "symbolLayout": Object {
+    "icon-image": "case-confirmation",
+    "icon-size": 0.045,
+    "visibility": "visible",
+  },
+  "symbolPaint": Object {
+    "text-color": "#0000ff",
+    "text-halo-blur": 1,
+    "text-halo-color": "#fff",
+    "text-halo-width": 1.3,
+  },
+  "type": "symbol",
+}
+`;
+
+exports[`containers/pages/FocusInvestigation/activeMap displays historical indices for empty map 4`] = `
+Object {
+  "id": "historical-index-cases-fill-line",
+  "lineLayout": Object {
+    "visibility": "visible",
+  },
+  "linePaint": Object {
+    "line-color": Array [
+      "get",
+      "color",
+    ],
+    "line-opacity": 1,
+    "line-width": 2,
+  },
+  "type": "line",
+}
+`;
+
+exports[`containers/pages/FocusInvestigation/activeMap displays historical indices for empty map 5`] = `
+Object {
+  "fillLayout": Object {
+    "visibility": "visible",
+  },
+  "fillPaint": Object {
+    "fill-color": Array [
+      "get",
+      "color",
+    ],
+    "fill-outline-color": Array [
+      "get",
+      "color",
+    ],
+  },
+  "id": "historical-index-cases-fill",
+  "type": "fill",
+}
+`;
+
+exports[`containers/pages/FocusInvestigation/activeMap displays historical indices for empty map 6`] = `
+Object {
+  "id": "historical-index-cases-poly-symbol",
+  "symbolLayout": Object {
+    "icon-image": "case-confirmation",
+    "icon-size": 0.045,
+    "visibility": "visible",
+  },
+  "symbolPaint": Object {
+    "text-color": "#0000ff",
+    "text-halo-blur": 1,
+    "text-halo-color": "#fff",
+    "text-halo-width": 1.3,
+  },
+  "type": "symbol",
+}
+`;
+
+exports[`containers/pages/FocusInvestigation/activeMap displays historical indices for empty map 7`] = `
+Object {
+  "id": "current-index-cases-poly-symbol",
+  "symbolLayout": Object {
+    "icon-image": "current-case-confirmation",
+    "icon-size": 0.045,
+    "visibility": "visible",
+  },
+  "symbolPaint": Object {
+    "text-color": "#0000ff",
+    "text-halo-blur": 1,
+    "text-halo-color": "#fff",
+    "text-halo-width": 1.3,
+  },
+  "type": "symbol",
+}
+`;
+
 exports[`containers/pages/FocusInvestigation/activeMap passes historical index cases to gisida lite 1`] = `
 Object {
   "id": "main-plan-layer-3951",

--- a/src/containers/pages/FocusInvestigation/map/active/tests/indexCases.test.tsx
+++ b/src/containers/pages/FocusInvestigation/map/active/tests/indexCases.test.tsx
@@ -98,4 +98,59 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
       expect(localLayer).toMatchSnapshot();
     });
   });
+
+  it('displays historical indices for empty map', async () => {
+    // use dispatch
+    store.dispatch(fetchPlans(fixturesMap.processedPlansJSON));
+    store.dispatch(fetchJurisdictions(fixturesMap.processedJurisdictionJSON));
+    store.dispatch(structureDucks.setStructures(fixturesMap.processedStructuresJSON));
+    store.dispatch(fetchGoals(fixturesMap.processedGoalsJSON));
+    store.dispatch(fetchTasks(fixturesMap.processedPlansTasksJson));
+    store.dispatch(fetchTasks(fixturesMap.processedCaseConfirmationTasksJSON));
+    const mock = jest.fn();
+    const supersetServiceMock = jest.fn(async () => null);
+    const props = {
+      history,
+      location: mock,
+      match: {
+        isExact: true,
+        params: { id: '94af1ec6-52c9-5bbb-8453-0ff71d572400' },
+        path: `${FI_SINGLE_URL}/:id`,
+        url: `${FI_SINGLE_URL}/94af1ec6-52c9-5bbb-8453-0ff71d572400`,
+      },
+      supersetService: supersetServiceMock,
+    };
+    const wrapper = mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <ConnectedMapSingleFI {...props} />
+        </Router>
+      </Provider>
+    );
+    await new Promise(resolve => setImmediate(resolve));
+    wrapper.update();
+
+    const componentProps: any = wrapper.find('SingleActiveFIMap').props();
+
+    expect(componentProps.plan.id).toEqual('94af1ec6-52c9-5bbb-8453-0ff71d572400');
+    expect(componentProps.jurisdiction.jurisdiction_id).toEqual('3951');
+    expect(componentProps.pointFeatureCollection.features.length).toEqual(0);
+    expect(componentProps.polygonFeatureCollection.features.length).toEqual(0);
+    expect(componentProps.currentPointIndexCases).toEqual(null);
+    expect(componentProps.currentPolyIndexCases).toEqual(null);
+    expect(componentProps.historicalPointIndexCases.features.length).toEqual(1);
+    expect(componentProps.historicalPolyIndexCases.features.length).toEqual(2);
+
+    // gisida lite layers
+    const gisidaLiteProps: any = wrapper.find('MemoizedGisidaLiteMock').props();
+    const { layers } = gisidaLiteProps;
+
+    layers.forEach((layer: any) => {
+      const layerProps = layer.props;
+      // remove data so that we do not pollute the snapshot
+      const localLayer = cloneDeep(layerProps);
+      delete localLayer.data;
+      expect(localLayer).toMatchSnapshot();
+    });
+  });
 });


### PR DESCRIPTION
Closes #943 

Solve bug historical indices not showing on empty maps or maps with no other points. Fixtures were used in solving this bug

**A map that is not empty**

![Screenshot from 2020-08-14 10-52-52](https://user-images.githubusercontent.com/19818819/90227459-461dd700-de1d-11ea-99d8-81229a33f2bd.png)


**Selecting a plan from other plans that has no points now shows historical indices**



![Screenshot from 2020-08-14 10-53-25](https://user-images.githubusercontent.com/19818819/90227249-e7585d80-de1c-11ea-8a9b-50656ed78cd4.png)
