### PR TITLE
Indicate plans displayed are for the applied user filter only

### DIFF
--- a/src/components/DropDownRenderer/index.css
+++ b/src/components/DropDownRenderer/index.css
@@ -7,3 +7,8 @@
   font-size: 16px !important;
   margin: 5px;
 }
+
+.btn-outline-secondary-active {
+  color: #28a745 !important;
+  border-color: #28a745 !important;
+}

--- a/src/components/DropDownRenderer/index.tsx
+++ b/src/components/DropDownRenderer/index.tsx
@@ -4,12 +4,14 @@ import './index.css';
 
 /** DropDownRenderer props */
 export interface DropDownRendererProps {
+  filterActive?: boolean;
   renderMenu: () => React.ReactNode;
   renderToggle: () => React.ReactNode;
 }
 
 /** default props */
 export const defaultDropDownRenderProps = {
+  filterActive: false,
   renderMenu: () => null,
   renderToggle: () => null,
 };
@@ -18,6 +20,7 @@ export const defaultDropDownRenderProps = {
 export const DropDownRenderer = (props: DropDownRendererProps = defaultDropDownRenderProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
   const toggle = () => setIsOpen(!isOpen);
+  const activeClass = props.filterActive ? ' btn-outline-secondary-active' : '';
   return (
     <Dropdown
       size="sm"
@@ -26,7 +29,7 @@ export const DropDownRenderer = (props: DropDownRendererProps = defaultDropDownR
       isOpen={isOpen}
       toggle={toggle}
     >
-      <DropdownToggle outline={true} className="filter-bar-btns">
+      <DropdownToggle outline={true} className={`filter-bar-btns${activeClass}`}>
         {props.renderToggle()}
       </DropdownToggle>
       {props.renderMenu()}

--- a/src/components/DropDownRenderer/tests/dropdownrender.test.tsx
+++ b/src/components/DropDownRenderer/tests/dropdownrender.test.tsx
@@ -17,5 +17,12 @@ describe('src/forms/filterForms/helpers', () => {
     wrapper.find('button.filter-bar-btns').simulate('click');
     wrapper.update();
     expect(toJson(wrapper)).toMatchSnapshot();
+    expect(wrapper.find('.btn-outline-secondary-active').length).toBeFalsy();
+  });
+
+  it('applies active class', () => {
+    props.filterActive = true;
+    const wrapper = mount(<DropDownRenderer {...props} />);
+    expect(wrapper.find('.btn-outline-secondary-active').length).toBeTruthy();
   });
 });

--- a/src/components/forms/ColumnHider/index.tsx
+++ b/src/components/forms/ColumnHider/index.tsx
@@ -13,9 +13,11 @@ export const ColumnHider = <T extends object>({ allColumns }: DrillDownInstanceP
    * per page.
    */
   const salt = uuid();
+  const anyColumnHidden = allColumns.some(column => !column.isVisible);
   return (
     <>
       <DropDownRenderer
+        filterActive={anyColumnHidden}
         // tslint:disable-next-line: jsx-no-lambda
         renderToggle={() => (
           <>

--- a/src/components/forms/RowHeightPicker/index.tsx
+++ b/src/components/forms/RowHeightPicker/index.tsx
@@ -42,6 +42,7 @@ const RowHeightFilter = (props: Props) => {
   };
   return (
     <DropDownRenderer
+      filterActive={!!rowHeight.trim()}
       renderToggle={rowHeightRenderToggle}
       // tslint:disable-next-line: jsx-no-lambda
       renderMenu={() => (

--- a/src/components/forms/UserFilter/index.tsx
+++ b/src/components/forms/UserFilter/index.tsx
@@ -85,8 +85,11 @@ export const BaseUserSelectFilter = (props: BaseUserSelectFilterPropTypes) => {
     userNameAsValue: true,
   };
 
+  const filterActive = defaultUserNameValue !== SELECT_USERNAME && !!defaultUserNameValue.trim();
+
   return (
     <DropDownRenderer
+      filterActive={filterActive}
       // tslint:disable-next-line:jsx-no-lambda
       renderToggle={() => (
         <>

--- a/src/configs/lang.ts
+++ b/src/configs/lang.ts
@@ -828,3 +828,8 @@ export const COVERAGE_LABEL = translate('COVERAGE_LABEL', 'Coverage');
 export const TARGET_LABEL = translate('TARGET_LABEL', 'Target');
 export const POPULATION_LABEL = translate('POPULATION_LABEL', 'Population');
 export const RISK_TEXT = translate('RISK_TEXT', 'Risk');
+
+export const PLANS_USER_FILTER_NOTIFICATION = translate(
+  'PLANS_USER_FILTER_NOTIFICATION',
+  'User filter on: Only plans assigned to %s are listed.'
+);

--- a/src/configs/strings/en.json
+++ b/src/configs/strings/en.json
@@ -1600,5 +1600,9 @@
     "message": "There are no descendant jurisdictions that are targeted.",
     "description": "Info message shown when there are no selected jurisdiction records found"
   },
-  "TOTAL": { "message": "Total", "description": "Total" }
+  "TOTAL": { "message": "Total", "description": "Total" },
+  "USER_FILTER_NOTIFICATION": {
+    "message": "User filter on: Only plans assigned to %s are listed.",
+    "description": "Info message to indicate plans are filtered by a specific user"
+  }
 }

--- a/src/containers/pages/FocusInvestigation/active/index.tsx
+++ b/src/containers/pages/FocusInvestigation/active/index.tsx
@@ -35,6 +35,7 @@ import {
   LOADING,
   NAME,
   NO_INVESTIGATIONS_FOUND,
+  PLANS_USER_FILTER_NOTIFICATION,
   REACTIVE,
   ROUTINE_TITLE,
   START_DATE,
@@ -196,6 +197,7 @@ class ActiveFocusInvestigation extends React.Component<
   }
 
   public render() {
+    const { userName } = this.props;
     const breadcrumbProps: BreadCrumbProps = {
       currentPage: {
         label: `${FOCUS_INVESTIGATIONS}`,
@@ -340,6 +342,9 @@ class ActiveFocusInvestigation extends React.Component<
         <h2 className="mb-3 mt-5 page-title">{pageTitle}</h2>
         <hr />
         <h3 className="mb-3 mt-5 page-title">{REACTIVE}</h3>
+        {userName && (
+          <p className="user-filter-info">{format(PLANS_USER_FILTER_NOTIFICATION, userName)}</p>
+        )}
         <div>
           <DrillDownTable
             {...createTableProps(

--- a/src/containers/pages/FocusInvestigation/active/tests/index.test.tsx
+++ b/src/containers/pages/FocusInvestigation/active/tests/index.test.tsx
@@ -485,6 +485,9 @@ describe('containers/pages/ActiveFocusInvestigation', () => {
     await new Promise(resolve => setImmediate(resolve));
     wrapper.update();
 
+    expect(wrapper.find('.user-filter-info').text()).toMatchInlineSnapshot(
+      `"User filter on: Only plans assigned to ghost are listed."`
+    );
     expect(
       wrapper
         .find('Table')

--- a/src/containers/pages/InterventionPlan/PlanDefinitionList/index.tsx
+++ b/src/containers/pages/InterventionPlan/PlanDefinitionList/index.tsx
@@ -3,8 +3,8 @@ import { RouteComponentProps } from 'react-router';
 import { BreadCrumbProps } from '../../../../components/page/HeaderBreadcrumb/HeaderBreadcrumb';
 import { HIDDEN_PLAN_STATUSES } from '../../../../configs/env';
 import { ADD_PLAN, HOME, PLANS } from '../../../../configs/lang';
-import { HOME_URL, NEW_PLAN_URL, PLAN_LIST_URL } from '../../../../constants';
-import { getPlanStatusToDisplay } from '../../../../helpers/utils';
+import { HOME_URL, NEW_PLAN_URL, PLAN_LIST_URL, QUERY_PARAM_USER } from '../../../../constants';
+import { getPlanStatusToDisplay, getQueryParams } from '../../../../helpers/utils';
 import {
   createConnectedOpenSRPPlansList,
   OpenSRPPlanListViewProps,
@@ -31,12 +31,15 @@ export const PlanDefinitionList = (props: RouteComponentProps) => {
   };
 
   const planStatuses = getPlanStatusToDisplay(HIDDEN_PLAN_STATUSES);
+  const allQueryParams = getQueryParams(props.location);
+  const userParam = allQueryParams[QUERY_PARAM_USER] as string;
 
   const renderBody = draftPlansPageBodyFactory({
     addPlanBtnText: ADD_PLAN,
     breadCrumbProps,
     newPlanUrl: NEW_PLAN_URL,
     pageTitle,
+    userParam,
   });
 
   const opensrpListProps: Partial<OpenSRPPlanListViewProps> & RouteComponentProps = {

--- a/src/containers/pages/InterventionPlan/PlanningView/helpers/tests/utils.test.tsx
+++ b/src/containers/pages/InterventionPlan/PlanningView/helpers/tests/utils.test.tsx
@@ -1,0 +1,57 @@
+import { mount } from 'enzyme';
+import { createBrowserHistory } from 'history';
+import React from 'react';
+import { Router } from 'react-router';
+import { format } from 'util';
+import { BreadCrumbProps } from '../../../../../../components/page/HeaderBreadcrumb/HeaderBreadcrumb';
+import { HOME, PLANS, PLANS_USER_FILTER_NOTIFICATION } from '../../../../../../configs/lang';
+import { HOME_URL, PLAN_LIST_URL } from '../../../../../../constants';
+import { draftPlansPageBodyFactory } from '../utils';
+
+const history = createBrowserHistory();
+const homePage = {
+  label: HOME,
+  url: HOME_URL,
+};
+const breadCrumbProps: BreadCrumbProps = {
+  currentPage: {
+    label: PLANS,
+    url: PLAN_LIST_URL,
+  },
+  pages: [homePage],
+};
+
+describe('planning view utils', () => {
+  it('draftPlansPageBodyFactory: works correctly without user param', () => {
+    const renderBody = draftPlansPageBodyFactory({
+      breadCrumbProps,
+      newPlanUrl: PLAN_LIST_URL,
+      pageTitle: PLANS,
+    });
+    const element = () => <div className="test-class" />;
+    const wrapper = mount(<Router history={history}>{renderBody(element)}</Router>);
+
+    expect(wrapper.find('.page-title').text()).toEqual(PLANS);
+    expect(wrapper.find('.create-plan a').text()).toEqual('Create New Plan');
+    expect(wrapper.find('Col p').length).toBeFalsy();
+    expect(wrapper.find('.test-class').length).toEqual(1);
+  });
+
+  it('draftPlansPageBodyFactory: works correctly with user param', () => {
+    const userParam = 'TestsUser';
+    const renderBody = draftPlansPageBodyFactory({
+      breadCrumbProps,
+      newPlanUrl: PLAN_LIST_URL,
+      pageTitle: PLANS,
+      userParam,
+    });
+    const element = () => <div className="test-class" />;
+    const wrapper = mount(<Router history={history}>{renderBody(element)}</Router>);
+
+    expect(wrapper.find('.page-title').text()).toEqual(PLANS);
+    expect(wrapper.find('.create-plan a').text()).toEqual('Create New Plan');
+    expect(wrapper.find('Col p').length).toBeTruthy();
+    expect(wrapper.find('Col p').text()).toEqual(format(PLANS_USER_FILTER_NOTIFICATION, userParam));
+    expect(wrapper.find('.test-class').length).toEqual(1);
+  });
+});

--- a/src/containers/pages/InterventionPlan/PlanningView/helpers/utils.tsx
+++ b/src/containers/pages/InterventionPlan/PlanningView/helpers/utils.tsx
@@ -5,11 +5,18 @@ import { Link } from 'react-router-dom';
 import { Cell } from 'react-table';
 import Col from 'reactstrap/lib/Col';
 import Row from 'reactstrap/lib/Row';
+import { format } from 'util';
 import LinkAsButton from '../../../../../components/LinkAsButton';
 import HeaderBreadcrumbs, {
   BreadCrumbProps,
 } from '../../../../../components/page/HeaderBreadcrumb/HeaderBreadcrumb';
-import { CREATE_NEW_PLAN, DATE_CREATED, NAME, STATUS_HEADER } from '../../../../../configs/lang';
+import {
+  CREATE_NEW_PLAN,
+  DATE_CREATED,
+  NAME,
+  PLANS_USER_FILTER_NOTIFICATION,
+  STATUS_HEADER,
+} from '../../../../../configs/lang';
 import { planStatusDisplay } from '../../../../../configs/settings';
 import { ASSIGN_JURISDICTIONS_URL } from '../../../../../constants';
 import { PlanRecord } from '../../../../../store/ducks/plans';
@@ -56,12 +63,13 @@ interface Options {
   pageTitle: string;
   breadCrumbProps: BreadCrumbProps;
   newPlanUrl: string;
+  userParam?: string;
 }
 /** creates a render prop that receives a render function for the plans list table and
  * renders the whole view.
  */
 export const draftPlansPageBodyFactory = (options: Options) => {
-  const { pageTitle, breadCrumbProps, newPlanUrl, addPlanBtnText } = options;
+  const { pageTitle, breadCrumbProps, newPlanUrl, addPlanBtnText, userParam } = options;
   return (renderConnectedTable: RenderProp) => {
     return (
       <div className="mb-5">
@@ -72,6 +80,7 @@ export const draftPlansPageBodyFactory = (options: Options) => {
         <Row>
           <Col md={8}>
             <h3 className="mt-3 mb-3 page-title">{pageTitle}</h3>
+            {userParam && <p>{format(PLANS_USER_FILTER_NOTIFICATION, userParam)}</p>}
           </Col>
           {newPlanUrl && (
             <Col md={4}>


### PR DESCRIPTION
Part of https://github.com/OpenSRP/opensrp-client-reveal/issues/1024

Adds a text when the user filter is applied specifying the plans listed are ones assigned to the named user only. 