### PR TITLE
fix bug Invalid plans due to modifying fiReason

### DIFF
--- a/src/components/forms/PlanForm/helpers.ts
+++ b/src/components/forms/PlanForm/helpers.ts
@@ -122,7 +122,9 @@ export const PlanSchema = Yup.object().shape({
   caseNum: Yup.string(),
   date: Yup.string().required(DATE_IS_REQUIRED),
   end: Yup.date().required(REQUIRED),
-  fiReason: Yup.string().oneOf(FIReasons.map(e => e)),
+  fiReason: Yup.string()
+    .oneOf(FIReasons.map(e => e))
+    .required(REQUIRED),
   fiStatus: Yup.string().oneOf(fiStatusCodes),
   identifier: Yup.string(),
   interventionType: Yup.string()

--- a/src/components/forms/PlanForm/helpers.ts
+++ b/src/components/forms/PlanForm/helpers.ts
@@ -95,6 +95,13 @@ export const showDefinitionUriFor = [
   InterventionType.DynamicMDA,
 ];
 
+/**
+ * Check if intervention type id FI or Dynamic FI
+ * @param {InterventionType} interventionType - intervention type
+ */
+export const isFIOrDynamicFI = (interventionType: InterventionType): boolean =>
+  [InterventionType.DynamicFI, InterventionType.FI].includes(interventionType);
+
 /** Yup validation schema for PlanForm */
 export const PlanSchema = Yup.object().shape({
   activities: Yup.array().of(
@@ -122,9 +129,13 @@ export const PlanSchema = Yup.object().shape({
   caseNum: Yup.string(),
   date: Yup.string().required(DATE_IS_REQUIRED),
   end: Yup.date().required(REQUIRED),
-  fiReason: Yup.string()
-    .oneOf(FIReasons.map(e => e))
-    .required(REQUIRED),
+  fiReason: Yup.string().when('interventionType', {
+    is: value => isFIOrDynamicFI(value),
+    otherwise: Yup.string(),
+    then: Yup.string()
+      .oneOf(FIReasons.map(e => e))
+      .required(REQUIRED),
+  }),
   fiStatus: Yup.string().oneOf(fiStatusCodes),
   identifier: Yup.string(),
   interventionType: Yup.string()
@@ -787,10 +798,3 @@ export const onSubmitSuccess = (
   setSubmitting(false);
   setAreWeDoneHere(true);
 };
-
-/**
- * Check if intervention type id FI or Dynamic FI
- * @param {InterventionType} interventionType - intervention type
- */
-export const isFIOrDynamicFI = (interventionType: InterventionType): boolean =>
-  [InterventionType.DynamicFI, InterventionType.FI].includes(interventionType);

--- a/src/components/forms/PlanForm/index.tsx
+++ b/src/components/forms/PlanForm/index.tsx
@@ -200,7 +200,7 @@ const PlanForm = (props: PlanFormProps) => {
   const editMode: boolean = initialValues.identifier !== '';
 
   let filteredFIReasons: FIReasonType[] = [...FIReasons];
-  if (ENABLED_FI_REASONS.length) {
+  if (ENABLED_FI_REASONS.length && !editMode) {
     filteredFIReasons = FIReasons.filter((reason: FIReasonType) =>
       ENABLED_FI_REASONS.includes(reason)
     );
@@ -536,33 +536,21 @@ const PlanForm = (props: PlanFormProps) => {
             {isFIOrDynamicFI(values.interventionType) && (
               <FormGroup>
                 <Label for="fiReason">{FOCUS_INVESTIGATION_STATUS_REASON}</Label>
-                {editMode ? (
-                  <Field
-                    required={isFIOrDynamicFI(values.interventionType)}
-                    type="input"
-                    readOnly={true}
-                    name="fiReason"
-                    id="fiReason"
-                    disabled={disabledFields.includes('fiReason')}
-                    className={errors.fiReason ? 'form-control is-invalid' : 'form-control'}
-                  />
-                ) : (
-                  <Field
-                    required={isFIOrDynamicFI(values.interventionType)}
-                    component="select"
-                    name="fiReason"
-                    id="fiReason"
-                    disabled={disabledFields.includes('fiReason')}
-                    className={errors.fiReason ? 'form-control is-invalid' : 'form-control'}
-                  >
-                    <option>----</option>
-                    {filteredFIReasons.map(e => (
-                      <option key={e} value={e}>
-                        {FIReasonsDisplay[e]}
-                      </option>
-                    ))}
-                  </Field>
-                )}
+                <Field
+                  required={isFIOrDynamicFI(values.interventionType)}
+                  component="select"
+                  name="fiReason"
+                  id="fiReason"
+                  disabled={disabledFields.includes('fiReason')}
+                  className={errors.fiReason ? 'form-control is-invalid' : 'form-control'}
+                >
+                  <option>----</option>
+                  {filteredFIReasons.map(e => (
+                    <option key={e} value={e}>
+                      {FIReasonsDisplay[e]}
+                    </option>
+                  ))}
+                </Field>
                 <ErrorMessage
                   name="fiReason"
                   component="small"

--- a/src/components/forms/PlanForm/index.tsx
+++ b/src/components/forms/PlanForm/index.tsx
@@ -200,7 +200,7 @@ const PlanForm = (props: PlanFormProps) => {
   const editMode: boolean = initialValues.identifier !== '';
 
   let filteredFIReasons: FIReasonType[] = [...FIReasons];
-  if (ENABLED_FI_REASONS.length) {
+  if (ENABLED_FI_REASONS.length && !editMode) {
     filteredFIReasons = FIReasons.filter((reason: FIReasonType) =>
       ENABLED_FI_REASONS.includes(reason)
     );

--- a/src/components/forms/PlanForm/index.tsx
+++ b/src/components/forms/PlanForm/index.tsx
@@ -200,7 +200,7 @@ const PlanForm = (props: PlanFormProps) => {
   const editMode: boolean = initialValues.identifier !== '';
 
   let filteredFIReasons: FIReasonType[] = [...FIReasons];
-  if (ENABLED_FI_REASONS.length && !editMode) {
+  if (ENABLED_FI_REASONS.length) {
     filteredFIReasons = FIReasons.filter((reason: FIReasonType) =>
       ENABLED_FI_REASONS.includes(reason)
     );
@@ -536,21 +536,33 @@ const PlanForm = (props: PlanFormProps) => {
             {isFIOrDynamicFI(values.interventionType) && (
               <FormGroup>
                 <Label for="fiReason">{FOCUS_INVESTIGATION_STATUS_REASON}</Label>
-                <Field
-                  required={isFIOrDynamicFI(values.interventionType)}
-                  component="select"
-                  name="fiReason"
-                  id="fiReason"
-                  disabled={disabledFields.includes('fiReason')}
-                  className={errors.fiReason ? 'form-control is-invalid' : 'form-control'}
-                >
-                  <option>----</option>
-                  {filteredFIReasons.map(e => (
-                    <option key={e} value={e}>
-                      {FIReasonsDisplay[e]}
-                    </option>
-                  ))}
-                </Field>
+                {editMode ? (
+                  <Field
+                    required={isFIOrDynamicFI(values.interventionType)}
+                    type="input"
+                    readOnly={true}
+                    name="fiReason"
+                    id="fiReason"
+                    disabled={disabledFields.includes('fiReason')}
+                    className={errors.fiReason ? 'form-control is-invalid' : 'form-control'}
+                  />
+                ) : (
+                  <Field
+                    required={isFIOrDynamicFI(values.interventionType)}
+                    component="select"
+                    name="fiReason"
+                    id="fiReason"
+                    disabled={disabledFields.includes('fiReason')}
+                    className={errors.fiReason ? 'form-control is-invalid' : 'form-control'}
+                  >
+                    <option>----</option>
+                    {filteredFIReasons.map(e => (
+                      <option key={e} value={e}>
+                        {FIReasonsDisplay[e]}
+                      </option>
+                    ))}
+                  </Field>
+                )}
                 <ErrorMessage
                   name="fiReason"
                   component="small"

--- a/src/components/forms/PlanForm/index.tsx
+++ b/src/components/forms/PlanForm/index.tsx
@@ -124,7 +124,7 @@ export const defaultInitialValues: PlanFormFields = {
   end: moment()
     .add(DEFAULT_PLAN_DURATION_DAYS, 'days')
     .toDate(),
-  fiReason: undefined,
+  fiReason: FIReasons[0],
   fiStatus: undefined,
   identifier: '',
   interventionType: defaultInterventionType,

--- a/src/components/forms/PlanForm/tests/__snapshots__/index.test.tsx.snap
+++ b/src/components/forms/PlanForm/tests/__snapshots__/index.test.tsx.snap
@@ -4155,6 +4155,7 @@ exports[`containers/forms/PlanForm renders correctly: fiReason field 1`] = `
   onBlur={[Function]}
   onChange={[Function]}
   required={true}
+  value="Routine"
 >
   <option>
     ----

--- a/src/components/forms/PlanForm/tests/__snapshots__/index.thailand.test.tsx.snap
+++ b/src/components/forms/PlanForm/tests/__snapshots__/index.thailand.test.tsx.snap
@@ -60,6 +60,7 @@ exports[`Thailand: containers/forms/PlanForm renders correctly: fiReason field 1
   onBlur={[Function]}
   onChange={[Function]}
   required={true}
+  value="Routine"
 >
   <option>
     ----

--- a/src/components/forms/PlanForm/tests/fixtures.ts
+++ b/src/components/forms/PlanForm/tests/fixtures.ts
@@ -968,3 +968,199 @@ export const jurisdictionParen1JSON =
 
 export const jurisdictionFocusAreasJSON =
   '[{"type":"Feature","id":"1337","properties":{"status":"Active","parentId":"3019","name":"REVEAL TEST","geographicLevel":2,"version":0},"serverVersion":1548770400099},{"type":"Feature","id":"3951","properties":{"status":"Active","parentId":"3019","name":"Akros_1","geographicLevel":2,"version":0},"serverVersion":1545204913829},{"type":"Feature","id":"3952","properties":{"status":"Active","parentId":"3019","name":"Akros_2","geographicLevel":2,"version":0},"serverVersion":1545204913830}]';
+
+export const fiReasonTestPlan = {
+  action: [
+    {
+      code: 'Case Confirmation',
+      description: 'Confirm the index case',
+      goalId: 'Case_Confirmation',
+      identifier: '38cd9c29-b583-5405-80af-a362a219b353',
+      prefix: 1,
+      reason: 'Investigation',
+      subjectCodableConcept: { text: 'Jurisdiction' },
+      taskTemplate: 'Case_Confirmation',
+      timingPeriod: { end: '2020-09-24', start: '2020-09-17' },
+      title: 'Case Confirmation',
+    },
+    {
+      code: 'RACD Register Family',
+      description:
+        'Register all families & family members in all residential structures enumerated (100%) within the operational area',
+      goalId: 'RACD_register_families',
+      identifier: '082be289-cf66-5312-8717-1218b1ac055d',
+      prefix: 2,
+      reason: 'Investigation',
+      subjectCodableConcept: { text: 'Location' },
+      taskTemplate: 'RACD_register_families',
+      timingPeriod: { end: '2020-09-24', start: '2020-09-17' },
+      title: 'Family Registration',
+    },
+    {
+      code: 'Blood Screening',
+      description:
+        'Visit all residential structures (100%) within a 1 km radius of a confirmed index case and test each registered person',
+      goalId: 'RACD_Blood_Screening',
+      identifier: '26a0d7f9-d69b-5870-a189-21f17b22d9cf',
+      prefix: 3,
+      reason: 'Investigation',
+      subjectCodableConcept: { text: 'Person' },
+      taskTemplate: 'RACD_Blood_Screening',
+      timingPeriod: { end: '2020-09-24', start: '2020-09-17' },
+      title: 'Blood Screening',
+    },
+    {
+      code: 'Bednet Distribution',
+      description: 'Visit 100% of residential structures in the operational area and provide nets',
+      goalId: 'RACD_bednet_distribution',
+      identifier: 'bf4d8bfc-fff2-57a9-be96-c06c9beb4656',
+      prefix: 4,
+      reason: 'Investigation',
+      subjectCodableConcept: { text: 'Location' },
+      taskTemplate: 'Bednet_Distribution',
+      timingPeriod: { end: '2020-09-24', start: '2020-09-17' },
+      title: 'Bednet Distribution',
+    },
+    {
+      code: 'Larval Dipping',
+      description: 'Perform a minimum of three larval dipping activities in the operational area',
+      goalId: 'Larval_Dipping',
+      identifier: 'fd0e920b-70f3-5ef4-afa5-d8b8a66bb543',
+      prefix: 5,
+      reason: 'Investigation',
+      subjectCodableConcept: { text: 'Location' },
+      taskTemplate: 'Larval_Dipping',
+      timingPeriod: { end: '2020-09-24', start: '2020-09-17' },
+      title: 'Larval Dipping',
+    },
+    {
+      code: 'Mosquito Collection',
+      description:
+        'Set a minimum of three mosquito collection traps and complete the mosquito collection process',
+      goalId: 'Mosquito_Collection',
+      identifier: '62e2b828-3c44-5e01-9cb9-32a7e09e3c22',
+      prefix: 6,
+      reason: 'Investigation',
+      subjectCodableConcept: { text: 'Location' },
+      taskTemplate: 'Mosquito_Collection_Point',
+      timingPeriod: { end: '2020-09-24', start: '2020-09-17' },
+      title: 'Mosquito Collection',
+    },
+    {
+      code: 'BCC',
+      description: 'Conduct BCC activity',
+      goalId: 'BCC_Focus',
+      identifier: '4d9f9a8c-32c9-589b-a0f0-29e65e7ac1f9',
+      prefix: 7,
+      reason: 'Investigation',
+      subjectCodableConcept: { text: 'Jurisdiction' },
+      taskTemplate: 'BCC_Focus',
+      timingPeriod: { end: '2020-09-24', start: '2020-09-17' },
+      title: 'Behaviour Change Communication',
+    },
+  ],
+  goal: [
+    {
+      description: 'Confirm the index case',
+      id: 'Case_Confirmation',
+      priority: 'medium-priority',
+      target: [
+        {
+          detail: { detailQuantity: { comparator: '>=', unit: 'case(s)', value: 1 } },
+          due: '2020-09-24',
+          measure: 'Number of cases confirmed',
+        },
+      ],
+    },
+    {
+      description:
+        'Register all families & family members in all residential structures enumerated (100%) within the operational area',
+      id: 'RACD_register_families',
+      priority: 'medium-priority',
+      target: [
+        {
+          detail: { detailQuantity: { comparator: '>=', unit: 'Percent', value: 100 } },
+          due: '2020-09-24',
+          measure: 'Percent of residential structures with full family registration',
+        },
+      ],
+    },
+    {
+      description:
+        'Visit all residential structures (100%) within a 1 km radius of a confirmed index case and test each registered person',
+      id: 'RACD_Blood_Screening',
+      priority: 'medium-priority',
+      target: [
+        {
+          detail: { detailQuantity: { comparator: '>=', unit: 'Person(s)', value: 100 } },
+          due: '2020-09-24',
+          measure: 'Number of registered people tested',
+        },
+      ],
+    },
+    {
+      description: 'Visit 100% of residential structures in the operational area and provide nets',
+      id: 'RACD_bednet_distribution',
+      priority: 'medium-priority',
+      target: [
+        {
+          detail: { detailQuantity: { comparator: '>=', unit: 'Percent', value: 100 } },
+          due: '2020-09-24',
+          measure: 'Percent of residential structures received nets',
+        },
+      ],
+    },
+    {
+      description: 'Perform a minimum of three larval dipping activities in the operational area',
+      id: 'Larval_Dipping',
+      priority: 'medium-priority',
+      target: [
+        {
+          detail: { detailQuantity: { comparator: '>=', unit: 'activit(y|ies)', value: 3 } },
+          due: '2020-09-24',
+          measure: 'Number of larval dipping activities completed',
+        },
+      ],
+    },
+    {
+      description:
+        'Set a minimum of three mosquito collection traps and complete the mosquito collection process',
+      id: 'Mosquito_Collection',
+      priority: 'medium-priority',
+      target: [
+        {
+          detail: { detailQuantity: { comparator: '>=', unit: 'activit(y|ies)', value: 3 } },
+          due: '2020-09-24',
+          measure: 'Number of mosquito collection activities completed',
+        },
+      ],
+    },
+    {
+      description: 'Complete at least 1 BCC activity for the operational area',
+      id: 'BCC_Focus',
+      priority: 'medium-priority',
+      target: [
+        {
+          detail: { detailQuantity: { comparator: '>=', unit: 'activit(y|ies)', value: 1 } },
+          due: '2020-09-24',
+          measure: 'BCC Activities Completed',
+        },
+      ],
+    },
+  ],
+  // tslint:disable: object-literal-sort-keys
+  date: '2020-09-17',
+  effectivePeriod: { end: '2020-10-07', start: '2020-09-17' },
+  experimental: false,
+  identifier: '311d4728-8e88-575d-8189-e88d9a4ae3b6',
+  jurisdiction: [{ code: '40aee4db-1c05-4fdf-a984-612829d6900b' }],
+  name: 'A1-Test OA-2020-09-17',
+  status: 'draft',
+  title: 'A1 Test OA 2020-09-17 FI Reason Test',
+  useContext: [
+    { code: 'interventionType', valueCodableConcept: 'FI' },
+    { code: 'fiStatus', valueCodableConcept: 'A1' },
+    { code: 'taskGenerationStatus', valueCodableConcept: 'False' },
+  ],
+  version: '1',
+};

--- a/src/components/forms/PlanForm/tests/helpers.test.ts
+++ b/src/components/forms/PlanForm/tests/helpers.test.ts
@@ -2,6 +2,7 @@ import MockDate from 'mockdate';
 import {
   PlanActionCodes,
   planActivities as planActivitiesFromConfig,
+  PlanDefinition,
 } from '../../../../configs/settings';
 import { plans } from '../../../../store/ducks/opensrp/PlanDefinition/tests/fixtures';
 import { InterventionType } from '../../../../store/ducks/plans';
@@ -29,6 +30,7 @@ import {
   expectedExtractActivityFromPlanformResult,
   expectedPlanDefinition,
   extractedActivitiesFromForms,
+  fiReasonTestPlan,
   planActivities,
   planActivityWithEmptyfields,
   planActivityWithoutTargets,
@@ -234,5 +236,11 @@ describe('containers/forms/PlanForm/helpers', () => {
     expect(isFIOrDynamicFI(InterventionType.FI)).toBeTruthy();
     expect(isFIOrDynamicFI(InterventionType.DynamicFI)).toBeTruthy();
     expect(isFIOrDynamicFI(InterventionType.IRS)).toBeFalsy();
+  });
+
+  it('getPlanFormValues missing fi reason', () => {
+    // what is the eventual form initial values
+    const res = getPlanFormValues(fiReasonTestPlan as PlanDefinition);
+    expect(res.fiReason).toBeUndefined();
   });
 });

--- a/src/components/forms/PlanForm/tests/index.test.tsx
+++ b/src/components/forms/PlanForm/tests/index.test.tsx
@@ -1,5 +1,6 @@
 import { getOpenSRPUserInfo } from '@onaio/gatekeeper';
 import { authenticateUser } from '@onaio/session-reducer';
+import { act } from '@testing-library/react';
 import { mount, ReactWrapper, shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import { cloneDeep } from 'lodash';
@@ -575,6 +576,7 @@ describe('containers/forms/PlanForm - Submission', () => {
         .first()
         .props() as any).formik.errors
     ).toEqual({
+      fiReason: 'Required',
       jurisdictions: [
         {
           id: 'Required',
@@ -650,10 +652,6 @@ describe('containers/forms/PlanForm - Submission', () => {
       .find('select[name="interventionType"]')
       .simulate('change', { target: { name: 'interventionType', value: 'FI' } });
 
-    // Set wrong fiReason field value
-    wrapper
-      .find('select[name="fiReason"]')
-      .simulate('change', { target: { name: 'fiReason', value: 'justin' } });
     // Set wrong fiStatus field value
     wrapper
       .find('select[name="fiStatus"]')
@@ -664,6 +662,21 @@ describe('containers/forms/PlanForm - Submission', () => {
       .simulate('change', { target: { name: 'status', value: 'Ona' } });
 
     wrapper.find('form').simulate('submit');
+
+    await act(async () => {
+      await new Promise<any>(resolve => setImmediate(resolve));
+      wrapper.update();
+    });
+
+    // fiStatus should be as expected
+    expect(wrapper.find('small.fiStatus-error').text()).toMatchInlineSnapshot(
+      `"fiStatus must be one of the following values: A1, A2, B1, B2"`
+    );
+
+    // Set wrong fiReason field value
+    wrapper
+      .find('select[name="fiReason"]')
+      .simulate('change', { target: { name: 'fiReason', value: 'justin' } });
 
     await new Promise<any>(resolve => setImmediate(resolve));
     wrapper.update();

--- a/src/components/forms/PlanForm/tests/index.test.tsx
+++ b/src/components/forms/PlanForm/tests/index.test.tsx
@@ -576,7 +576,6 @@ describe('containers/forms/PlanForm - Submission', () => {
         .first()
         .props() as any).formik.errors
     ).toEqual({
-      fiReason: 'Required',
       jurisdictions: [
         {
           id: 'Required',
@@ -668,15 +667,15 @@ describe('containers/forms/PlanForm - Submission', () => {
       wrapper.update();
     });
 
-    // fiStatus should be as expected
-    expect(wrapper.find('small.fiStatus-error').text()).toMatchInlineSnapshot(
-      `"fiStatus must be one of the following values: A1, A2, B1, B2"`
-    );
+    // there is no FIReason error due to default value
+    expect(wrapper.find('small.fiReason-error').length).toEqual(0);
 
     // Set wrong fiReason field value
     wrapper
       .find('select[name="fiReason"]')
       .simulate('change', { target: { name: 'fiReason', value: 'justin' } });
+
+    wrapper.find('form').simulate('submit');
 
     await new Promise<any>(resolve => setImmediate(resolve));
     wrapper.update();

--- a/src/containers/pages/InterventionPlan/UpdatePlan/index.tsx
+++ b/src/containers/pages/InterventionPlan/UpdatePlan/index.tsx
@@ -10,9 +10,10 @@ import PlanForm, {
   propsForUpdatingPlans,
 } from '../../../../components/forms/PlanForm';
 import { getPlanFormValues } from '../../../../components/forms/PlanForm/helpers';
+import { ErrorPage } from '../../../../components/page/ErrorPage';
 import HeaderBreadcrumb from '../../../../components/page/HeaderBreadcrumb/HeaderBreadcrumb';
 import Loading from '../../../../components/page/Loading';
-import { HOME, PLANS, UPDATE_PLAN } from '../../../../configs/lang';
+import { COULD_NOT_LOAD_PLAN, HOME, PLANS, UPDATE_PLAN } from '../../../../configs/lang';
 import { PlanDefinition } from '../../../../configs/settings';
 import { HOME_URL, NEW_PLAN_URL, OPENSRP_PLANS, PLAN_LIST_URL } from '../../../../constants';
 import { displayError } from '../../../../helpers/errors';
@@ -65,18 +66,21 @@ const UpdatePlan = (props: RouteComponentProps<RouteParams> & UpdatePlanProps) =
   }
 
   useEffect(() => {
+    if (!planIdentifier) {
+      return;
+    }
     loadData().catch(err => displayError(err));
   }, []);
 
-  if (!planIdentifier) {
-    return null; /** we should make this into a better error page */
-  }
-
-  if (loading === true) {
+  if (loading) {
     return <Loading />;
   }
 
-  const pageTitle: string = plan ? `${UPDATE_PLAN}: ${plan.title}` : UPDATE_PLAN;
+  if (!plan) {
+    return <ErrorPage errorMessage={COULD_NOT_LOAD_PLAN} />;
+  }
+
+  const pageTitle: string = `${UPDATE_PLAN}: ${plan.title}`;
 
   const breadcrumbProps = {
     currentPage: {

--- a/src/containers/pages/InterventionPlan/UpdatePlan/index.tsx
+++ b/src/containers/pages/InterventionPlan/UpdatePlan/index.tsx
@@ -7,6 +7,7 @@ import { Col, Row } from 'reactstrap';
 import { Store } from 'redux';
 import PlanForm, {
   LocationChildRenderProp,
+  PlanFormProps,
   propsForUpdatingPlans,
 } from '../../../../components/forms/PlanForm';
 import { getPlanFormValues } from '../../../../components/forms/PlanForm/helpers';
@@ -99,10 +100,12 @@ const UpdatePlan = (props: RouteComponentProps<RouteParams> & UpdatePlanProps) =
     ],
   };
 
+  const initialValues = getPlanFormValues(plan);
+
   const planStatus = (plan && plan.status) || '';
-  const planFormProps = {
+  const planFormProps: Partial<PlanFormProps> = {
     ...propsForUpdatingPlans(planStatus),
-    ...(plan && { initialValues: getPlanFormValues(plan) }),
+    initialValues,
     /** a renderProp prop. this tells the planForm; I will give you a component that knows of the plan you are displaying,
      * the component will get jurisdictions associated with that plan and render them as links, what you(planForm)
      * will do, is provide a child prop(a renderProp) that tells the mentioned component what other stuff you would wish

--- a/src/containers/pages/InterventionPlan/UpdatePlan/tests/__snapshots__/index.test.tsx.snap
+++ b/src/containers/pages/InterventionPlan/UpdatePlan/tests/__snapshots__/index.test.tsx.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`components/InterventionPlan/UpdatePlan deduces the fiReason field value correctly: fiReason field 1`] = `
+<select
+  className="form-control"
+  disabled={true}
+  id="fiReason"
+  name="fiReason"
+  onBlur={[Function]}
+  onChange={[Function]}
+  required={true}
+  value="Routine"
+>
+  <option>
+    ----
+  </option>
+  <option
+    key="Routine"
+    value="Routine"
+  >
+    Routine
+  </option>
+  <option
+    key="Case Triggered"
+    value="Case Triggered"
+  >
+    Case Triggered
+  </option>
+</select>
+`;
+
 exports[`components/InterventionPlan/UpdatePlan renders plan Location names component: Renders PlanLocation Mock 1`] = `
 <div
   id="Helmuth"

--- a/src/containers/pages/InterventionPlan/UpdatePlan/tests/index.test.tsx
+++ b/src/containers/pages/InterventionPlan/UpdatePlan/tests/index.test.tsx
@@ -10,6 +10,8 @@ import {
   generatePlanDefinition,
   getPlanFormValues,
 } from '../../../../../components/forms/PlanForm/helpers';
+import { fiReasonTestPlan } from '../../../../../components/forms/PlanForm/tests/fixtures';
+import { COULD_NOT_LOAD_PLAN } from '../../../../../configs/lang';
 import { PlanDefinition } from '../../../../../configs/settings';
 import { PLAN_UPDATE_URL } from '../../../../../constants';
 import store from '../../../../../store';
@@ -286,5 +288,49 @@ describe('components/InterventionPlan/UpdatePlan', () => {
     expect(store.getState().PlanDefinition).toEqual({
       planDefinitionsById: {},
     });
+  });
+
+  it('shows error when plan was not found', async () => {
+    fetch.mockResponseOnce(JSON.stringify([]));
+    const mock: any = jest.fn();
+    const thisPlansId = fiReasonTestPlan.identifier;
+    const props = {
+      history,
+      location: mock,
+      match: {
+        isExact: true,
+        params: { id: thisPlansId },
+        path: `${PLAN_UPDATE_URL}/:id`,
+        url: `${PLAN_UPDATE_URL}/${thisPlansId}`,
+      },
+    };
+    const wrapper = mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <ConnectedUpdatePlan {...props} />
+        </Router>
+      </Provider>
+    );
+
+    await act(async () => {
+      await new Promise(resolve => setImmediate(resolve));
+      wrapper.update();
+    });
+
+    expect(fetch.mock.calls).toEqual([
+      [
+        'https://reveal-stage.smartregister.org/opensrp/rest/plans/311d4728-8e88-575d-8189-e88d9a4ae3b6',
+        {
+          headers: {
+            accept: 'application/json',
+            authorization: 'Bearer null',
+            'content-type': 'application/json;charset=UTF-8',
+          },
+          method: 'GET',
+        },
+      ],
+    ]);
+    // shows error message
+    expect(wrapper.text().includes(COULD_NOT_LOAD_PLAN)).toBeTruthy();
   });
 });


### PR DESCRIPTION
- makes the fiReason field required when the interentionType is FI or Dynamic-FI
- change to how the planform.initialValues prop is passed to the form. 
- when creating plan, all configured fiReasons are allowed. when editing the plan all the Fi reasons options are allowed although the field will remain disabled(i.e. when editing)
- update plans page will now show an error when a plan is not in the api
- set default fiReason when creating plan => `Routine`
close #1287, part of #1278