### PR TITLE
Update helper that removes plans with invalid jurisdiction_id values

### DIFF
--- a/src/containers/pages/FocusInvestigation/active/tests/fixtures.ts
+++ b/src/containers/pages/FocusInvestigation/active/tests/fixtures.ts
@@ -1,3 +1,4 @@
+// tslint:disable: object-literal-sort-keys
 /** Fixtures for tests */
 import { keyBy } from 'lodash';
 import * as fixtures from '../../../../../store/ducks/tests/fixtures';
@@ -250,3 +251,48 @@ export const selectedPlan1 = {
   village: 'Naviluli',
   ...fixtures.plan1,
 };
+
+export const nullJurisdictionIdsPlans = [
+  {
+    id: 'cab03044-9517-5857-b5fb-f95639c7595e',
+    plan_id: 'e835698d-fbad-4e2d-948c-5bb28763f821',
+    plan_title: 'A1 - เลตองคุ (6308041001) - เสาวภา คีรีการะเกด - 2020-09-02 - Site',
+    plan_name: 'A1-เลตองคุ (6308041001)-เสาวภา_คีรีการะเกด-2020-09-02-Site',
+    plan_status: 'active',
+    jurisdiction_id: null,
+    plan_fi_status: 'A1',
+    plan_fi_reason: 'Case Triggered',
+    plan_date: '2020-09-02',
+    plan_effective_period_start: '2020-09-02',
+    plan_effective_period_end: '2020-09-22',
+    plan_intervention_type: 'FI',
+    plan_version: 1,
+    jurisdiction_parent_id: null,
+    jurisdiction_name: null,
+    jurisdiction_geometry: null,
+    jurisdiction_depth: null,
+    jurisdiction_path: null,
+    jurisdiction_name_path: null,
+  },
+  {
+    id: 'febf9df3-d649-50f9-b035-45fe62279286',
+    plan_id: '9e382a18-cb6d-4f90-83bb-151527778571',
+    plan_title: 'A1 - นุซะโปล้ (6308040102) - หม่อโพแหน่ ชัยนทีนาวิน - 2020-09-02 - Site',
+    plan_name: 'A1-นุซะโปล้ (6308040102)-หม่อโพแหน่_ชัยนทีนาวิน-2020-09-02-Site',
+    plan_status: 'active',
+    jurisdiction_id: null,
+    plan_fi_status: 'A1',
+    plan_fi_reason: 'Case Triggered',
+    plan_date: '2020-09-02',
+    plan_effective_period_start: '2020-09-02',
+    plan_effective_period_end: '2020-09-22',
+    plan_intervention_type: 'FI',
+    plan_version: 1,
+    jurisdiction_parent_id: null,
+    jurisdiction_name: null,
+    jurisdiction_geometry: null,
+    jurisdiction_depth: null,
+    jurisdiction_path: null,
+    jurisdiction_name_path: null,
+  },
+];

--- a/src/helpers/utils.tsx
+++ b/src/helpers/utils.tsx
@@ -458,15 +458,15 @@ export function getColor(taskObject: InitialTask): Color {
   }
 }
 
-/** filters out plans whose jurisdiction id is null
+/** filters out plans whose jurisdiction id is null or has a value of 'null'
  * @param {Plan []} plansArray - a list of pre-filtered plans
  *
  * @return {Plan []} - A list of filtered plans
  */
 export const removeNullJurisdictionPlans = (plansArray: Plan[]): Plan[] => {
   return plansArray.filter((plan: Plan) => {
-    const jurisdictionID = plan.jurisdiction_id.toLowerCase().trim();
-    return !jurisdictionID.includes('null');
+    const jurisdictionId = plan.jurisdiction_id?.toLowerCase().trim();
+    return !!jurisdictionId && !jurisdictionId.includes('null');
   });
 };
 


### PR DESCRIPTION
the mentioned helper should now also:
- filter out plans whose jurisdiction_id value is falsy

close #1251