### PR TITLE
get Dynamic FI plans too in Focus investigation pages

### DIFF
--- a/src/components/forms/PlanForm/helpers.ts
+++ b/src/components/forms/PlanForm/helpers.ts
@@ -758,7 +758,6 @@ export function getGoalUnitFromActionCode(actionCode: PlanActionCodesType): Goal
   }
   return GoalUnit.UNKNOWN;
 }
-
 /**
  * Check if a plan type should be visible
  * @param {InterventionType} planType - plan type

--- a/src/containers/pages/FocusInvestigation/active/index.tsx
+++ b/src/containers/pages/FocusInvestigation/active/index.tsx
@@ -58,7 +58,10 @@ import {
   ROUTINE,
   ROUTINE_QUERY_PARAM,
 } from '../../../../constants';
-import { loadPlansByUserFilter } from '../../../../helpers/dataLoading/plans';
+import {
+  loadPlansByUserFilter,
+  supersetFIPlansParamFilters,
+} from '../../../../helpers/dataLoading/plans';
 import { displayError } from '../../../../helpers/errors';
 import { renderClassificationRow } from '../../../../helpers/indicators';
 import '../../../../helpers/tables.css';
@@ -146,9 +149,7 @@ class ActiveFocusInvestigation extends React.Component<
 
   public componentDidMount() {
     const { userName, fetchPlansActionCreator, supersetService } = this.props;
-    const supersetParams = superset.getFormData(2000, [
-      { comparator: InterventionType.FI, operator: '==', subject: 'plan_intervention_type' },
-    ]);
+    const supersetParams = superset.getFormData(2000, supersetFIPlansParamFilters);
     supersetService(SUPERSET_PLANS_SLICE, supersetParams)
       .then((result: Plan[]) => {
         if (result) {

--- a/src/containers/pages/FocusInvestigation/active/index.tsx
+++ b/src/containers/pages/FocusInvestigation/active/index.tsx
@@ -19,7 +19,7 @@ import HeaderBreadCrumb, {
   BreadCrumbProps,
 } from '../../../../components/page/HeaderBreadcrumb/HeaderBreadcrumb';
 import Loading from '../../../../components/page/Loading';
-import { SUPERSET_PLANS_SLICE } from '../../../../configs/env';
+import { SUPERSET_MAX_RECORDS, SUPERSET_PLANS_SLICE } from '../../../../configs/env';
 import {
   ADD_FOCUS_INVESTIGATION,
   CASE_CLASSIFICATION_HEADER,
@@ -149,7 +149,7 @@ class ActiveFocusInvestigation extends React.Component<
 
   public componentDidMount() {
     const { userName, fetchPlansActionCreator, supersetService } = this.props;
-    const supersetParams = superset.getFormData(2000, supersetFIPlansParamFilters);
+    const supersetParams = superset.getFormData(SUPERSET_MAX_RECORDS, supersetFIPlansParamFilters);
     supersetService(SUPERSET_PLANS_SLICE, supersetParams)
       .then((result: Plan[]) => {
         if (result) {

--- a/src/containers/pages/FocusInvestigation/active/tests/index.test.tsx
+++ b/src/containers/pages/FocusInvestigation/active/tests/index.test.tsx
@@ -265,16 +265,9 @@ describe('containers/pages/ActiveFocusInvestigation', () => {
       adhoc_filters: [
         {
           clause: 'WHERE',
-          comparator: 'FI',
+          comparator: [InterventionType.FI, InterventionType.DynamicFI],
           expressionType: 'SIMPLE',
-          operator: '==',
-          subject: 'plan_intervention_type',
-        },
-        {
-          clause: 'WHERE',
-          comparator: 'Dynamic-FI',
-          expressionType: 'SIMPLE',
-          operator: '==',
+          operator: 'in',
           subject: 'plan_intervention_type',
         },
       ],
@@ -287,13 +280,8 @@ describe('containers/pages/ActiveFocusInvestigation', () => {
         2000,
         [
           {
-            comparator: InterventionType.FI,
-            operator: '==',
-            subject: 'plan_intervention_type',
-          },
-          {
-            comparator: InterventionType.DynamicFI,
-            operator: '==',
+            comparator: [InterventionType.FI, InterventionType.DynamicFI],
+            operator: 'in',
             subject: 'plan_intervention_type',
           },
         ],

--- a/src/containers/pages/FocusInvestigation/active/tests/index.test.tsx
+++ b/src/containers/pages/FocusInvestigation/active/tests/index.test.tsx
@@ -272,12 +272,12 @@ describe('containers/pages/ActiveFocusInvestigation', () => {
         },
       ],
 
-      row_limit: 2000,
+      row_limit: 3000,
     };
 
     const supersetCallList = [
       [
-        2000,
+        3000,
         [
           {
             comparator: [InterventionType.FI, InterventionType.DynamicFI],

--- a/src/containers/pages/FocusInvestigation/jurisdiction/index.tsx
+++ b/src/containers/pages/FocusInvestigation/jurisdiction/index.tsx
@@ -13,7 +13,7 @@ import HeaderBreadcrumbs, {
 import Loading from '../../../../components/page/Loading';
 import NullDataTable from '../../../../components/Table/NullDataTable';
 import TableHeader from '../../../../components/Table/TableHeaders';
-import { SUPERSET_PLANS_SLICE } from '../../../../configs/env';
+import { SUPERSET_MAX_RECORDS, SUPERSET_PLANS_SLICE } from '../../../../configs/env';
 import {
   AN_ERROR_OCCURRED,
   CANTON,
@@ -135,7 +135,7 @@ export const FIJurisdiction = (props: FIJurisdictionProps & RouteComponentProps<
   }
 
   // this gets FI plans for the current jurisdiction
-  const supersetParams = superset.getFormData(2000, [
+  const supersetParams = superset.getFormData(SUPERSET_MAX_RECORDS, [
     { comparator: jurisdictionId, operator: '==', subject: 'jurisdiction_id' },
     ...supersetFIPlansParamFilters,
   ]);

--- a/src/containers/pages/FocusInvestigation/jurisdiction/index.tsx
+++ b/src/containers/pages/FocusInvestigation/jurisdiction/index.tsx
@@ -57,12 +57,12 @@ import {
   TablePropsType,
 } from '../../../../helpers/utils';
 
+import { supersetFIPlansParamFilters } from '../../../../helpers/dataLoading/plans';
 import supersetFetch from '../../../../services/superset';
 import { Jurisdiction } from '../../../../store/ducks/jurisdictions';
 import plansReducer, {
   fetchPlans,
   FetchPlansAction,
-  InterventionType,
   makePlansArraySelector,
   Plan,
   reducerName as plansReducerName,
@@ -137,7 +137,7 @@ export const FIJurisdiction = (props: FIJurisdictionProps & RouteComponentProps<
   // this gets FI plans for the current jurisdiction
   const supersetParams = superset.getFormData(2000, [
     { comparator: jurisdictionId, operator: '==', subject: 'jurisdiction_id' },
-    { comparator: InterventionType.FI, operator: '==', subject: 'plan_intervention_type' },
+    ...supersetFIPlansParamFilters,
   ]);
 
   const jurisdictionCallback = (val: Jurisdiction) => {

--- a/src/containers/pages/FocusInvestigation/map/active/index.tsx
+++ b/src/containers/pages/FocusInvestigation/map/active/index.tsx
@@ -16,7 +16,7 @@ import HeaderBreadcrumb, {
 } from '../../../../../components/page/HeaderBreadcrumb/HeaderBreadcrumb';
 import Loading from '../../../../../components/page/Loading';
 import SelectComponent from '../../../../../components/SelectPlan/';
-import { SUPERSET_PLANS_SLICE } from '../../../../../configs/env';
+import { SUPERSET_MAX_RECORDS, SUPERSET_PLANS_SLICE } from '../../../../../configs/env';
 import {
   AN_ERROR_OCCURRED,
   FOCUS_INVESTIGATION,
@@ -173,7 +173,10 @@ const SingleActiveFIMap = (props: MapSingleFIProps & RouteComponentProps<RoutePa
        * Fetch plans incase the plan is not available e.g when page is refreshed
        */
       const { supersetService, fetchPlansActionCreator } = props;
