### PR TITLE
Set toDate to time of unassigning team

### DIFF
--- a/src/containers/pages/PlanAssignment/helpers/JurisdictionAssignmentForm/helpers.ts
+++ b/src/containers/pages/PlanAssignment/helpers/JurisdictionAssignmentForm/helpers.ts
@@ -50,7 +50,7 @@ export const getPayload = (
   }
 
   // turns out if you put it in the loop it keeps subtracting a day for every iteration
-  const retireDate = now.subtract(1, 'day').format();
+  const retireDate = now.format();
 
   for (const retiredOrgId of initialOrgs.filter(orgId => !selectedOrgs.includes(orgId))) {
     if (!payload.map(obj => obj.organization).includes(retiredOrgId)) {

--- a/src/containers/pages/PlanAssignment/helpers/JurisdictionAssignmentForm/tests/helpers.test.ts
+++ b/src/containers/pages/PlanAssignment/helpers/JurisdictionAssignmentForm/tests/helpers.test.ts
@@ -36,11 +36,11 @@ describe('PlanAssignment/helpers', () => {
       assignments[0],
       {
         ...assignments[1],
-        toDate: '2019-12-29T00:00:00+00:00',
+        toDate: '2019-12-30T00:00:00+00:00',
       },
       {
         ...assignments[2],
-        toDate: '2019-12-29T00:00:00+00:00',
+        toDate: '2019-12-30T00:00:00+00:00',
       },
     ]);
   });
@@ -61,11 +61,11 @@ describe('PlanAssignment/helpers', () => {
       assignment5,
       {
         ...assignments[1],
-        toDate: '2019-12-29T00:00:00+00:00',
+        toDate: '2019-12-30T00:00:00+00:00',
       },
       {
         ...assignments[2],
-        toDate: '2019-12-29T00:00:00+00:00',
+        toDate: '2019-12-30T00:00:00+00:00',
       },
     ]);
   });
@@ -84,11 +84,11 @@ describe('PlanAssignment/helpers', () => {
       assignments[0],
       {
         ...assignments[1],
-        toDate: '2019-12-29T00:00:00+00:00',
+        toDate: '2019-12-30T00:00:00+00:00',
       },
       {
         ...assignments[2],
-        toDate: '2019-12-29T00:00:00+00:00',
+        toDate: '2019-12-30T00:00:00+00:00',
       },
     ]);
   });


### PR DESCRIPTION
close #1174 

sets the `toDate` value to now(i.e.  at the time of unassigning).
previously this value was set to `now minus a day`. 