### PR TITLE
1216 audit jurisdiction requests

### DIFF
--- a/src/containers/pages/JurisdictionAssignment/EntryView/utils.tsx
+++ b/src/containers/pages/JurisdictionAssignment/EntryView/utils.tsx
@@ -121,10 +121,6 @@ export function useGetRootJurisdictionId(
   return rootJurisdictionId;
 }
 
-const defaultCallback = () => {
-  return;
-};
-
 /** get the jurisdiction Tree given the rootJurisdiction Id
  * @param rootJurisdictionId - id of top level jurisdiction
  * @param startLoading - helper to start loading
@@ -132,7 +128,6 @@ const defaultCallback = () => {
  * @param stopLoading - helper to stop loading
  * @param handleBrokenPage - helper to handle page errors
  * @param tree - the tree if it exists, used to know if we should set loading to true.
- * @param onThen - a callback called with the response
  */
 export function useGetJurisdictionTree(
   rootJurisdictionId: string,
@@ -140,8 +135,7 @@ export function useGetJurisdictionTree(
   treeFetchedCreator: ActionCreator<FetchedTreeAction>,
   stopLoading: StopLoading,
   handleBrokenPage: HandleBrokenPage,
-  tree?: TreeNode,
-  onThen: (apiResponse: Result<RawOpenSRPHierarchy>) => void = defaultCallback
+  tree?: TreeNode
 ) {
   React.useEffect(() => {
     const params = {
@@ -154,7 +148,6 @@ export function useGetJurisdictionTree(
           if (apiResponse.value) {
             const responseData = apiResponse.value;
             treeFetchedCreator(responseData);
-            onThen(apiResponse);
           }
           if (apiResponse.error) {
             throw new Error(COULD_NOT_LOAD_JURISDICTION_HIERARCHY);

--- a/src/containers/pages/JurisdictionAssignment/EntryView/utils.tsx
+++ b/src/containers/pages/JurisdictionAssignment/EntryView/utils.tsx
@@ -121,6 +121,10 @@ export function useGetRootJurisdictionId(
   return rootJurisdictionId;
 }
 
+const defaultCallback = () => {
+  return;
+};
+
 /** get the jurisdiction Tree given the rootJurisdiction Id
  * @param rootJurisdictionId - id of top level jurisdiction
  * @param startLoading - helper to start loading
@@ -128,6 +132,7 @@ export function useGetRootJurisdictionId(
  * @param stopLoading - helper to stop loading
  * @param handleBrokenPage - helper to handle page errors
  * @param tree - the tree if it exists, used to know if we should set loading to true.
+ * @param onThen - a callback called with the response
  */
 export function useGetJurisdictionTree(
   rootJurisdictionId: string,
@@ -135,7 +140,8 @@ export function useGetJurisdictionTree(
   treeFetchedCreator: ActionCreator<FetchedTreeAction>,
   stopLoading: StopLoading,
   handleBrokenPage: HandleBrokenPage,
-  tree?: TreeNode
+  tree?: TreeNode,
+  onThen: (apiResponse: Result<RawOpenSRPHierarchy>) => void = defaultCallback
 ) {
   React.useEffect(() => {
     const params = {
@@ -148,6 +154,7 @@ export function useGetJurisdictionTree(
           if (apiResponse.value) {
             const responseData = apiResponse.value;
             treeFetchedCreator(responseData);
+            onThen(apiResponse);
           }
           if (apiResponse.error) {
             throw new Error(COULD_NOT_LOAD_JURISDICTION_HIERARCHY);

--- a/src/containers/pages/JurisdictionAssignment/ManualSelectJurisdiction/index.tsx
+++ b/src/containers/pages/JurisdictionAssignment/ManualSelectJurisdiction/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import reducerRegistry from '@onaio/redux-reducer-registry';
-import React from 'react';
+import React, { useEffect } from 'react';
 import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
@@ -125,16 +125,15 @@ export const JurisdictionAssignmentView = (props: JurisdictionAssignmentViewFull
     return existingAssignmentsIds.includes(node.model.id);
   };
 
-  /** useGetJurisdictionTree callback, called after the the hierarchy apiResponse has been received. */
-  const getTreeCallback = () => {
-    if (!plan) {
-      return;
-    }
-    const autoSelectCallback = autoSelectCallbackFactory(plan);
+  /** autoSelects existing plan jurisdiction assignments
+   * @param thePlan - plan to derive the existing assignments from.
+   */
+  const getTreeCallback = (thePlan: PlanDefinition) => {
+    const autoSelectCallback = autoSelectCallbackFactory(thePlan);
     autoSelectNodesCreator(
       rootId,
       autoSelectCallback,
-      plan.identifier,
+      thePlan.identifier,
       SELECTION_REASON.USER_CHANGE
     );
   };
@@ -145,9 +144,14 @@ export const JurisdictionAssignmentView = (props: JurisdictionAssignmentViewFull
     treeFetchedCreator,
     stopLoading,
     handleBrokenPage,
-    tree,
-    getTreeCallback
+    tree
   );
+
+  useEffect(() => {
+    if (plan && tree) {
+      getTreeCallback(plan);
+    }
+  }, [plan, tree]);
 
   if (loading()) {
     return <Ripple />;

--- a/src/containers/pages/JurisdictionAssignment/ManualSelectJurisdiction/tests/e2e.test.tsx
+++ b/src/containers/pages/JurisdictionAssignment/ManualSelectJurisdiction/tests/e2e.test.tsx
@@ -14,6 +14,7 @@ import hierarchiesReducer, {
 import { raZambiaHierarchy } from '../../../../../store/ducks/opensrp/hierarchies/tests/fixtures';
 import plansReducer, { reducerName } from '../../../../../store/ducks/opensrp/PlanDefinition';
 import { plans } from '../../../../../store/ducks/opensrp/PlanDefinition/tests/fixtures';
+import { e2eFetchCalls } from './fixtures';
 
 reducerRegistry.register(reducerName, plansReducer);
 reducerRegistry.register(hierarchiesReducerName, hierarchiesReducer);
@@ -37,6 +38,7 @@ it('plans with existing node selections', async () => {
   jest.setTimeout(10000);
   const envModule = require('../../../../../configs/env');
   envModule.ASSIGNMENT_PAGE_SHOW_MAP = true;
+  envModule.OPENSRP_API_BASE_URL = 'https://test.smartregister.org/opensrp/rest/';
 
   const App = () => {
     return (
@@ -186,4 +188,6 @@ it('plans with existing node selections', async () => {
       ).toBeFalsy();
     }
   });
+  // 2 fetch calls one for plan and another for hierarchy.
+  expect(fetch.mock.calls).toEqual(e2eFetchCalls);
 });

--- a/src/containers/pages/JurisdictionAssignment/ManualSelectJurisdiction/tests/fixtures.ts
+++ b/src/containers/pages/JurisdictionAssignment/ManualSelectJurisdiction/tests/fixtures.ts
@@ -63,3 +63,28 @@ export const fetchCalls = [
     },
   ],
 ];
+
+export const e2eFetchCalls = [
+  [
+    'https://test.smartregister.org/opensrp/rest/plans/356b6b84-fc36-4389-a44a-2b038ed2f38d',
+    {
+      headers: {
+        accept: 'application/json',
+        authorization: 'Bearer null',
+        'content-type': 'application/json;charset=UTF-8',
+      },
+      method: 'GET',
+    },
+  ],
+  [
+    'https://test.smartregister.org/opensrp/rest/location/hierarchy/0ddd9ad1-452b-4825-a92a-49cb9fc82d18?return_structure_count=true',
+    {
+      headers: {
+        accept: 'application/json',
+        authorization: 'Bearer null',
+        'content-type': 'application/json;charset=UTF-8',
+      },
+      method: 'GET',
+    },
+  ],
+];

--- a/src/helpers/useLoadingReducer.tsx
+++ b/src/helpers/useLoadingReducer.tsx
@@ -54,8 +54,7 @@ export const reducer = (state: State, action: ActionType) => {
  * however there are a few cases where the above might not work and hence a useCase for this hook
  * , for e.g. when promises are spread across hooks, or where they are nested.
  *
- * @param initialKey - uses this key to create the initial state
- * @param load - the value of initialKey; forms the initial state
+ * @param initialLoadingState - whether to start in loading state or not
  */
 export const useLoadingReducer = (initialLoadingState: boolean = true) => {
   const initialLoadingStateKey = 'initialState';


### PR DESCRIPTION
closes #1216 
Manual select Jurisdictions:
- getting tree hook is now dependent on changes to the rootId only, removed plan from dependency array
- selecting existing selections was thus moved to own useEffect that depends on both plan and tree.
