### PR TITLE
Add support for 'is_leaf_node' property

### DIFF
--- a/src/containers/pages/GenericJurisdictionReport/helpers.ts
+++ b/src/containers/pages/GenericJurisdictionReport/helpers.ts
@@ -394,11 +394,14 @@ export const getColumnsToUse: GetColumnsToUse = (
   // Determine if this is a focus area level by checking if "is_leaf_node" exists and is true
   // Otherwise use the focusAreaLevel
   // TODO: remove focusAreaLevel once we fully transition to using "is_leaf_node"
-  let isFocusArea: boolean = true;
-  if (currLevelData[0].hasOwnProperty('is_leaf_node')) {
-    isFocusArea = currLevelData[0].is_leaf_node;
-  } else {
-    isFocusArea = currLevelData[0].jurisdiction_depth >= +focusAreaLevel;
+  let isFocusArea: boolean = false;
+
+  if (currLevelData.length > 0) {
+    if (currLevelData[0].hasOwnProperty('is_leaf_node')) {
+      isFocusArea = currLevelData[0].is_leaf_node;
+    } else {
+      isFocusArea = currLevelData[0].jurisdiction_depth >= +focusAreaLevel;
+    }
   }
 
   return currLevelData && currLevelData.length > 0 && isFocusArea

--- a/src/containers/pages/GenericJurisdictionReport/helpers.ts
+++ b/src/containers/pages/GenericJurisdictionReport/helpers.ts
@@ -390,9 +390,18 @@ export const getColumnsToUse: GetColumnsToUse = (
   jurisdictionId: string | null
 ) => {
   const currLevelData = jurisdiction.filter(el => el.jurisdiction_parent_id === jurisdictionId);
-  return currLevelData &&
-    currLevelData.length > 0 &&
-    currLevelData[0].jurisdiction_depth >= +focusAreaLevel
+
+  // Determine if this is a focus area level by checking if "is_leaf_node" exists and is true
+  // Otherwise use the focusAreaLevel
+  // TODO: remove focusAreaLevel once we fully transition to using "is_leaf_node"
+  let isFocusArea: boolean = true;
+  if (currLevelData[0].hasOwnProperty('is_leaf_node')) {
+    isFocusArea = currLevelData[0].is_leaf_node;
+  } else {
+    isFocusArea = currLevelData[0].jurisdiction_depth >= +focusAreaLevel;
+  }
+
+  return currLevelData && currLevelData.length > 0 && isFocusArea
     ? get(plansTableColumns, focusAreaColumn, null)
     : get(plansTableColumns, jurisdictionColumn, null);
 };

--- a/src/containers/pages/GenericJurisdictionReport/tests/helpers.test.ts
+++ b/src/containers/pages/GenericJurisdictionReport/tests/helpers.test.ts
@@ -73,7 +73,6 @@ describe('containers/pages/IRS/JurisdictionsReport/helpers', () => {
         jurisdictionId
       )
     ).toEqual(helpers.zambiaMDALowerJurisdictions);
-
     // jurisdiction_depth of 1
     jurisdictionId = 'ecfbf048-fb7a-47d8-a12b-61bf5d2a6e7b';
     expect(
@@ -85,5 +84,31 @@ describe('containers/pages/IRS/JurisdictionsReport/helpers', () => {
         jurisdictionId
       )
     ).toEqual(helpers.zambiaMDAUpperJurisdictions);
+  });
+
+  it('getColumnsToUse: should work with "is_leaf_node"', () => {
+    const jurisdictions = superset.processData(fixtures.ZambiaJurisdictionsJSON) || [];
+    const focusAreas = superset.processData(fixtures.ZambiaFocusAreasJSON) || [];
+    const jurisdictionColumn = 'zambiaJurisdictions2019';
+    const focusAreaColumn = 'zambiaFocusArea2019';
+    // lets test cases where "is_focus_area" is defined in the data
+    expect(
+      getColumnsToUse(
+        jurisdictions.concat(focusAreas),
+        jurisdictionColumn,
+        focusAreaColumn,
+        '-1', // --> something that actually cant work if "is_focus_area" fails
+        'ee21d269-1179-4d04-aea9-900155f890cd'
+      )
+    ).toEqual(helpers.ZambiaJurisdictionsColumns);
+    expect(
+      getColumnsToUse(
+        jurisdictions.concat(focusAreas),
+        jurisdictionColumn,
+        focusAreaColumn,
+        '-1', // --> something that actually cant work if "is_focus_area" fails
+        '4bcbad9e-77cd-47df-8674-fdf0fdf2d831'
+      )
+    ).toEqual(helpers.ZambiaFocusAreasColumns);
   });
 });

