### PR TITLE
PlanLocation names as Hyperlinks to reporting pages when updating Dynamic-FI plans

### DIFF
--- a/src/containers/pages/InterventionPlan/NewPlan/General/index.tsx
+++ b/src/containers/pages/InterventionPlan/NewPlan/General/index.tsx
@@ -6,7 +6,10 @@ import PlanForm, {
   defaultInitialValues,
   PlanFormProps,
 } from '../../../../../components/forms/PlanForm';
-import { planActivitiesMap } from '../../../../../components/forms/PlanForm/helpers';
+import {
+  isFIOrDynamicFI,
+  planActivitiesMap,
+} from '../../../../../components/forms/PlanForm/helpers';
 import HeaderBreadcrumb, {
   Page,
 } from '../../../../../components/page/HeaderBreadcrumb/HeaderBreadcrumb';
@@ -126,7 +129,7 @@ const BaseNewPlan = (props: BaseNewPlanProps) => {
         </Col>
         {props.showJurisdictionDetails && (
           <Col md={4}>
-            {formValues.interventionType === InterventionType.FI &&
+            {isFIOrDynamicFI(formValues.interventionType) &&
               formValues.jurisdictions[0].id !== '' && (
                 <JurisdictionDetails planFormJurisdiction={formValues.jurisdictions[0]} />
               )}

--- a/src/containers/pages/InterventionPlan/NewPlan/General/tests/index.test.tsx
+++ b/src/containers/pages/InterventionPlan/NewPlan/General/tests/index.test.tsx
@@ -96,6 +96,13 @@ describe('containers/pages/NewPlan', () => {
     wrapper.update();
     expect(wrapper.find('JurisdictionDetails').length).toEqual(0);
 
+    // change to Dynamic-FI
+    wrapper
+      .find('select[name="interventionType"]')
+      .simulate('change', { target: { name: 'interventionType', value: 'Dynamic-FI' } });
+    wrapper.update();
+    expect(wrapper.find('JurisdictionDetails').length).toEqual(0);
+
     wrapper.unmount();
   });
 

--- a/src/containers/pages/InterventionPlan/NewPlan/General/tests/index.test.tsx
+++ b/src/containers/pages/InterventionPlan/NewPlan/General/tests/index.test.tsx
@@ -101,7 +101,17 @@ describe('containers/pages/NewPlan', () => {
       .find('select[name="interventionType"]')
       .simulate('change', { target: { name: 'interventionType', value: 'Dynamic-FI' } });
     wrapper.update();
-    expect(wrapper.find('JurisdictionDetails').length).toEqual(0);
+
+    (wrapper
+      .find('FieldInner')
+      .first()
+      .props() as any).formik.setFieldValue('jurisdictions[0].id', '1337');
+    // set jurisdiction name
+    wrapper
+      .find('input[name="jurisdictions[0].name"]')
+      .simulate('change', { target: { name: 'jurisdictions[0].name', value: 'Onyx' } });
+
+    expect(wrapper.find('JurisdictionDetails').length).toEqual(1);
 
     wrapper.unmount();
   });

--- a/src/containers/pages/InterventionPlan/UpdatePlan/PlanLocationNames/index.tsx
+++ b/src/containers/pages/InterventionPlan/UpdatePlan/PlanLocationNames/index.tsx
@@ -62,7 +62,7 @@ const PlanLocationNames = (props: Props) => {
       {props.locations.map((location, index) => {
         return (
           <li key={index}>
-            {isPlanDefinitionOfType(plan, InterventionType.FI) ? (
+            {isPlanDefinitionOfType(plan, [InterventionType.FI, InterventionType.DynamicFI]) ? (
               <Link to={`${FI_SINGLE_URL}/${location.identifier}`}>{location.name}</Link>
             ) : (
               <span>{location.name}</span>

--- a/src/containers/pages/InterventionPlan/UpdatePlan/PlanLocationNames/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/pages/InterventionPlan/UpdatePlan/PlanLocationNames/tests/__snapshots__/index.test.tsx.snap
@@ -45,6 +45,75 @@ Array [
 ]
 `;
 
+exports[`src/components/locationIdToNames renders jurisdiction names as links for Dynamic-FI 1`] = `
+<li
+  key="0"
+>
+  <Link
+    to="/focus-investigation/view/f45b9380-c970-4dd1-8533-9e95ab12f128"
+  >
+    <LinkAnchor
+      href="/focus-investigation/view/f45b9380-c970-4dd1-8533-9e95ab12f128"
+      navigate={[Function]}
+    >
+      <a
+        href="/focus-investigation/view/f45b9380-c970-4dd1-8533-9e95ab12f128"
+        onClick={[Function]}
+      >
+        Namibia
+      </a>
+    </LinkAnchor>
+  </Link>
+  <h2
+    className="mock-child"
+  >
+    Mock child render function
+  </h2>
+</li>
+`;
+
+exports[`src/components/locationIdToNames renders jurisdiction names as links for Dynamic-FI 2`] = `
+<li
+  key="1"
+>
+  <Link
+    to="/focus-investigation/view/3951"
+  >
+    <LinkAnchor
+      href="/focus-investigation/view/3951"
+      navigate={[Function]}
+    >
+      <a
+        href="/focus-investigation/view/3951"
+        onClick={[Function]}
+      >
+        Akros_1
+      </a>
+    </LinkAnchor>
+  </Link>
+  <h2
+    className="mock-child"
+  >
+    Mock child render function
+  </h2>
+</li>
+`;
+
+exports[`src/components/locationIdToNames renders jurisdiction names as links for Dynamic-FI 3`] = `
+Array [
+  <h2
+    className="mock-child"
+  >
+    Mock child render function
+  </h2>,
+  <h2
+    className="mock-child"
+  >
+    Mock child render function
+  </h2>,
+]
+`;
+
 exports[`src/components/locationIdToNames renders jurisdiction names as links for FI 1`] = `
 <li
   key="0"

--- a/src/containers/pages/InterventionPlan/UpdatePlan/PlanLocationNames/tests/index.test.tsx
+++ b/src/containers/pages/InterventionPlan/UpdatePlan/PlanLocationNames/tests/index.test.tsx
@@ -3,6 +3,7 @@ import { mount, shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import flushPromises from 'flush-promises';
 import { createBrowserHistory } from 'history';
+import { cloneDeep } from 'lodash';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
@@ -103,6 +104,33 @@ describe('src/components/locationIdToNames', () => {
       child: () => <h2 className="mock-child">Mock child render function</h2>,
       locations: sampleLocations,
       plan: plans[0],
+    };
+
+    const wrapper = mount(
+      <Router history={history}>
+        <PlanLocationNames {...props} />
+      </Router>
+    );
+    await flushPromises();
+    wrapper.update();
+
+    // should have at exactly 2 li with children links.
+    expect(wrapper.find('li').length).toEqual(2);
+    expect(toJson(wrapper.find('li').at(0))).toMatchSnapshot();
+    expect(toJson(wrapper.find('li').at(1))).toMatchSnapshot();
+
+    // invokes render prop child
+    expect(toJson(wrapper.find('h2.mock-child'))).toMatchSnapshot();
+  });
+
+  it('renders jurisdiction names as links for Dynamic-FI', async () => {
+    fetch.once(JSON.stringify([]));
+    const plan = cloneDeep(plans[0]);
+    plan.useContext = [{ code: 'interventionType', valueCodableConcept: 'Dynamic-FI' }];
+    const props = {
+      child: () => <h2 className="mock-child">Mock child render function</h2>,
+      locations: sampleLocations,
+      plan,
     };
 
     const wrapper = mount(


### PR DESCRIPTION
close #1280 


Show JurisdictionDetails for Dynamic-FI plans
Show planLocation name entries as links in update plan 