### PR TITLE
Update jurisdiction metadata payload

### DIFF
--- a/src/helpers/tests/utils.test.tsx
+++ b/src/helpers/tests/utils.test.tsx
@@ -453,9 +453,9 @@ describe('helpers/utils', () => {
     expect(payloads).toHaveLength(2);
     expect(payload).toEqual(expectedPayload);
 
-    const payloadWithUser: SettingConfiguration[] = creatSettingsPayloads(result, true);
-    const expectedPayloadWithUser = { ...expectedPayload, providerId: 'testUser' };
-    expect(payloadWithUser[0]).toEqual(expectedPayloadWithUser);
+    const payloadWithProvider: SettingConfiguration[] = creatSettingsPayloads(result, true);
+    const expectedPayloadWithProvider = { ...expectedPayload, providerId: 'testUser' };
+    expect(payloadWithProvider[0]).toEqual(expectedPayloadWithProvider);
   });
 
   it('getPlanStatusToDisplay - eliminates unwanted plans', () => {

--- a/src/helpers/utils.tsx
+++ b/src/helpers/utils.tsx
@@ -959,7 +959,7 @@ export interface SettingConfiguration {
  */
 export const creatSettingsPayloads = (
   result: PapaResult,
-  addUsername: boolean = false
+  addProvider: boolean = false
 ): SettingConfiguration[] => {
   const payloads: SettingConfiguration[] = [];
   const { data } = result;
@@ -988,13 +988,12 @@ export const creatSettingsPayloads = (
           }
         }
       }
-
       const payload: SettingConfiguration = {
         identifier: `jurisdiction_metadata-${header}`,
         settings,
         type: SETTINGS_CONFIGURATION,
       };
-      if (addUsername) {
+      if (addProvider) {
         payload.providerId = username;
       }
       payloads.push(payload);

--- a/src/helpers/utils.tsx
+++ b/src/helpers/utils.tsx
@@ -948,18 +948,22 @@ export interface Setting {
 export interface SettingConfiguration {
   type: string;
   identifier: string;
-  providerId: string;
-  locationId: string;
+  providerId?: string;
+  locationId?: string;
   settings: Setting[];
-  teamId: string;
+  teamId?: string;
 }
 
 /**
  * Create payload for sending settings to OpenSRP v1 Settings endpoint
  */
-export const creatSettingsPayloads = (result: PapaResult): SettingConfiguration[] => {
+export const creatSettingsPayloads = (
+  result: PapaResult,
+  addUsername: boolean = false
+): SettingConfiguration[] => {
   const payloads: SettingConfiguration[] = [];
   const { data } = result;
+  const username = getUser(store.getState()).username;
   // check if jurisdiction_id exists
   if (data.length > 0 && data[0].jurisdiction_id) {
     // get the metadata items
@@ -984,15 +988,15 @@ export const creatSettingsPayloads = (result: PapaResult): SettingConfiguration[
           }
         }
       }
-      const username = getUser(store.getState()).username;
+
       const payload: SettingConfiguration = {
         identifier: `jurisdiction_metadata-${header}`,
-        locationId: '',
-        providerId: username,
         settings,
-        teamId: '',
         type: SETTINGS_CONFIGURATION,
       };
+      if (addUsername) {
+        payload.providerId = username;
+      }
       payloads.push(payload);
     }
   }


### PR DESCRIPTION
Removes `teamId` and `locationId` keys and makes `providerId` key configurable when uploading jurisdictions metadata.