--- a/src/containers/pages/IRS/JurisdictionsReport/fixtures/zambia_focus_areas.json
+++ b/src/containers/pages/IRS/JurisdictionsReport/fixtures/zambia_focus_areas.json
@@ -35,7 +35,8 @@
       "spraycov",
       "spraytarg",
       "spraysuccess",
-      "roomcov"
+      "roomcov",
+      "is_leaf_node"
     ],
     "order_by_cols": ["[\"jurisdiction_depth\", true]"],
     "adhoc_filters": [
@@ -92,6 +93,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -115,6 +117,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -138,6 +141,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -161,6 +165,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -184,6 +189,7 @@
         "spraytarg": 1.0,
         "spraysuccess": 0.8055555555555556,
         "roomcov": 0.8671875,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -207,6 +213,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -230,6 +237,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -253,6 +261,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -297,6 +306,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -341,6 +351,7 @@
         "spraytarg": 1.0,
         "spraysuccess": 1.0,
         "roomcov": 1.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -364,6 +375,7 @@
         "spraytarg": 1.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -387,6 +399,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1082,6 +1095,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1105,6 +1119,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1128,6 +1143,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1151,6 +1167,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1174,6 +1191,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1197,6 +1215,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1220,6 +1239,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1243,6 +1263,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1266,6 +1287,7 @@
         "spraytarg": 1.0,
         "spraysuccess": 0.7777777777777778,
         "roomcov": 0.9354838709677419,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1289,6 +1311,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1312,6 +1335,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1335,6 +1359,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1358,6 +1383,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1381,6 +1407,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1404,6 +1431,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1427,6 +1455,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1450,6 +1479,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1473,6 +1503,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1496,6 +1527,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1519,6 +1551,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1542,6 +1575,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1565,6 +1599,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1588,6 +1623,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1611,6 +1647,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1634,6 +1671,7 @@
         "spraytarg": 1.0,
         "spraysuccess": 0.5,
         "roomcov": 0.8636363636363636,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1657,6 +1695,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1680,6 +1719,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1703,6 +1743,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1726,6 +1767,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1749,6 +1791,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1772,6 +1815,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1795,6 +1839,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1818,6 +1863,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1841,6 +1887,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1864,6 +1911,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1887,6 +1935,7 @@
         "spraytarg": 1.0,
         "spraysuccess": 0.7157894736842105,
         "roomcov": 0.8666666666666667,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1910,6 +1959,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1933,6 +1983,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1956,6 +2007,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -1979,6 +2031,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -2002,6 +2055,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -2025,6 +2079,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -2048,6 +2103,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -2071,6 +2127,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -2094,6 +2151,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -2117,6 +2175,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -2140,6 +2199,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -2163,6 +2223,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -2186,6 +2247,7 @@
         "spraytarg": 1.0,
         "spraysuccess": 0.25,
         "roomcov": 0.5714285714285714,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -2209,6 +2271,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -2232,6 +2295,7 @@
         "spraytarg": 1.0,
         "spraysuccess": 0.875,
         "roomcov": 0.9142857142857143,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -2255,6 +2319,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -2278,6 +2343,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -2301,6 +2367,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -2324,6 +2391,7 @@
         "spraytarg": 0.0,
         "spraysuccess": 0.0,
         "roomcov": 0.0,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       },
