### PR TITLE
Generate default plan displayed dynamically

### DIFF
--- a/src/components/forms/PlanForm/index.tsx
+++ b/src/components/forms/PlanForm/index.tsx
@@ -22,6 +22,7 @@ import {
   DEFAULT_PLAN_DURATION_DAYS,
   DEFAULT_PLAN_VERSION,
   ENABLED_FI_REASONS,
+  ENABLED_PLAN_TYPES,
 } from '../../../configs/env';
 import {
   ACTION,
@@ -108,9 +109,14 @@ const initialJurisdictionValues: PlanJurisdictionFormFields = {
   name: '',
 };
 
+/** default intervention type displayed */
+const defaultInterventionType = ENABLED_PLAN_TYPES
+  ? (ENABLED_PLAN_TYPES[0] as InterventionType)
+  : InterventionType.FI;
+
 /** initial values for plan Form */
 export const defaultInitialValues: PlanFormFields = {
-  activities: planActivitiesMap[InterventionType.FI],
+  activities: planActivitiesMap[defaultInterventionType],
   caseNum: '',
   date: moment().toDate(),
   end: moment()
@@ -119,7 +125,7 @@ export const defaultInitialValues: PlanFormFields = {
   fiReason: undefined,
   fiStatus: undefined,
   identifier: '',
-  interventionType: InterventionType.FI,
+  interventionType: defaultInterventionType,
   jurisdictions: [initialJurisdictionValues],
   name: '',
   opensrpEventId: undefined,

--- a/src/containers/pages/InterventionPlan/NewPlan/General/tests/__snapshots__/index.intervention.test.tsx.snap
+++ b/src/containers/pages/InterventionPlan/NewPlan/General/tests/__snapshots__/index.intervention.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`containers/pages/NewPlan: single enabled intervention type renders correctly: page title 1`] = `
+<h3
+  className="mb-3 page-title"
+>
+  Create New Plan
+</h3>
+`;

--- a/src/containers/pages/InterventionPlan/NewPlan/General/tests/__snapshots__/index.intervention.test.tsx.snap
+++ b/src/containers/pages/InterventionPlan/NewPlan/General/tests/__snapshots__/index.intervention.test.tsx.snap
@@ -1,9 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`containers/pages/NewPlan: single enabled intervention type renders correctly: page title 1`] = `
-<h3
-  className="mb-3 page-title"
->
-  Create New Plan
-</h3>
-`;

--- a/src/containers/pages/InterventionPlan/NewPlan/General/tests/index.intervention.test.tsx
+++ b/src/containers/pages/InterventionPlan/NewPlan/General/tests/index.intervention.test.tsx
@@ -1,0 +1,69 @@
+import { mount, shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import { createBrowserHistory } from 'history';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { Router } from 'react-router';
+import { defaultProps as defaultPlanFormProps } from '../../../../../../components/forms/PlanForm';
+import store from '../../../../../../store';
+import { removePlanDefinitions } from '../../../../../../store/ducks/opensrp/PlanDefinition';
+import ConnectedBaseNewPlan from '../index';
+
+/* tslint:disable-next-line no-var-requires */
+const fetch = require('jest-fetch-mock');
+
+const history = createBrowserHistory();
+
+jest.mock('../../../../../../configs/env', () => ({
+  ENABLED_FI_REASONS: ['Case Triggered', 'Routine'],
+  ENABLED_PLAN_TYPES: ['IRS'],
+}));
+
+describe('containers/pages/NewPlan: single enabled intervention type', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    fetch.resetMocks();
+    jest.clearAllMocks();
+    store.dispatch(removePlanDefinitions());
+  });
+
+  it('renders without crashing', () => {
+    shallow(<ConnectedBaseNewPlan />);
+  });
+
+  it('renders correctly', () => {
+    const wrapper = mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <ConnectedBaseNewPlan />
+        </Router>
+      </Provider>
+    );
+
+    // check that page title is displayed
+    expect(toJson(wrapper.find('h3.mb-3.page-title'))).toMatchSnapshot('page title');
+    // jurisdictionLabel is contry for IRS
+    expect(wrapper.find('PlanForm').props()).toEqual({
+      ...defaultPlanFormProps,
+      addPlan: expect.any(Function),
+      allowMoreJurisdictions: false,
+      cascadingSelect: false,
+      formHandler: expect.any(Function),
+      jurisdictionLabel: 'Country',
+    });
+
+    // check that there's a Row that nests a Col that nests a PlanForm
+    expect(wrapper.find('Row')).toHaveLength(1);
+    expect(wrapper.find('Row').find('Col')).toHaveLength(2);
+    expect(
+      wrapper
+        .find('Row')
+        .find('Col#planform-col-container')
+        .find('PlanForm')
+    ).toHaveLength(1);
+
+    // FI intervention type not loaded loaded
+    expect(wrapper.find('#fiStatus').length).toBeFalsy();
+    expect(wrapper.find('#fiReason').length).toBeFalsy();
+  });
+});

--- a/src/containers/pages/InterventionPlan/NewPlan/General/tests/index.intervention.test.tsx
+++ b/src/containers/pages/InterventionPlan/NewPlan/General/tests/index.intervention.test.tsx
@@ -1,5 +1,4 @@
 import { mount, shallow } from 'enzyme';
-import toJson from 'enzyme-to-json';
 import { createBrowserHistory } from 'history';
 import React from 'react';
 import { Provider } from 'react-redux';
@@ -41,7 +40,7 @@ describe('containers/pages/NewPlan: single enabled intervention type', () => {
     );
 
     // check that page title is displayed
-    expect(toJson(wrapper.find('h3.mb-3.page-title'))).toMatchSnapshot('page title');
+    expect(wrapper.find('h3.mb-3.page-title').text()).toEqual('Create New Plan');
     // jurisdictionLabel is contry for IRS
     expect(wrapper.find('PlanForm').props()).toEqual({
       ...defaultPlanFormProps,

--- a/src/containers/pages/InterventionPlan/NewPlan/General/tests/index.test.tsx
+++ b/src/containers/pages/InterventionPlan/NewPlan/General/tests/index.test.tsx
@@ -22,6 +22,8 @@ const history = createBrowserHistory();
 const middlewares: any = [];
 const mockStore = configureMockStore(middlewares);
 
+jest.mock('../../../../../../configs/env');
+
 describe('containers/pages/NewPlan', () => {
   beforeEach(() => {
     jest.resetAllMocks();
@@ -61,6 +63,10 @@ describe('containers/pages/NewPlan', () => {
         .find('Col#planform-col-container')
         .find('PlanForm')
     ).toHaveLength(1);
+
+    // FI intervention type is loaded
+    expect(wrapper.find('#fiStatus').length).toBeTruthy();
+    expect(wrapper.find('#fiReason').length).toBeTruthy();
 
     // test that JurisdictionDetails are shown
     // set jurisdiction id ==> we use Formik coz React-Select is acting weird


### PR DESCRIPTION
Closes #1153 
Changes default intervention type passed by default from `FI` type to the first intervention type defined in `REACT_APP_ENABLED_PLAN_TYPES` . 