### PR TITLE
Handle invalid geometries

### DIFF
--- a/src/containers/pages/AssigmentMapWrapper/tests/fixtures.ts
+++ b/src/containers/pages/AssigmentMapWrapper/tests/fixtures.ts
@@ -705,6 +705,41 @@ export const payload = [
   },
 ];
 
+export const payloadWithInvalidCoordinates = [
+  {
+    geometry: {
+      coordinates: [[[[]]]],
+      type: 'MultiPolygon',
+    },
+    id: '2942',
+    properties: {
+      geographicLevel: 3,
+      name: 'Two Two Two Release Village',
+      parentId: '872cc59e-0bce-427a-bd1f-6ef674dba8e2',
+      status: 'Active',
+      version: 0,
+    },
+    serverVersion: 1563491844118,
+    type: 'Feature',
+  },
+  {
+    geometry: {
+      coordinates: [[[[]]]],
+      type: 'MultiPolygon',
+    },
+    id: '3951',
+    properties: {
+      geographicLevel: 3,
+      name: 'Two Three Two Release Village',
+      parentId: '3019',
+      status: 'Active',
+      version: 0,
+    },
+    serverVersion: 1565045134411,
+    type: 'Feature',
+  },
+];
+
 export const fetchCalls = [
   [
     'https://reveal-stage.smartregister.org/opensrp/rest/location/findByJurisdictionIds?is_jurisdiction=true&jurisdiction_ids=07b09ec1-0589-4a98-9480-4c403ac24d59,8fb28715-6c80-4e2c-980f-422798fe9f41&return_geometry=true',
@@ -728,4 +763,44 @@ export const jurisdiction1 = {
     version: 0,
   },
   type: 'Feature',
+};
+
+export const invalidCoordinatesGeom = {
+  features: [
+    {
+      geometry: {
+        coordinates: [[[]]],
+        type: 'Polygon',
+      },
+      id: '07b09ec1-0589-4a98-9480-4c403ac24d59',
+      properties: {
+        geographicLevel: 3,
+        name: 'Two Two Two Release Village',
+        // parentId: '872cc59e-0bce-427a-bd1f-6ef674dba8e2',
+        status: 'Active',
+        version: 0,
+      },
+      type: 'Feature',
+    },
+    {
+      geometry: {
+        coordinates: [[[]]],
+        type: 'Polygon',
+      },
+      id: '3951',
+      properties: {
+        fillColor: '#792b16',
+        fillOutlineColor: '#ffffff',
+        geographicLevel: 3,
+        jurisdiction_id: '3951',
+        lineColor: '#ffffff',
+        name: 'Two Three Two Release Village',
+        parentId: '3019',
+        status: 'Active',
+        version: 0,
+      },
+      type: 'Feature',
+    },
+  ],
+  type: 'FeatureCollection',
 };

--- a/src/containers/pages/AssigmentMapWrapper/tests/index.test.tsx
+++ b/src/containers/pages/AssigmentMapWrapper/tests/index.test.tsx
@@ -9,6 +9,7 @@ import { Provider } from 'react-redux';
 import { Router } from 'react-router';
 import { AssignmentMapWrapper, ConnectedAssignmentMapWrapper } from '..';
 import { getJurisdictions } from '../../../../components/TreeWalker/helpers';
+import { MAP_LOAD_ERROR } from '../../../../configs/lang';
 import { PlanDefinition } from '../../../../configs/settings';
 import { ASSIGN_PLAN_URL, MANUAL_ASSIGN_JURISDICTIONS_URL } from '../../../../constants';
 import { OpenSRPService } from '../../../../services/opensrp';
@@ -622,5 +623,35 @@ describe('containers/pages/AssigmentMapWrapper', () => {
     expect(history.location.pathname).toEqual(
       '/manualSelectJurisdictions/2493/2942/8fb28715-6c80-4e2c-980f-422798fe9f41'
     );
+  });
+  it('shows error div when features have invalid coordinates', async () => {
+    store.dispatch(fetchTree(sampleHierarchy, '2942'));
+    store.dispatch(fetchJurisdictions(fixtures.payloadWithInvalidCoordinates as any));
+    store.dispatch(selectNode('2942', '2942', '2943'));
+    const children = getCurrentChildren()(store.getState(), {
+      currentParentId: '2942',
+      leafNodesOnly: true,
+      planId: '2953',
+      rootJurisdictionId: '2942',
+    });
+    const props = {
+      currentChildren: [children] as any,
+      currentParentId: '3019',
+      fetchJurisdictionsActionCreator: fetchJurisdictions,
+      getJurisdictionsFeatures: fixtures.invalidCoordinatesGeom as any,
+      plan: {
+        identifier: '2493',
+      } as PlanDefinition,
+      rootJurisdictionId: '2942',
+      serviceClass: OpenSRPService,
+    };
+    const wrapper = mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <ConnectedAssignmentMapWrapper {...props} />
+        </Router>
+      </Provider>
+    );
+    expect(wrapper.find('div').text()).toEqual(MAP_LOAD_ERROR);
   });
 });


### PR DESCRIPTION
Handle jurisdictions with invalid coordinates to prevent jurisdiction assignment page from breaking