### PR TITLE
Handle empty jurisdiction metadata API response

### DIFF
--- a/src/components/forms/JurisdictionMetadataDownload/index.tsx
+++ b/src/components/forms/JurisdictionMetadataDownload/index.tsx
@@ -10,6 +10,7 @@ import {
   DOWNLOAD,
   DOWNLOAD_FILE,
   DOWNLOADING,
+  ERROR_NO_JURISDICTION_METADATA_FOUND,
   FILE,
   FILE_DOWNLOADED_SUCCESSFULLY,
   IDENTIFIER,
@@ -22,6 +23,7 @@ import {
   OPENSRP_V2_SETTINGS,
   TEXT_CSV,
 } from '../../../constants';
+import { displayError } from '../../../helpers/errors';
 import { downloadFile, successGrowl } from '../../../helpers/utils';
 import { OpenSRPService } from '../../../services/opensrp';
 
@@ -82,7 +84,12 @@ const createCsv = (entries: JurisdictionMetadataFile[], fileName: string): void 
  * Download CSV file from obtained data
  */
 export const download = (response: JurisdictionMetadataResponse[]) => {
+  if (!response.length) {
+    return;
+  }
+
   const entries: JurisdictionMetadataFile[] = [];
+
   response.forEach(item => {
     const metaType = item.settingIdentifier.replace('jurisdiction_metadata-', '');
     const entry: JurisdictionMetadataFile = {
@@ -128,8 +135,13 @@ export const submitForm = (
   serviceClass
     .list(params)
     .then((response: JurisdictionMetadataResponse[]) => {
-      download(response);
-      successGrowl(FILE_DOWNLOADED_SUCCESSFULLY);
+      if (response.length) {
+        download(response);
+        successGrowl(FILE_DOWNLOADED_SUCCESSFULLY);
+      } else {
+        displayError(new Error(ERROR_NO_JURISDICTION_METADATA_FOUND));
+      }
+
       setSubmitting(false);
     })
     .catch((e: Error) => {

--- a/src/components/forms/JurisdictionMetadataDownload/tests/index.test.tsx
+++ b/src/components/forms/JurisdictionMetadataDownload/tests/index.test.tsx
@@ -3,7 +3,9 @@ import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import React from 'react';
 import JurisdictionMetadataDownloadForm, { Option, submitForm } from '..';
+import { ERROR_NO_JURISDICTION_METADATA_FOUND } from '../../../../configs/lang';
 import { JURISDICTION_METADATA_RISK } from '../../../../constants';
+import * as helperErrors from '../../../../helpers/errors';
 import * as helperUtils from '../../../../helpers/utils';
 import * as fixtures from '../../../../store/ducks/tests/fixtures';
 
@@ -66,6 +68,38 @@ describe('components/forms/JurisdictionMetadata', () => {
       expect(mockedOpenSRPservice).toHaveBeenCalledTimes(1);
       expect(mockGrowl).toBeCalled();
       expect(mockDownload).toBeCalled();
+    });
+  });
+
+  it('csv file is not download is response is empty', async () => {
+    const identifier: Option = { value: JURISDICTION_METADATA_RISK, label: 'Risk' };
+    const setSubmitting = jest.fn();
+    const setGlobalError = jest.fn();
+    const mockGrowl: any = jest.fn();
+    const mockDownload: any = jest.fn();
+    const mockDisplayError: any = jest.fn();
+    (helperUtils as any).successGrowl = mockGrowl;
+    (helperUtils as any).downloadFile = mockDownload;
+    (helperErrors as any).displayError = mockDisplayError;
+    const mockedOpenSRPservice = jest.fn().mockImplementation(() => {
+      return {
+        list: () => {
+          return Promise.resolve([]);
+        },
+      };
+    });
+    const props = {
+      initialValues: {
+        identifier,
+      },
+      serviceClass: new mockedOpenSRPservice(),
+    };
+    submitForm(setSubmitting, setGlobalError, props as any, { identifier });
+    await waitFor(() => {
+      expect(mockedOpenSRPservice).toHaveBeenCalledTimes(1);
+      expect(mockGrowl).not.toBeCalled();
+      expect(mockDownload).not.toBeCalled();
+      expect(mockDisplayError).toBeCalledWith(new Error(ERROR_NO_JURISDICTION_METADATA_FOUND));
     });
   });
 });

--- a/src/configs/lang.ts
+++ b/src/configs/lang.ts
@@ -828,4 +828,9 @@ export const NO_JURISDICTION_SELECTIONS_FOUND = translate(
   'No Jurisdiction selections were found'
 );
 
+export const ERROR_NO_JURISDICTION_METADATA_FOUND = translate(
+  'ERROR_NO_JURISDICTION_METADATA_FOUND',
+  'No jurisdiction metadata found'
+);
+
 export const TOTAL = translate('TOTAL', 'Total');

--- a/src/configs/strings/en.json
+++ b/src/configs/strings/en.json
@@ -1202,5 +1202,9 @@
   "UPLOADING_FILE": {
     "message": "Uploading File",
     "description": "text displayed when uploading a file"
+  },
+  "ERROR_NO_JURISDICTION_METADATA_FOUND": {
+    "message": "No jurisdiction metadata found",
+    "description": "Error message displayed if no jurisdiction metadata is found"
   }
 }


### PR DESCRIPTION
Closes #1157

Display error message if no jurisdiction  metadata is found