### PR TITLE
Remove default task generation status

### DIFF
--- a/src/components/forms/PlanForm/helpers.ts
+++ b/src/components/forms/PlanForm/helpers.ts
@@ -57,7 +57,6 @@ import {
   FAMILY_REGISTRATION_ACTIVITY_CODE,
   FI_REASON_CODE,
   FI_STATUS_CODE,
-  IGNORE,
   INTERVENTION_TYPE_CODE,
   IRS_ACTIVITY_CODE,
   LARVAL_DIPPING_ACTIVITY_CODE,
@@ -157,7 +156,7 @@ export const PlanSchema = Yup.object().shape({
   status: Yup.string()
     .oneOf(Object.values(PlanStatus))
     .required(REQUIRED),
-  taskGenerationStatus: Yup.string().oneOf(taskGenerationStatuses.map(e => e)),
+  taskGenerationStatus: Yup.string().oneOf(Object.values(taskGenerationStatuses)),
   teamAssignmentStatus: Yup.string(),
   title: Yup.string().required(REQUIRED),
   version: Yup.string(),
@@ -600,7 +599,7 @@ export const getTaskGenerationValue = (
   taskGenerationStatusValue =
     isDynamic &&
     configuredEnv &&
-    taskGenerationStatuses.includes(configuredEnv as taskGenerationStatusType)
+    Object.values(taskGenerationStatuses).includes(configuredEnv as taskGenerationStatusType)
       ? (configuredEnv as taskGenerationStatusType)
       : undefined;
   return taskGenerationStatusValue;
@@ -663,8 +662,8 @@ export function generatePlanDefinition(
 
   if (
     formValue.taskGenerationStatus &&
-    formValue.taskGenerationStatus !== IGNORE &&
-    (taskGenerationStatusValue !== IGNORE || isEditMode)
+    formValue.taskGenerationStatus !== taskGenerationStatuses.ignore &&
+    (taskGenerationStatusValue !== taskGenerationStatuses.ignore || isEditMode)
   ) {
     useContext.push({
       code: TASK_GENERATION_STATUS_CODE,
@@ -773,8 +772,8 @@ export function getPlanFormValues(planObject: PlanDefinition): PlanFormFields {
     taskGenerationStatusContext.length > 0
       ? (taskGenerationStatusContext[0].valueCodableConcept as taskGenerationStatusType)
       : isDynamicPlan(planObject)
-      ? taskGenerationStatuses[4]
-      : taskGenerationStatuses[1];
+      ? taskGenerationStatuses.ignore
+      : taskGenerationStatuses.False;
 
   const teamAssignmentStatus: string =
     teamAssignmentStatusContext.length > 0

--- a/src/components/forms/PlanForm/helpers.ts
+++ b/src/components/forms/PlanForm/helpers.ts
@@ -661,7 +661,11 @@ export function generatePlanDefinition(
     useContext.push({ code: OPENSRP_EVENT_ID_CODE, valueCodableConcept: formValue.opensrpEventId });
   }
 
-  if (formValue.taskGenerationStatus && (taskGenerationStatusValue !== IGNORE || isEditMode)) {
+  if (
+    formValue.taskGenerationStatus &&
+    formValue.taskGenerationStatus !== IGNORE &&
+    (taskGenerationStatusValue !== IGNORE || isEditMode)
+  ) {
     useContext.push({
       code: TASK_GENERATION_STATUS_CODE,
       valueCodableConcept: isEditMode ? formValue.taskGenerationStatus : taskGenerationStatusValue,
@@ -769,7 +773,7 @@ export function getPlanFormValues(planObject: PlanDefinition): PlanFormFields {
     taskGenerationStatusContext.length > 0
       ? (taskGenerationStatusContext[0].valueCodableConcept as taskGenerationStatusType)
       : isDynamicPlan(planObject)
-      ? taskGenerationStatuses[2]
+      ? taskGenerationStatuses[4]
       : taskGenerationStatuses[1];
 
   const teamAssignmentStatus: string =

--- a/src/components/forms/PlanForm/tests/helpers.test.ts
+++ b/src/components/forms/PlanForm/tests/helpers.test.ts
@@ -159,6 +159,28 @@ describe('containers/forms/PlanForm/helpers', () => {
     );
   });
 
+  it('plans with no task generation status are not added task generation status', () => {
+    MockDate.set('1/30/2000', 0);
+    const envModule = require('../../../../configs/env');
+    envModule.PLAN_UUID_NAMESPACE = '85f7dbbf-07d0-4c92-aa2d-d50d141dde00';
+    envModule.ACTION_UUID_NAMESPACE = '35968df5-f335-44ae-8ae5-25804caa2d86';
+    envModule.TASK_GENERATION_STATUS = TRUE;
+    const noTaskGenerationstatus = getPlanFormValues(plans[5]);
+    const planCopy = {
+      ...plans[5],
+      version: 2,
+    };
+    // remove serverVersion
+    const { serverVersion, ...expectedDynamicPlan } = planCopy;
+    expectedDynamicPlan.action[0].type = 'create';
+    // on create
+    expect(generatePlanDefinition(noTaskGenerationstatus, null, false)).toEqual(
+      expectedDynamicPlan
+    );
+    // on edit
+    expect(generatePlanDefinition(noTaskGenerationstatus, null, true)).toEqual(expectedDynamicPlan);
+  });
+
   it('generatePlanDefinition should ignore taskGenerationStatus if specified when creating plan and keep value on edit', () => {
     MockDate.set('1/30/2000', 0);
     const envModule = require('../../../../configs/env');

--- a/src/components/forms/PlanForm/types.ts
+++ b/src/components/forms/PlanForm/types.ts
@@ -31,7 +31,7 @@ export type UseContextCodesType = typeof useContextCodes[number];
 export type PlanActionCodesType = typeof PlanActionCodes[number];
 
 /** Task generation status type */
-export type taskGenerationStatusType = typeof taskGenerationStatuses[number];
+export type taskGenerationStatusType = keyof typeof taskGenerationStatuses;
 
 /** Plan activity title type */
 export type PlanActivityTitlesType = typeof PlanActivityTitles[number];

--- a/src/configs/settings.ts
+++ b/src/configs/settings.ts
@@ -333,7 +333,13 @@ export const PlanActionCodes = [
 
 /** Allowed taskGenerationStatus values */
 /* tslint:disable-next-line no-useless-cast */
-export const taskGenerationStatuses = [TRUE, FALSE, DISABLED, INTERNAL, IGNORE] as const;
+export const taskGenerationStatuses = {
+  [FALSE]: FALSE,
+  [TRUE]: TRUE,
+  [DISABLED]: DISABLED,
+  [IGNORE]: IGNORE,
+  [INTERNAL]: INTERNAL,
+} as const;
 
 /** Plan Action Timing Period */
 export interface PlanActionTimingPeriod {

--- a/src/containers/pages/InterventionPlan/UpdatePlan/tests/dynamicFi.test.tsx
+++ b/src/containers/pages/InterventionPlan/UpdatePlan/tests/dynamicFi.test.tsx
@@ -131,7 +131,6 @@ describe('components/InterventionPlan/UpdatePlan', () => {
       { code: 'interventionType', valueCodableConcept: 'Dynamic-FI' },
       { code: 'fiStatus', valueCodableConcept: 'A1' },
       { code: 'fiReason', valueCodableConcept: 'Routine' },
-      { code: 'taskGenerationStatus', valueCodableConcept: 'Disabled' },
     ]);
   });
 });


### PR DESCRIPTION
Fixes task generation status being given disabled value by default when editing.
Ensures task generation status is only added to plans which have the status and not those which didn't have the status.