@@ -2347,6 +2415,7 @@
         "spraytarg": 0.8,
         "spraysuccess": 0.7777777777777778,
         "roomcov": 0.8840579710144928,
+        "is_leaf_node": true,
         "notsprayed_reasons": "[\"locked\", \"locked\", \"locked\", \"locked\", \"other\"]",
         "notsprayed_reasons_counts": "{\"locked\": 13, \"refused\": 2, \"other\": 1}"
       }

--- a/src/containers/pages/IRS/JurisdictionsReport/fixtures/zambia_jurisdictions.json
+++ b/src/containers/pages/IRS/JurisdictionsReport/fixtures/zambia_jurisdictions.json
@@ -37,7 +37,8 @@
       "targstruct",
       "perctvisareaseffect",
       "spraycovtarg",
-      "roomcov"
+      "roomcov",
+      "is_leaf_node"
     ],
     "order_by_cols": ["[\"jurisdiction_depth\", true]"],
     "adhoc_filters": [
@@ -95,6 +96,7 @@
         "targstruct": 101,
         "perctvisareaseffect": 0.5555555555555556,
         "spraycovtarg": 0.7125,
+        "is_leaf_node": false,
         "roomcov": 0.9030544488711819,
         "spraysuccess": 0.74,
         "foundcoverage": 0.5,
@@ -121,6 +123,7 @@
         "targstruct": 10,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -147,6 +150,7 @@
         "targstruct": 0,
         "perctvisareaseffect": 0,
         "spraycovtarg": 0,
+        "is_leaf_node": false,
         "roomcov": 0
       },
       {
@@ -170,6 +174,7 @@
         "targstruct": 21,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -193,6 +198,7 @@
         "targstruct": 10,
         "perctvisareaseffect": 3.0,
         "spraycovtarg": 0.6111111111111112,
+        "is_leaf_node": false,
         "roomcov": 0.8787878787878788
       },
       {
@@ -216,6 +222,7 @@
         "targstruct": 25,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -239,6 +246,7 @@
         "targstruct": 30,
         "perctvisareaseffect": 0.4,
         "spraycovtarg": 0.740909090909091,
+        "is_leaf_node": false,
         "roomcov": 0.93646408839779
       },
       {
@@ -262,6 +270,7 @@
         "targstruct": 5,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.6942148760330579,
+        "is_leaf_node": false,
         "roomcov": 0.8718291054739653
       },
       {
@@ -285,6 +294,7 @@
         "targstruct": 5,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -308,6 +318,7 @@
         "targstruct": 5,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -331,6 +342,7 @@
         "targstruct": 4,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -354,6 +366,7 @@
         "targstruct": 3,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -377,6 +390,7 @@
         "targstruct": 5,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -400,6 +414,7 @@
         "targstruct": 15,
         "perctvisareaseffect": 0.5,
         "spraycovtarg": 0.782608695652174,
+        "is_leaf_node": false,
         "roomcov": 0.9451476793248945
       },
       {
@@ -423,6 +438,7 @@
         "targstruct": 5,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -446,6 +462,7 @@
         "targstruct": 5,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -469,6 +486,7 @@
         "targstruct": 4,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -492,6 +510,7 @@
         "targstruct": 5,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.6942148760330579,
+        "is_leaf_node": false,
         "roomcov": 0.8718291054739653
       },
       {
@@ -515,6 +534,7 @@
         "targstruct": 3,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -538,6 +558,7 @@
         "targstruct": 5,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -561,6 +582,7 @@
         "targstruct": 10,
         "perctvisareaseffect": 3.0,
         "spraycovtarg": 0.6111111111111112,
+        "is_leaf_node": false,
         "roomcov": 0.8787878787878788,
         "visitedareas": 12
       },
@@ -585,6 +607,7 @@
         "targstruct": 3,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -608,6 +631,7 @@
         "targstruct": 5,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -631,6 +655,7 @@
         "targstruct": 5,
         "perctvisareaseffect": 1.0,
         "spraycovtarg": 0.7105263157894737,
