### PR TITLE
Fix dynamic activity management

### DIFF
--- a/src/components/forms/PlanForm/components/actions.tsx
+++ b/src/components/forms/PlanForm/components/actions.tsx
@@ -18,6 +18,7 @@ export const getConditionAndTriggers = (
   const triggers: Dictionary = {};
   for (let index = 0; index < planActivities.length; index++) {
     const element = planActivities[index];
+
     if (element.condition) {
       conditions[element.actionCode] = element.condition.map((item, mapIndex) => {
         return (
@@ -38,6 +39,7 @@ export const getConditionAndTriggers = (
                   name={`activities[${index}].condition[${mapIndex}].expression`}
                   id={`activities[${index}].condition[${mapIndex}].expression`}
                   disabled={disabledFields}
+                  value={item.expression}
                 />
               </React.Fragment>
             )}
@@ -53,6 +55,7 @@ export const getConditionAndTriggers = (
                   name={`activities[${index}].condition[${mapIndex}].description`}
                   id={`activities[${index}].condition[${mapIndex}].description`}
                   disabled={disabledFields}
+                  value={item.description}
                 />
               </React.Fragment>
             )}
@@ -81,6 +84,7 @@ export const getConditionAndTriggers = (
                   name={`activities[${index}].trigger[${mapIndex}].name`}
                   id={`activities[${index}].trigger[${mapIndex}].name`}
                   disabled={disabledFields}
+                  value={item.name}
                 />
               </React.Fragment>
             )}
@@ -96,6 +100,7 @@ export const getConditionAndTriggers = (
                   name={`activities[${index}].trigger[${mapIndex}].expression`}
                   id={`activities[${index}].trigger[${mapIndex}].expression`}
                   disabled={disabledFields}
+                  value={item.expression}
                 />
               </React.Fragment>
             )}
@@ -111,6 +116,7 @@ export const getConditionAndTriggers = (
                   name={`activities[${index}].trigger[${mapIndex}].description`}
                   id={`activities[${index}].trigger[${mapIndex}].description`}
                   disabled={disabledFields}
+                  value={item.description}
                 />
               </React.Fragment>
             )}

--- a/src/components/forms/PlanForm/components/actions.tsx
+++ b/src/components/forms/PlanForm/components/actions.tsx
@@ -25,7 +25,7 @@ export const getConditionAndTriggers = (
           <FormGroup
             className="condition-group"
             row={true}
-            key={`${element.actionCode}-${index}-condition-${mapIndex}`}
+            key={`${element.actionCode}-condition-${index}-${mapIndex}`}
           >
             {item.expression && (
               <React.Fragment>
@@ -69,7 +69,7 @@ export const getConditionAndTriggers = (
           <FormGroup
             className="trigger-group"
             row={true}
-            key={`${element.actionCode}-${index}-trigger-${mapIndex}`}
+            key={`${element.actionCode}-trigger-${index}-${mapIndex}`}
           >
             {item.name && (
               <React.Fragment>

--- a/src/components/forms/PlanForm/components/actions.tsx
+++ b/src/components/forms/PlanForm/components/actions.tsx
@@ -39,7 +39,6 @@ export const getConditionAndTriggers = (
                   name={`activities[${index}].condition[${mapIndex}].expression`}
                   id={`activities[${index}].condition[${mapIndex}].expression`}
                   disabled={disabledFields}
-                  value={item.expression}
                 />
               </React.Fragment>
             )}
@@ -55,7 +54,6 @@ export const getConditionAndTriggers = (
                   name={`activities[${index}].condition[${mapIndex}].description`}
                   id={`activities[${index}].condition[${mapIndex}].description`}
                   disabled={disabledFields}
-                  value={item.description}
                 />
               </React.Fragment>
             )}
@@ -84,7 +82,6 @@ export const getConditionAndTriggers = (
                   name={`activities[${index}].trigger[${mapIndex}].name`}
                   id={`activities[${index}].trigger[${mapIndex}].name`}
                   disabled={disabledFields}
-                  value={item.name}
                 />
               </React.Fragment>
             )}
@@ -100,7 +97,6 @@ export const getConditionAndTriggers = (
                   name={`activities[${index}].trigger[${mapIndex}].expression`}
                   id={`activities[${index}].trigger[${mapIndex}].expression`}
                   disabled={disabledFields}
-                  value={item.expression}
                 />
               </React.Fragment>
             )}
@@ -116,7 +112,6 @@ export const getConditionAndTriggers = (
                   name={`activities[${index}].trigger[${mapIndex}].description`}
                   id={`activities[${index}].trigger[${mapIndex}].description`}
                   disabled={disabledFields}
-                  value={item.description}
                 />
               </React.Fragment>
             )}

--- a/src/components/forms/PlanForm/index.tsx
+++ b/src/components/forms/PlanForm/index.tsx
@@ -695,7 +695,7 @@ const PlanForm = (props: PlanFormProps) => {
               render={arrayHelpers => (
                 <div>
                   {values.activities.map((arrItem, index) => (
-                    <div className="card mb-3" key={`div${arrItem.actionCode}`}>
+                    <div className="card mb-3" key={`div${arrItem.actionCode}-${index}`}>
                       <h5 className="card-header position-relative">
                         {values.activities[index].actionTitle}
                         {values.activities && values.activities.length > 1 && !editMode && (
@@ -710,7 +710,7 @@ const PlanForm = (props: PlanFormProps) => {
                         )}
                       </h5>
                       <div className="card-body">
-                        <fieldset key={`fieldset${arrItem.actionCode}`}>
+                        <fieldset key={`fieldset${arrItem.actionCode}-${index}`}>
                           {errors.activities && errors.activities[index] && (
                             <div
                               className={`alert alert-danger activities-${index}-errors`}

--- a/src/components/forms/PlanForm/index.tsx
+++ b/src/components/forms/PlanForm/index.tsx
@@ -694,8 +694,8 @@ const PlanForm = (props: PlanFormProps) => {
               /* tslint:disable-next-line jsx-no-lambda */
               render={arrayHelpers => (
                 <div>
-                  {values.activities.map((_, index) => (
-                    <div className="card mb-3" key={index}>
+                  {values.activities.map((arrItem, index) => (
+                    <div className="card mb-3" key={`div${JSON.stringify(arrItem)}`}>
                       <h5 className="card-header position-relative">
                         {values.activities[index].actionTitle}
                         {values.activities && values.activities.length > 1 && !editMode && (
@@ -710,7 +710,7 @@ const PlanForm = (props: PlanFormProps) => {
                         )}
                       </h5>
                       <div className="card-body">
-                        <fieldset key={index}>
+                        <fieldset key={`fieldset${JSON.stringify(arrItem)}`}>
                           {errors.activities && errors.activities[index] && (
                             <div
                               className={`alert alert-danger activities-${index}-errors`}

--- a/src/components/forms/PlanForm/index.tsx
+++ b/src/components/forms/PlanForm/index.tsx
@@ -703,7 +703,20 @@ const PlanForm = (props: PlanFormProps) => {
                             type="button"
                             className="close position-absolute removeArrItem removeActivity"
                             aria-label="Close"
-                            onClick={() => arrayHelpers.remove(index)}
+                            onClick={() => {
+                              /** when we remove an item, we want to also remove its value from
+                               * the values object otherwise the Formik state gets out of sync
+                               */
+                              arrayHelpers.remove(index);
+                              const newActivityValues = getConditionAndTriggers(
+                                values.activities.filter(
+                                  e => e.actionCode !== values.activities[index].actionCode
+                                ),
+                                disabledFields.includes('activities')
+                              );
+                              setActionConditions(newActivityValues.conditions);
+                              setActionTriggers(newActivityValues.triggers);
+                            }}
                           >
                             <span aria-hidden="true">&times;</span>
                           </button>

--- a/src/components/forms/PlanForm/index.tsx
+++ b/src/components/forms/PlanForm/index.tsx
@@ -695,7 +695,7 @@ const PlanForm = (props: PlanFormProps) => {
               render={arrayHelpers => (
                 <div>
                   {values.activities.map((arrItem, index) => (
-                    <div className="card mb-3" key={`div${JSON.stringify(arrItem)}`}>
+                    <div className="card mb-3" key={`div${arrItem.actionCode}`}>
                       <h5 className="card-header position-relative">
                         {values.activities[index].actionTitle}
                         {values.activities && values.activities.length > 1 && !editMode && (
@@ -710,7 +710,7 @@ const PlanForm = (props: PlanFormProps) => {
                         )}
                       </h5>
                       <div className="card-body">
-                        <fieldset key={`fieldset${JSON.stringify(arrItem)}`}>
+                        <fieldset key={`fieldset${arrItem.actionCode}`}>
                           {errors.activities && errors.activities[index] && (
                             <div
                               className={`alert alert-danger activities-${index}-errors`}

--- a/src/components/forms/PlanForm/index.tsx
+++ b/src/components/forms/PlanForm/index.tsx
@@ -241,7 +241,6 @@ const PlanForm = (props: PlanFormProps) => {
     if (planActivitiesMap.hasOwnProperty(values.interventionType)) {
       return planActivitiesMap[values.interventionType];
     }
-
     return allFormActivities;
   }
 
@@ -1098,14 +1097,22 @@ const PlanForm = (props: PlanFormProps) => {
                                   e =>
                                     !values.activities.map(f => f.actionCode).includes(e.actionCode)
                                 )
-                                .map(g => (
-                                  <li key={g.actionCode}>
+                                .map(thisActivity => (
+                                  <li key={thisActivity.actionCode}>
                                     <button
                                       type="button"
                                       className="btn btn-primary btn-sm mb-1 addActivity"
-                                      onClick={() => arrayHelpers.push(g)}
+                                      onClick={() => {
+                                        values.activities.push(thisActivity);
+                                        const newActivityValues = getConditionAndTriggers(
+                                          values.activities,
+                                          disabledFields.includes('activities')
+                                        );
+                                        setActionConditions(newActivityValues.conditions);
+                                        setActionTriggers(newActivityValues.triggers);
+                                      }}
                                     >
-                                      {format(ADD_CODED_ACTIVITY, g.actionCode)}
+                                      {format(ADD_CODED_ACTIVITY, thisActivity.actionCode)}
                                     </button>
                                   </li>
                                 ))}

--- a/src/components/forms/PlanForm/tests/__snapshots__/index.test.tsx.snap
+++ b/src/components/forms/PlanForm/tests/__snapshots__/index.test.tsx.snap
@@ -50,6 +50,64 @@ Array [
 ]
 `;
 
+exports[`containers/forms/PlanForm - Dynamic Form Activities removing dynamic activities works correctly: Final activity conditions text input names 1`] = `Array []`;
+
+exports[`containers/forms/PlanForm - Dynamic Form Activities removing dynamic activities works correctly: Final activity conditions text textarea names 1`] = `
+Array [
+  "activities[0].condition[0].expression",
+  "activities[0].condition[0].description",
+  "activities[1].condition[0].expression",
+  "activities[1].condition[0].description",
+  "activities[1].condition[1].expression",
+  "activities[1].condition[1].description",
+  "activities[2].condition[0].expression",
+  "activities[2].condition[0].description",
+  "activities[2].condition[1].expression",
+  "activities[2].condition[1].description",
+  "activities[3].condition[0].expression",
+  "activities[3].condition[0].description",
+  "activities[3].condition[1].expression",
+  "activities[3].condition[1].description",
+  "activities[4].condition[0].expression",
+  "activities[4].condition[0].description",
+  "activities[5].condition[0].expression",
+  "activities[5].condition[0].description",
+  "activities[5].condition[1].expression",
+  "activities[5].condition[1].description",
+]
+`;
+
+exports[`containers/forms/PlanForm - Dynamic Form Activities removing dynamic activities works correctly: Final activity trigger text input names 1`] = `
+Array [
+  "activities[0].trigger[0].name",
+  "activities[0].trigger[1].name",
+  "activities[1].trigger[0].name",
+  "activities[1].trigger[1].name",
+  "activities[2].trigger[0].name",
+  "activities[2].trigger[1].name",
+  "activities[3].trigger[0].name",
+  "activities[3].trigger[1].name",
+  "activities[4].trigger[0].name",
+  "activities[5].trigger[0].name",
+  "activities[5].trigger[1].name",
+]
+`;
+
+exports[`containers/forms/PlanForm - Dynamic Form Activities removing dynamic activities works correctly: Final activity trigger text textarea names 1`] = `
+Array [
+  "activities[0].trigger[1].expression",
+  "activities[0].trigger[1].description",
+  "activities[1].trigger[1].expression",
+  "activities[1].trigger[1].description",
+  "activities[2].trigger[1].expression",
+  "activities[2].trigger[1].description",
+  "activities[3].trigger[1].expression",
+  "activities[3].trigger[1].description",
+  "activities[5].trigger[1].expression",
+  "activities[5].trigger[1].description",
+]
+`;
+
 exports[`containers/forms/PlanForm - Dynamic Form Activities removing dynamic activities works correctly: Original activity conditions text input names 1`] = `Array []`;
 
 exports[`containers/forms/PlanForm - Dynamic Form Activities removing dynamic activities works correctly: Original activity conditions text textarea names 1`] = `

--- a/src/components/forms/PlanForm/tests/__snapshots__/index.test.tsx.snap
+++ b/src/components/forms/PlanForm/tests/__snapshots__/index.test.tsx.snap
@@ -1,5 +1,113 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`containers/forms/PlanForm - Dynamic Form Activities removing dynamic activities works correctly: Changed activity conditions text input names 1`] = `Array []`;
+
+exports[`containers/forms/PlanForm - Dynamic Form Activities removing dynamic activities works correctly: Changed activity conditions text textarea names 1`] = `
+Array [
+  "activities[0].condition[0].expression",
+  "activities[0].condition[0].description",
+  "activities[1].condition[0].expression",
+  "activities[1].condition[0].description",
+  "activities[1].condition[1].expression",
+  "activities[1].condition[1].description",
+  "activities[2].condition[0].expression",
+  "activities[2].condition[0].description",
+  "activities[2].condition[1].expression",
+  "activities[2].condition[1].description",
+  "activities[3].condition[0].expression",
+  "activities[3].condition[0].description",
+  "activities[3].condition[1].expression",
+  "activities[3].condition[1].description",
+  "activities[4].condition[0].expression",
+  "activities[4].condition[0].description",
+]
+`;
+
+exports[`containers/forms/PlanForm - Dynamic Form Activities removing dynamic activities works correctly: Changed activity trigger text input names 1`] = `
+Array [
+  "activities[0].trigger[0].name",
+  "activities[0].trigger[1].name",
+  "activities[1].trigger[0].name",
+  "activities[1].trigger[1].name",
+  "activities[2].trigger[0].name",
+  "activities[2].trigger[1].name",
+  "activities[3].trigger[0].name",
+  "activities[3].trigger[1].name",
+  "activities[4].trigger[0].name",
+]
+`;
+
+exports[`containers/forms/PlanForm - Dynamic Form Activities removing dynamic activities works correctly: Changed activity trigger text textarea names 1`] = `
+Array [
+  "activities[0].trigger[1].expression",
+  "activities[0].trigger[1].description",
+  "activities[1].trigger[1].expression",
+  "activities[1].trigger[1].description",
+  "activities[2].trigger[1].expression",
+  "activities[2].trigger[1].description",
+  "activities[3].trigger[1].expression",
+  "activities[3].trigger[1].description",
+]
+`;
+
+exports[`containers/forms/PlanForm - Dynamic Form Activities removing dynamic activities works correctly: Original activity conditions text input names 1`] = `Array []`;
+
+exports[`containers/forms/PlanForm - Dynamic Form Activities removing dynamic activities works correctly: Original activity conditions text textarea names 1`] = `
+Array [
+  "activities[0].condition[0].expression",
+  "activities[0].condition[0].description",
+  "activities[0].condition[1].expression",
+  "activities[0].condition[1].description",
+  "activities[1].condition[0].expression",
+  "activities[1].condition[0].description",
+  "activities[2].condition[0].expression",
+  "activities[2].condition[0].description",
+  "activities[2].condition[1].expression",
+  "activities[2].condition[1].description",
+  "activities[3].condition[0].expression",
+  "activities[3].condition[0].description",
+  "activities[3].condition[1].expression",
+  "activities[3].condition[1].description",
+  "activities[4].condition[0].expression",
+  "activities[4].condition[0].description",
+  "activities[4].condition[1].expression",
+  "activities[4].condition[1].description",
+  "activities[5].condition[0].expression",
+  "activities[5].condition[0].description",
+]
+`;
+
+exports[`containers/forms/PlanForm - Dynamic Form Activities removing dynamic activities works correctly: Original activity trigger text input names 1`] = `
+Array [
+  "activities[0].trigger[0].name",
+  "activities[0].trigger[1].name",
+  "activities[1].trigger[0].name",
+  "activities[1].trigger[1].name",
+  "activities[2].trigger[0].name",
+  "activities[2].trigger[1].name",
+  "activities[3].trigger[0].name",
+  "activities[3].trigger[1].name",
+  "activities[4].trigger[0].name",
+  "activities[4].trigger[1].name",
+  "activities[5].trigger[0].name",
+]
+`;
+
+exports[`containers/forms/PlanForm - Dynamic Form Activities removing dynamic activities works correctly: Original activity trigger text textarea names 1`] = `
+Array [
+  "activities[0].trigger[1].expression",
+  "activities[0].trigger[1].description",
+  "activities[1].trigger[1].expression",
+  "activities[1].trigger[1].description",
+  "activities[2].trigger[1].expression",
+  "activities[2].trigger[1].description",
+  "activities[3].trigger[1].expression",
+  "activities[3].trigger[1].description",
+  "activities[4].trigger[1].expression",
+  "activities[4].trigger[1].description",
+]
+`;
+
 exports[`containers/forms/PlanForm - Edit ACTIVE renders all fields correctly in edit mode: Active Plan : interventionType field 1`] = `
 <select
   className="form-control"

--- a/src/components/forms/PlanForm/tests/index.test.tsx
+++ b/src/components/forms/PlanForm/tests/index.test.tsx
@@ -941,7 +941,9 @@ describe('containers/forms/PlanForm - Submission', () => {
     // submit button should not be disabled
     expect(wrapper.find('#planform-submit-button button').prop('disabled')).toBeFalsy();
 
-    wrapper.find('form').simulate('submit');
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
 
     await new Promise<any>(resolve => setImmediate(resolve));
 
@@ -995,7 +997,9 @@ describe('containers/forms/PlanForm - Submission', () => {
       </MemoryRouter>
     );
 
-    wrapper.find('form').simulate('submit');
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
 
     await new Promise<any>(resolve => setImmediate(resolve));
     wrapper.update();
@@ -1040,7 +1044,9 @@ describe('containers/forms/PlanForm - Submission', () => {
       { attachTo: div }
     );
 
-    wrapper.find('form').simulate('submit');
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
 
     await new Promise<any>(resolve => setImmediate(resolve));
     wrapper.update();
@@ -1141,7 +1147,9 @@ describe('containers/forms/PlanForm - Submission', () => {
       </MemoryRouter>
     );
 
-    wrapper.find('form').simulate('submit');
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
 
     await new Promise<any>(resolve => setImmediate(resolve));
     wrapper.update();
@@ -1257,7 +1265,9 @@ describe('containers/forms/PlanForm - Submission', () => {
       .find('select[name="fiStatus"]')
       .simulate('change', { target: { name: 'fiStatus', value: 'A2' } });
 
-    wrapper.find('form').simulate('submit');
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
 
     await new Promise<any>(resolve => setImmediate(resolve));
 

--- a/src/components/forms/PlanForm/tests/index.test.tsx
+++ b/src/components/forms/PlanForm/tests/index.test.tsx
@@ -3,6 +3,7 @@ import { authenticateUser } from '@onaio/session-reducer';
 import { act } from '@testing-library/react';
 import { mount, ReactWrapper, shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
+import flushPromises from 'flush-promises';
 import { cloneDeep } from 'lodash';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -1377,25 +1378,45 @@ describe('containers/forms/PlanForm - Dynamic Form Activities', () => {
     // there are initially 7 activities
     expect(wrapper.find(`.removeActivity`).length).toEqual(6);
     // lets get the form input values of the triggers
-    const expectedInputValues = wrapper.find('.triggers-fieldset input').map(e => e.props().value);
-    const expectedTextValues = wrapper
+    const expectedTriggerInputValues = wrapper
+      .find('.triggers-fieldset input')
+      .map(e => e.props().value);
+    const expectedTriggerTextValues = wrapper
       .find('.triggers-fieldset textarea')
       .map(e => e.props().value);
+    const expectedConditionInputValues = wrapper
+      .find('.conditions-fieldset input')
+      .map(e => e.props().value);
+    const expectedConditionTextValues = wrapper
+      .find('.conditions-fieldset textarea')
+      .map(e => e.props().value);
     // lets remove one activity
-    wrapper
-      .find(`.removeActivity`)
-      .first()
-      .simulate('click');
-    wrapper.update();
+    await act(async () => {
+      wrapper
+        .find(`.removeActivity`)
+        .first()
+        .simulate('click');
+    });
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
     // 1 less activity
     expect(wrapper.find(`.removeActivity`).length).toEqual(5);
     // the slice values are determined by the type of activity that was removed
     // the meaning is that we should be left with ALL the triggers excluding the ones removed
     expect(wrapper.find(`.triggers-fieldset input`).map(e => e.props().value)).toEqual(
-      expectedInputValues.slice(2)
+      expectedTriggerInputValues.slice(2)
     );
     expect(wrapper.find(`.triggers-fieldset textarea`).map(e => e.props().value)).toEqual(
-      expectedTextValues.slice(4)
+      expectedTriggerTextValues.slice(2)
+    );
+    expect(wrapper.find(`.conditions-fieldset textarea`).map(e => e.props().value)).toEqual(
+      expectedConditionTextValues.slice(4)
+    );
+    // this one does not change because currently there are no conditions with an input field
+    expect(wrapper.find(`.conditions-fieldset input`).map(e => e.props().value)).toEqual(
+      expectedConditionInputValues
     );
     wrapper.unmount();
   });

--- a/src/components/forms/PlanForm/tests/index.test.tsx
+++ b/src/components/forms/PlanForm/tests/index.test.tsx
@@ -1385,7 +1385,7 @@ describe('containers/forms/PlanForm - Dynamic Form Activities', () => {
       await flushPromises();
       wrapper.update();
     });
-    // there are initially 7 activities
+    // there are initially 6 activities
     expect(wrapper.find(`.removeActivity`).length).toEqual(6);
     // lets get the form input values of the triggers
     const expectedTriggerInputValues = wrapper

--- a/src/components/forms/PlanForm/tests/index.test.tsx
+++ b/src/components/forms/PlanForm/tests/index.test.tsx
@@ -387,50 +387,6 @@ describe('containers/forms/PlanForm', () => {
 
     wrapper.unmount();
   });
-
-  it('removing dynamic activities works correctly', () => {
-    const defaults = {
-      ...defaultInitialValues,
-      activities: planActivitiesMap[InterventionType.DynamicFI],
-    };
-
-    const wrapper = mount(
-      <MemoryRouter>
-        <PlanForm initialValues={defaults} />
-      </MemoryRouter>,
-      { attachTo: div }
-    );
-
-    // change interventionType to Dynamic-FI
-    wrapper
-      .find('#interventionType select')
-      .simulate('change', { target: { value: 'Dynamic-FI', name: 'interventionType' } });
-    wrapper.update();
-    // there are initially 7 activities
-    expect(wrapper.find(`.removeActivity`).length).toEqual(6);
-    // lets get the form input values of the triggers
-    const expectedInputValues = wrapper.find('.triggers-fieldset input').map(e => e.props().value);
-    const expectedTextValues = wrapper
-      .find('.triggers-fieldset textarea')
-      .map(e => e.props().value);
-    // lets remove one activity
-    wrapper
-      .find(`.removeActivity`)
-      .first()
-      .simulate('click');
-    wrapper.update();
-    // 1 less activity
-    expect(wrapper.find(`.removeActivity`).length).toEqual(5);
-    // the slice values are determined by the type of activity that was removed
-    // the meaning is that we should be left with ALL the triggers excluding the ones removed
-    expect(wrapper.find(`.triggers-fieldset input`).map(e => e.props().value)).toEqual(
-      expectedInputValues.slice(2)
-    );
-    expect(wrapper.find(`.triggers-fieldset textarea`).map(e => e.props().value)).toEqual(
-      expectedTextValues.slice(4)
-    );
-    wrapper.unmount();
-  });
 });
 
 describe('containers/forms/PlanForm - Edit', () => {
@@ -1383,5 +1339,64 @@ describe('containers/forms/PlanForm - Submission', () => {
     wrapper.update();
     expect(wrapper.find('#planform-submit-button button').prop('disabled')).toEqual(false);
     expect(wrapper.find('#planform-submit-button button').text()).toEqual('Save Plan');
+  });
+});
+
+describe('containers/forms/PlanForm - Dynamic Form Activities', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    fetch.resetMocks();
+  });
+
+  it('removing dynamic activities works correctly', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const defaults = {
+      ...defaultInitialValues,
+      activities: planActivitiesMap[InterventionType.DynamicFI],
+    };
+
+    const wrapper = mount(
+      <MemoryRouter>
+        <PlanForm initialValues={defaults} />
+      </MemoryRouter>,
+      { attachTo: container }
+    );
+
+    // change interventionType to Dynamic-FI
+    await act(async () => {
+      wrapper
+        .find('#interventionType select')
+        .simulate('change', { target: { value: 'Dynamic-FI', name: 'interventionType' } });
+    });
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+    // there are initially 7 activities
+    expect(wrapper.find(`.removeActivity`).length).toEqual(6);
+    // lets get the form input values of the triggers
+    const expectedInputValues = wrapper.find('.triggers-fieldset input').map(e => e.props().value);
+    const expectedTextValues = wrapper
+      .find('.triggers-fieldset textarea')
+      .map(e => e.props().value);
+    // lets remove one activity
+    wrapper
+      .find(`.removeActivity`)
+      .first()
+      .simulate('click');
+    wrapper.update();
+    // 1 less activity
+    expect(wrapper.find(`.removeActivity`).length).toEqual(5);
+    // the slice values are determined by the type of activity that was removed
+    // the meaning is that we should be left with ALL the triggers excluding the ones removed
+    expect(wrapper.find(`.triggers-fieldset input`).map(e => e.props().value)).toEqual(
+      expectedInputValues.slice(2)
+    );
+    expect(wrapper.find(`.triggers-fieldset textarea`).map(e => e.props().value)).toEqual(
+      expectedTextValues.slice(4)
+    );
+    wrapper.unmount();
   });
 });

--- a/src/components/forms/PlanForm/tests/index.test.tsx
+++ b/src/components/forms/PlanForm/tests/index.test.tsx
@@ -1444,6 +1444,63 @@ describe('containers/forms/PlanForm - Dynamic Form Activities', () => {
     expect(wrapper.find(`.conditions-fieldset input`).map(e => e.props().name)).toMatchSnapshot(
       'Changed activity conditions text input names'
     );
+    // there should now be one button to add activities
+    expect(wrapper.find(`button.add-more-activities`).length).toEqual(1);
+    // lets bring up the modal that allows us to add activities
+    await act(async () => {
+      wrapper
+        .find(`button.add-more-activities`)
+        .first()
+        .simulate('click');
+    });
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+    // there should be one activity that can be added back
+    expect(wrapper.find(`button.addActivity`).length).toEqual(1);
+    // lets click the button in the modal and add back the activity we had removed
+    await act(async () => {
+      wrapper
+        .find(`button.addActivity`)
+        .first()
+        .simulate('click');
+    });
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+    // we should have 6 activities again
+    expect(wrapper.find(`.removeActivity`).length).toEqual(6);
+    // and now we come full circle.  The inputs should be what we had on initial load,
+    // with those of the first activity moved to the end of the arrays
+    expect(wrapper.find(`.triggers-fieldset input`).map(e => e.props().value)).toEqual(
+      expectedTriggerInputValues.slice(2).concat(expectedTriggerInputValues.slice(0, 2))
+    );
+    expect(wrapper.find(`.triggers-fieldset textarea`).map(e => e.props().value)).toEqual(
+      expectedTriggerTextValues.slice(2).concat(expectedTriggerTextValues.slice(0, 2))
+    );
+    expect(wrapper.find(`.conditions-fieldset textarea`).map(e => e.props().value)).toEqual(
+      expectedConditionTextValues.slice(4).concat(expectedConditionTextValues.slice(0, 4))
+    );
+    expect(wrapper.find(`.conditions-fieldset input`).map(e => e.props().value)).toEqual(
+      expectedConditionInputValues
+    );
+    // the names of the input fields should STILL STILL! be indexed from zero (0)
+    expect(wrapper.find(`.triggers-fieldset input`).map(e => e.props().name)).toMatchSnapshot(
+      'Final activity trigger text input names'
+    );
+    expect(wrapper.find(`.triggers-fieldset textarea`).map(e => e.props().name)).toMatchSnapshot(
+      'Final activity trigger text textarea names'
+    );
+    expect(wrapper.find(`.conditions-fieldset textarea`).map(e => e.props().name)).toMatchSnapshot(
+      'Final activity conditions text textarea names'
+    );
+    expect(wrapper.find(`.conditions-fieldset input`).map(e => e.props().name)).toMatchSnapshot(
+      'Final activity conditions text input names'
+    );
+    // there should not be any button to add activities
+    expect(wrapper.find(`button.add-more-activities`).length).toEqual(0);
     wrapper.unmount();
   });
 });

--- a/src/components/forms/PlanForm/tests/index.test.tsx
+++ b/src/components/forms/PlanForm/tests/index.test.tsx
@@ -1390,6 +1390,19 @@ describe('containers/forms/PlanForm - Dynamic Form Activities', () => {
     const expectedConditionTextValues = wrapper
       .find('.conditions-fieldset textarea')
       .map(e => e.props().value);
+    // the names of the input fields should be indexed from zero (0)
+    expect(wrapper.find(`.triggers-fieldset input`).map(e => e.props().name)).toMatchSnapshot(
+      'Original activity trigger text input names'
+    );
+    expect(wrapper.find(`.triggers-fieldset textarea`).map(e => e.props().name)).toMatchSnapshot(
+      'Original activity trigger text textarea names'
+    );
+    expect(wrapper.find(`.conditions-fieldset textarea`).map(e => e.props().name)).toMatchSnapshot(
+      'Original activity conditions text textarea names'
+    );
+    expect(wrapper.find(`.conditions-fieldset input`).map(e => e.props().name)).toMatchSnapshot(
+      'Original activity conditions text input names'
+    );
     // lets remove one activity
     await act(async () => {
       wrapper
@@ -1417,6 +1430,19 @@ describe('containers/forms/PlanForm - Dynamic Form Activities', () => {
     // this one does not change because currently there are no conditions with an input field
     expect(wrapper.find(`.conditions-fieldset input`).map(e => e.props().value)).toEqual(
       expectedConditionInputValues
+    );
+    // the names of the input fields should STILL be indexed from zero (0)
+    expect(wrapper.find(`.triggers-fieldset input`).map(e => e.props().name)).toMatchSnapshot(
+      'Changed activity trigger text input names'
+    );
+    expect(wrapper.find(`.triggers-fieldset textarea`).map(e => e.props().name)).toMatchSnapshot(
+      'Changed activity trigger text textarea names'
+    );
+    expect(wrapper.find(`.conditions-fieldset textarea`).map(e => e.props().name)).toMatchSnapshot(
+      'Changed activity conditions text textarea names'
+    );
+    expect(wrapper.find(`.conditions-fieldset input`).map(e => e.props().name)).toMatchSnapshot(
+      'Changed activity conditions text input names'
     );
     wrapper.unmount();
   });

--- a/src/configs/env.ts
+++ b/src/configs/env.ts
@@ -395,7 +395,9 @@ export const PLAN_TYPES_ALLOWED_TO_CREATE = String(
 export type PLAN_TYPES_ALLOWED_TO_CREATE = typeof PLAN_TYPES_ALLOWED_TO_CREATE;
 
 /** list of FI reasons enabled */
-export const ENABLED_FI_REASONS = String(process.env.REACT_APP_ENABLED_FI_REASONS || '').split(',');
+export const ENABLED_FI_REASONS = String(
+  process.env.REACT_APP_ENABLED_FI_REASONS || 'Routine'
+).split(',');
 export type ENABLED_FI_REASONS = typeof ENABLED_FI_REASONS;
 
 export const NAVBAR_BRAND_IMG_SRC =


### PR DESCRIPTION
Closes: https://github.com/onaio/reveal-frontend/issues/1384

This PR fixes a few things:

- Tries and ensure that when a dynamic activity is removed the Formik `values` object is updated to reflect this
- Tries and ensure that when a dynamic activity is added the Formik `values` object is updated to reflect this
- That generated plan activity component keys are unique and try not to use array indices
-  That adding and removing dynamic activities is well tested
- Adds usage of `act()` in other (unrelated) PlanForm tests that need it