### PR TITLE
Add translation for Dynamic-FI title

### DIFF
--- a/src/configs/strings/th.json
+++ b/src/configs/strings/th.json
@@ -1008,7 +1008,7 @@
     "description": "page title: for MDA point pages"
   },
   "DYNAMIC_FI_TITLE": {
-    "message": "Dynamic FI",
+    "message": "ประเภทของแผนปฏิบัติงาน",
     "description": "page title: for dynamic FI pages"
   },
   "DYNAMIC_IRS_TITLE": {


### PR DESCRIPTION
We are using "ประเภทของแผนปฏิบัติงาน" which is the Thai translation for "Focus Investigation".

Fix: https://github.com/onaio/reveal-frontend/issues/1294