### PR TITLE
Fix endless loading on FI reports

### DIFF
--- a/src/configs/lang.ts
+++ b/src/configs/lang.ts
@@ -915,3 +915,7 @@ export const JURISDICTION_NOT_FOUND = translate(
   'JURISDICTION_NOT_FOUND',
   'Map failed to load: Jurisdiction not found'
 );
+export const PLAN_OR_JURISDICTION_NOT_FOUND = translate(
+  'PLAN_OR_JURISDICTION_NOT_FOUND',
+  'Plan or Jurisdiction not found'
+);

--- a/src/containers/pages/FocusInvestigation/map/active/index.tsx
+++ b/src/containers/pages/FocusInvestigation/map/active/index.tsx
@@ -178,13 +178,14 @@ export const defaultMapSingleFIProps: MapSingleFIProps = {
 
 /** Map View for Single Active Focus Investigation */
 const SingleActiveFIMap = (props: MapSingleFIProps & RouteComponentProps<RouteParams>) => {
-  const [isLoading, setIsLoading] = React.useState(true);
+  const [isLoading, setIsLoading] = React.useState(false);
 
   React.useEffect(() => {
     if (!props.plan) {
       /**
        * Fetch plans incase the plan is not available e.g when page is refreshed
        */
+      setIsLoading(true);
       const { supersetService, fetchPlansActionCreator, match } = props;
       if (match.params.id) {
         supersetFIPlansParamFilters.push({

--- a/src/containers/pages/FocusInvestigation/map/active/tests/index.test.tsx
+++ b/src/containers/pages/FocusInvestigation/map/active/tests/index.test.tsx
@@ -1,4 +1,5 @@
 import superset from '@onaio/superset-connector';
+import { act } from '@testing-library/react';
 import { mount, shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import flushPromises from 'flush-promises';
@@ -92,7 +93,7 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
     );
   });
 
-  it('renders SingleActiveFimap correctly & changes page title', () => {
+  it('renders SingleActiveFimap correctly & changes page title', async () => {
     const mock: any = jest.fn();
     const supersetServiceMock: any = jest.fn(async () => []);
     const props = {
@@ -118,6 +119,10 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
         <SingleActiveFIMap {...props} />
       </Router>
     );
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
 
     // what is passed as the document page title text
     const helmet = Helmet.peek();
@@ -153,7 +158,7 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
     wrapper.unmount();
   });
 
-  it('works with redux store (gisidawrapper component that loads jurisdiction without structures and tasks)', () => {
+  it('works with redux store (gisidawrapper component that loads jurisdiction without structures and tasks)', async () => {
     const mock: any = jest.fn();
     const supersetServiceMock: any = jest.fn(async () => []);
     store.dispatch(fetchGoals([fixtures.goal3 as goalDucks.Goal]));
@@ -181,7 +186,10 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
         </Router>
       </Provider>
     );
-    wrapper.update();
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
 
     // case confirmation activity link si not clickable
     expect(wrapper.find(CASE_CONFIRMATION_GOAL_ID)).toMatchSnapshot('Should not be clickable tag');
@@ -214,7 +222,7 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
     wrapper.unmount();
   });
 
-  it('works correctly with Redux store when there is just one goal', () => {
+  it('works correctly with Redux store when there is just one goal', async () => {
     const mock: any = jest.fn();
     const supersetServiceMock: any = jest.fn(async () => []);
     store.dispatch(fetchGoals(processedOneGoalGoals));
@@ -240,7 +248,10 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
         </Router>
       </Provider>
     );
-    wrapper.update();
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
 
     const mapProps = wrapper.find('MemoizedGisidaLiteMock').props();
     expect((mapProps as any).mapCenter).toEqual([99.36859975, 11.33824805]);
@@ -388,7 +399,9 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
       ['123', jurisdictionParams],
     ];
 
-    await flushPromises();
+    await act(async () => {
+      await flushPromises();
+    });
     expect(supersetServiceMock.mock.calls).toEqual(callList);
     expect(supersetServiceMock).toHaveBeenCalledTimes(7);
     expect((superset.getFormData as any).mock.calls).toEqual(getformDataCallList);
@@ -412,7 +425,9 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
         </Router>
       </Provider>
     );
-    await new Promise<unknown>(resolve => setImmediate(resolve));
+    await act(async () => {
+      await new Promise<unknown>(resolve => setImmediate(resolve));
+    });
     expect(supersetServiceMock.mock.calls.length).toEqual(1);
     wrapper.unmount();
   });
@@ -437,12 +452,14 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
         </Router>
       </Provider>
     );
-    await new Promise<unknown>(resolve => setImmediate(resolve));
+    await act(async () => {
+      await new Promise<unknown>(resolve => setImmediate(resolve));
+    });
     expect(supersetServiceMock.mock.calls.length).toEqual(7);
     wrapper.unmount();
   });
 
-  it('displays the correct badge and mark complete when plan status is active', () => {
+  it('displays the correct badge and mark complete when plan status is active', async () => {
     const mock: any = jest.fn();
     const supersetServiceMock: any = jest.fn(async () => []);
     const props = {
@@ -468,12 +485,16 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
         <SingleActiveFIMap {...props} />
       </Router>
     );
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
     expect(wrapper.find('Badge').prop('color')).toEqual('warning');
     expect(toJson(wrapper.find('MarkCompleteLink'))).toMatchSnapshot('mark complete link');
     wrapper.unmount();
   });
 
-  it('displays the correct badge and mark complete link when the plan status is draft', () => {
+  it('displays the correct badge and mark complete link when the plan status is draft', async () => {
     const mock: any = jest.fn();
     const supersetServiceMock: any = jest.fn(async () => []);
     const props = {
@@ -499,12 +520,16 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
         <SingleActiveFIMap {...props} />
       </Router>
     );
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
     expect(wrapper.find('Badge').prop('color')).toEqual('warning');
     expect(wrapper.find('MarkCompleteLink').isEmptyRender()).toBe(true);
     wrapper.unmount();
   });
 
-  it('displays the correct badge and mark complete link when the plan status is complete', () => {
+  it('displays the correct badge and mark complete link when the plan status is complete', async () => {
     const mock: any = jest.fn();
     const supersetServiceMock: any = jest.fn(async () => []);
     const props = {
@@ -530,12 +555,16 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
         <SingleActiveFIMap {...props} />
       </Router>
     );
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
     expect(wrapper.find('Badge').prop('color')).toEqual('success');
     expect(wrapper.find('MarkCompleteLink').isEmptyRender()).toBe(true);
     wrapper.unmount();
   });
 
-  it('renders correct detail view when plan focus investigation reason is routine', () => {
+  it('renders correct detail view when plan focus investigation reason is routine', async () => {
     const mock: any = jest.fn();
     const supersetServiceMock: any = jest.fn(async () => []);
     const props = {
@@ -561,6 +590,10 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
         <SingleActiveFIMap {...props} />
       </Router>
     );
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
     expect(
       toJson(
         wrapper
@@ -572,7 +605,7 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
     wrapper.unmount();
   });
 
-  it('renders correct detail view when plan focus investigation reason is case triggered', () => {
+  it('renders correct detail view when plan focus investigation reason is case triggered', async () => {
     const mock: any = jest.fn();
     const supersetServiceMock: any = jest.fn(async () => []);
     const props = {
@@ -598,6 +631,10 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
         <SingleActiveFIMap {...props} />
       </Router>
     );
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
     expect(
       toJson(
         wrapper
@@ -699,7 +736,9 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
         </Router>
       </Provider>
     );
-    await new Promise<unknown>(resolve => setImmediate(resolve));
+    await act(async () => {
+      await new Promise<unknown>(resolve => setImmediate(resolve));
+    });
     expect(displayErrorMock).toHaveBeenCalledTimes(7);
     wrapper.unmount();
   });
@@ -726,7 +765,9 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
         </Router>
       </Provider>
     );
-    await new Promise<unknown>(resolve => setImmediate(resolve));
+    await act(async () => {
+      await new Promise<unknown>(resolve => setImmediate(resolve));
+    });
     expect(displayErrorMock).toHaveBeenCalledTimes(1);
     expect(displayErrorMock).toHaveBeenCalledWith(new Error(AN_ERROR_OCCURRED));
     wrapper.unmount();
@@ -736,7 +777,7 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
    * @todo Investigate why this test case that contains jest.spyon is leading to failure of other tests
    * above. It is intentionally put at the end to eliminate this
    */
-  it('selectors get called with correct arguments', () => {
+  it('selectors get called with correct arguments', async () => {
     // spy on the selectors
     const planByIdMock = jest.spyOn(planDucks, 'getPlanById');
     const currentGoalMock = jest.spyOn(goalDucks, 'getCurrentGoal');
@@ -772,6 +813,9 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
         </Router>
       </Provider>
     );
+    await act(async () => {
+      await flushPromises();
+    });
 
     // define expected results
     const planByIdExpected = [fixturesMap.existingState, 'ed2b4b7c-3388-53d9-b9f6-6a19d1ffde1f'];

--- a/src/containers/pages/FocusInvestigation/map/active/tests/index.test.tsx
+++ b/src/containers/pages/FocusInvestigation/map/active/tests/index.test.tsx
@@ -773,6 +773,34 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
     wrapper.unmount();
   });
 
+  it('should show error page when no plans or jurisdictions', async () => {
+    const supersetServiceMock: any = jest.fn(async () => []);
+    const props = {
+      match: {
+        isExact: true,
+        params: { id: fixtures.plan1.id },
+      },
+      plan: null,
+      supersetService: supersetServiceMock,
+    };
+    const wrapper = mount(
+      <Provider store={store}>
+        <Router history={history}>
+          <ConnectedMapSingleFI {...props} />
+        </Router>
+      </Provider>
+    );
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+    expect(wrapper.find('ErrorPage').length).toBeTruthy();
+    expect(wrapper.find('ErrorPage').text()).toMatchInlineSnapshot(
+      `"An error ocurred. Please try and refresh the page.The specific error is: Plan or Jurisdiction not found"`
+    );
+    wrapper.unmount();
+  });
+
   /**
    * @todo Investigate why this test case that contains jest.spyon is leading to failure of other tests
    * above. It is intentionally put at the end to eliminate this

--- a/src/containers/pages/FocusInvestigation/map/active/tests/indexCases.test.tsx
+++ b/src/containers/pages/FocusInvestigation/map/active/tests/indexCases.test.tsx
@@ -312,7 +312,7 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
     expect(wrapper.find('GisidaLite').text()).toEqual('Map is in the box');
   });
 
-  it('displays loader if plan not found', async () => {
+  it('displays error page if plan not found', async () => {
     // use dispatch
     store.dispatch(fetchPlans([]));
     store.dispatch(fetchJurisdictions(fixturesMap.processedJurisdictionJSON));
@@ -353,10 +353,14 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
     expect(componentProps.currentPolyIndexCases).toEqual(null);
     expect(componentProps.historicalPointIndexCases).toEqual(null);
     expect(componentProps.historicalPolyIndexCases).toEqual(null);
-    expect(wrapper.find('Ripple').length).toEqual(1);
+
+    expect(wrapper.find('ErrorPage').length).toBeTruthy();
+    expect(wrapper.find('ErrorPage').text()).toMatchInlineSnapshot(
+      `"An error ocurred. Please try and refresh the page.The specific error is: Plan or Jurisdiction not found"`
+    );
   });
 
-  it('displays loader if jurisdiction not found', async () => {
+  it('displays error page if jurisdiction not found', async () => {
     // use dispatch
     store.dispatch(fetchPlans(fixturesMap.processedPlansJSON));
     store.dispatch(fetchJurisdictions([]));
@@ -397,6 +401,10 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
     expect(componentProps.currentPolyIndexCases).toEqual(null);
     expect(componentProps.historicalPointIndexCases).toEqual(null);
     expect(componentProps.historicalPolyIndexCases).toEqual(null);
-    expect(wrapper.find('Ripple').length).toEqual(1);
+
+    expect(wrapper.find('ErrorPage').length).toBeTruthy();
+    expect(wrapper.find('ErrorPage').text()).toMatchInlineSnapshot(
+      `"An error ocurred. Please try and refresh the page.The specific error is: Plan or Jurisdiction not found"`
+    );
   });
 });


### PR DESCRIPTION
Closes #1406 
Prevents endless loading on FI map reports when plan or jurisdictions are not found. Instead it load the error page.