+        "is_leaf_node": false,
         "roomcov": 0.9764705882352941
       },
       {
@@ -654,6 +679,7 @@
         "targstruct": 9,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -677,6 +703,7 @@
         "targstruct": 5,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.7333333333333333,
+        "is_leaf_node": false,
         "roomcov": 0.8836206896551724
       },
       {
@@ -700,6 +727,7 @@
         "targstruct": 7,
         "perctvisareaseffect": 2.0,
         "spraycovtarg": 0.5882352941176471,
+        "is_leaf_node": false,
         "roomcov": 0.8709677419354839,
         "visitedareas": 33,
         "foundcoverage": 0.8,
@@ -726,6 +754,7 @@
         "targstruct": 4,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 1.0,
+        "is_leaf_node": false,
         "roomcov": 1.0
       },
       {
@@ -749,6 +778,7 @@
         "targstruct": 5,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -772,6 +802,7 @@
         "targstruct": 5,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -795,6 +826,7 @@
         "targstruct": 5,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.7333333333333333,
+        "is_leaf_node": false,
         "roomcov": 0.8836206896551724
       },
       {
@@ -818,6 +850,7 @@
         "targstruct": 1,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -841,6 +874,7 @@
         "targstruct": 2,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -864,6 +898,7 @@
         "targstruct": 1,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -887,6 +922,7 @@
         "targstruct": 3,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -910,6 +946,7 @@
         "targstruct": 4,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -933,6 +970,7 @@
         "targstruct": 3,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.6942148760330579,
+        "is_leaf_node": false,
         "roomcov": 0.8718291054739653
       },
       {
@@ -956,6 +994,7 @@
         "targstruct": 3,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -979,6 +1018,7 @@
         "targstruct": 3,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -1002,6 +1042,7 @@
         "targstruct": 1,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.6811594202898551,
+        "is_leaf_node": false,
         "roomcov": 0.9744680851063829
       },
       {
@@ -1025,6 +1066,7 @@
         "targstruct": 1,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -1048,6 +1090,7 @@
         "targstruct": 4,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -1071,6 +1114,7 @@
         "targstruct": 3,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -1094,6 +1138,7 @@
         "targstruct": 3,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 1.0,
+        "is_leaf_node": false,
         "roomcov": 1.0
       },
       {
@@ -1117,6 +1162,7 @@
         "targstruct": 3,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -1140,6 +1186,7 @@
         "targstruct": 1,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -1163,6 +1210,7 @@
         "targstruct": 2,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -1186,6 +1234,7 @@
         "targstruct": 2,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -1209,6 +1258,7 @@
         "targstruct": 1,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -1232,6 +1282,7 @@
         "targstruct": 4,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -1255,6 +1306,7 @@
         "targstruct": 1,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -1278,6 +1330,7 @@
         "targstruct": 5,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -1301,6 +1354,7 @@
         "targstruct": 9,
         "perctvisareaseffect": 0.0,
         "spraycovtarg": 0.0,
+        "is_leaf_node": false,
         "roomcov": 0.0
       },
       {
@@ -1324,6 +1378,7 @@
         "targstruct": 15,
         "perctvisareaseffect": 0.5,
         "spraycovtarg": 0.782608695652174,
+        "is_leaf_node": false,
         "roomcov": 0.9451476793248945
       }
     ],

--- a/src/store/ducks/generic/jurisdictions.ts
+++ b/src/store/ducks/generic/jurisdictions.ts
@@ -9,6 +9,7 @@ export const reducerName = 'GenericJurisdictions';
 /** GenericJurisdiction interface */
 export interface GenericJurisdiction {
   id: string;
+  is_leaf_node: boolean;
   is_virtual_jurisdiction?: boolean;
   jurisdiction_depth: number;
   jurisdiction_id: string;


### PR DESCRIPTION
Adding the ability to detect focus areas in the jurisdiction report tables using the "is_leaf_node" property.  Backwards compatibility is maintained so that reports continue to work when this property is missing.

Finally fixes: #1395 