-      const supersetParams = superset.getFormData(2000, supersetFIPlansParamFilters);
+      const supersetParams = superset.getFormData(
+        SUPERSET_MAX_RECORDS,
+        supersetFIPlansParamFilters
+      );
 
       /** TODO:// huge data set fetching to tasks slice */
 

--- a/src/containers/pages/FocusInvestigation/map/active/index.tsx
+++ b/src/containers/pages/FocusInvestigation/map/active/index.tsx
@@ -46,7 +46,7 @@ import {
   POLYGON,
   RACD_REGISTER_FAMILY_ID,
 } from '../../../../../constants';
-import { PLAN_INTERVENTION_TYPE } from '../../../../../constants';
+import { supersetFIPlansParamFilters } from '../../../../../helpers/dataLoading/plans';
 import { displayError } from '../../../../../helpers/errors';
 import { getGoalReport } from '../../../../../helpers/indicators';
 import {
@@ -173,9 +173,7 @@ const SingleActiveFIMap = (props: MapSingleFIProps & RouteComponentProps<RoutePa
        * Fetch plans incase the plan is not available e.g when page is refreshed
        */
       const { supersetService, fetchPlansActionCreator } = props;
-      const supersetParams = superset.getFormData(2000, [
-        { comparator: InterventionType.FI, operator: '==', subject: PLAN_INTERVENTION_TYPE },
-      ]);
+      const supersetParams = superset.getFormData(2000, supersetFIPlansParamFilters);
 
       /** TODO:// huge data set fetching to tasks slice */
 

--- a/src/helpers/dataLoading/plans.ts
+++ b/src/helpers/dataLoading/plans.ts
@@ -98,10 +98,12 @@ export async function loadOpenSRPPlan(
 
 /** Added to superset requests to specify only FI and Dynamic-Fi plans are required. */
 export const supersetFIPlansParamFilters = [
-  ...(isPlanTypeEnabled(InterventionType.FI)
-    ? [{ comparator: InterventionType.FI, operator: '==', subject: PLAN_INTERVENTION_TYPE }]
-    : []),
-  ...(isPlanTypeEnabled(InterventionType.DynamicFI)
-    ? [{ comparator: InterventionType.DynamicFI, operator: '==', subject: PLAN_INTERVENTION_TYPE }]
-    : []),
+  {
+    comparator: [
+      ...(isPlanTypeEnabled(InterventionType.FI) ? [InterventionType.FI] : []),
+      ...(isPlanTypeEnabled(InterventionType.DynamicFI) ? [InterventionType.DynamicFI] : []),
+    ],
+    operator: 'in',
+    subject: PLAN_INTERVENTION_TYPE,
+  },
 ] as SupersetAdhocFilterOption[];

--- a/src/helpers/dataLoading/plans.ts
+++ b/src/helpers/dataLoading/plans.ts
@@ -1,11 +1,22 @@
+import { SupersetAdhocFilterOption } from '@onaio/superset-connector';
 import { ActionCreator, AnyAction } from 'redux';
+import { isPlanTypeEnabled } from '../../components/forms/PlanForm/helpers';
 import { USER_HAS_NO_PLAN_ASSIGNMENTS } from '../../configs/lang';
-import { OPENSRP_PLANS, OPENSRP_PLANS_BY_USER_FILTER } from '../../constants';
+import {
+  OPENSRP_PLANS,
+  OPENSRP_PLANS_BY_USER_FILTER,
+  PLAN_INTERVENTION_TYPE,
+} from '../../constants';
 import { OpenSRPService } from '../../services/opensrp';
 import store from '../../store';
 import { AddPlanDefinitionAction } from '../../store/ducks/opensrp/PlanDefinition';
 import { fetchPlansByUser, FetchPlansByUserAction } from '../../store/ducks/opensrp/planIdsByUser';
-import { FetchPlanRecordsAction, PlanPayload, PlanRecordResponse } from '../../store/ducks/plans';
+import {
+  FetchPlanRecordsAction,
+  InterventionType,
+  PlanPayload,
+  PlanRecordResponse,
+} from '../../store/ducks/plans';
 import { displayError } from '../errors';
 import { extractPlanRecordResponseFromPlanPayload } from '../utils';
 
@@ -84,3 +95,13 @@ export async function loadOpenSRPPlan(
       displayError(err);
     });
 }
+
+/** Added to superset requests to specify only FI and Dynamic-Fi plans are required. */
+export const supersetFIPlansParamFilters = [
+  ...(isPlanTypeEnabled(InterventionType.FI)
+    ? [{ comparator: InterventionType.FI, operator: '==', subject: PLAN_INTERVENTION_TYPE }]
+    : []),
+  ...(isPlanTypeEnabled(InterventionType.DynamicFI)
+    ? [{ comparator: InterventionType.DynamicFI, operator: '==', subject: PLAN_INTERVENTION_TYPE }]
+    : []),
+] as SupersetAdhocFilterOption[];


### PR DESCRIPTION
close #1276 close #1272 
adds a filter to get `Dynamic-FI` plans too in the reportin> activeFI pages