### PR TITLE
Fix IRS reports

### DIFF
--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -174,6 +174,7 @@ export const GREEN = 'Green';
 export const YELLOW = 'Yellow';
 export const ORANGE = 'Orange';
 export const RED = 'Red';
+export const INHERIT = 'inherit';
 
 // plan activity codes
 export const CASE_CONFIRMATION_ACTIVITY_CODE = 'caseConfirmation';

--- a/src/containers/pages/GenericJurisdictionReport/helpers.ts
+++ b/src/containers/pages/GenericJurisdictionReport/helpers.ts
@@ -409,7 +409,16 @@ export const getColumnsToUse: GetColumnsToUse = (
   focusAreaLevel: string,
   jurisdictionId: string | null
 ) => {
-  const currLevelData = jurisdiction.filter(el => el.jurisdiction_parent_id === jurisdictionId);
+  // we are finding the array of children jurisdictions that are not virtual
+  const currLevelData = jurisdiction.filter(el => {
+    if (el.jurisdiction_parent_id !== jurisdictionId) {
+      return false;
+    }
+    if (el.hasOwnProperty('is_virtual_jurisdiction') && el.is_virtual_jurisdiction === true) {
+      return false;
+    }
+    return true;
+  });
 
   // Determine if this is a focus area level by checking if "is_leaf_node" exists and is true
   // Otherwise use the focusAreaLevel

--- a/src/containers/pages/GenericJurisdictionReport/tests/helpers.test.ts
+++ b/src/containers/pages/GenericJurisdictionReport/tests/helpers.test.ts
@@ -1,4 +1,5 @@
 import superset from '@onaio/superset-connector';
+import { cloneDeep } from 'lodash';
 import { MDAJurisdictionsJSON } from '../../DynamicMDA/JurisdictionsReport/tests/fixtures';
 import * as fixtures from '../../IRS/JurisdictionsReport/fixtures';
 import * as helpers from '../helpers';
@@ -104,6 +105,20 @@ describe('containers/pages/IRS/JurisdictionsReport/helpers', () => {
     expect(
       getColumnsToUse(
         jurisdictions.concat(focusAreas),
+        jurisdictionColumn,
+        focusAreaColumn,
+        '-1', // --> something that actually cant work if "is_focus_area" fails
+        '4bcbad9e-77cd-47df-8674-fdf0fdf2d831'
+      )
+    ).toEqual(helpers.ZambiaFocusAreasColumns);
+    // now lets make the first record a virtual jurisdiction
+    const randomJurisdiction = cloneDeep(jurisdictions[0]);
+    randomJurisdiction.id = '1337';
+    randomJurisdiction.is_virtual_jurisdiction = true;
+    randomJurisdiction.jurisdiction_parent_id = '4bcbad9e-77cd-47df-8674-fdf0fdf2d831';
+    expect(
+      getColumnsToUse(
+        [randomJurisdiction].concat(jurisdictions.concat(focusAreas)),
         jurisdictionColumn,
         focusAreaColumn,
         '-1', // --> something that actually cant work if "is_focus_area" fails

--- a/src/helpers/indicators.tsx
+++ b/src/helpers/indicators.tsx
@@ -16,7 +16,7 @@ import {
   ORANGE_THRESHOLD,
   YELLOW_THRESHOLD,
 } from '../configs/settings';
-import { BLOOD_SCREENING_CODE, CASE_CONFIRMATION_CODE } from '../constants';
+import { BLOOD_SCREENING_CODE, CASE_CONFIRMATION_CODE, INHERIT } from '../constants';
 import { IndicatorThresholdItemPercentage, roundToPrecision } from '../helpers/utils';
 import { Goal } from '../store/ducks/goals';
 
@@ -201,11 +201,11 @@ export function getIRSThresholdAdherenceIndicator(
   // determine if cell.value is a number
   const isNumber = !Number.isNaN(Number(cell.value));
   // determine cell background color
-  const cellColor = thresholds ? getThresholdColor(cell, thresholds) : WHITE;
+  const cellColor = isNumber ? (thresholds ? getThresholdColor(cell, thresholds) : WHITE) : INHERIT;
 
   return (
     <div className="irs-report-indicator-container" style={{ backgroundColor: cellColor }}>
-      {isNumber ? IndicatorThresholdItemPercentage(cell.value) : 'NaN'}
+      {isNumber ? IndicatorThresholdItemPercentage(cell.value) : ''}
     </div>
   );
 }

--- a/src/helpers/indicators.tsx
+++ b/src/helpers/indicators.tsx
@@ -235,7 +235,7 @@ export function renderPercentage(cell: Cell) {
   // determine if cell.value is a number
   const isNumber = !Number.isNaN(Number(cell.value));
 
-  return isNumber ? percentage(cell.value, 2).value : 'NaN';
+  return isNumber ? percentage(cell.value, 2).value : '';
 }
 
 /** default drillDown CellComponent for jurisdiction reporting

--- a/src/helpers/indicators.tsx
+++ b/src/helpers/indicators.tsx
@@ -222,11 +222,11 @@ export function getIRSLiteThresholdAdherenceIndicator(
   // determine if cell.value is a number
   const isNumber = !Number.isNaN(Number(cell.value));
   // determine cell background color
-  const cellColor = thresholds ? getThresholdColor(cell, thresholds) : WHITE;
+  const cellColor = isNumber ? (thresholds ? getThresholdColor(cell, thresholds) : WHITE) : INHERIT;
 
   return (
     <div className="irs-report-indicator-container" style={{ backgroundColor: cellColor }}>
-      {isNumber ? IndicatorThresholdItemPercentage(cell.value) : 'NaN'}
+      {isNumber ? IndicatorThresholdItemPercentage(cell.value) : ''}
     </div>
   );
 }

--- a/src/helpers/indicators.tsx
+++ b/src/helpers/indicators.tsx
@@ -12,7 +12,6 @@ import {
   IndicatorThresholds,
   indicatorThresholdsIRS,
   indicatorThresholdsIRSLite,
-  irsReportingCongif,
   ORANGE_THRESHOLD,
   YELLOW_THRESHOLD,
 } from '../configs/settings';
@@ -164,29 +163,6 @@ export function getThresholdColor(
 
   // fallback to white
   return WHITE;
-}
-
-/** Renders an indicator Cell based on cell.value and threshold configs
- * @param {Cell} cell - the ReactTable.Cell being rendered in an indicator drilldown table
- * @param {string} configId - the key vause used to get the custom reporting configs
- * @returns {React.ReactElement} - the ReactTable.Cell element to be rendered for the indicator
- */
-export function getThresholdAdherenceIndicator(cell: Cell, configId: string) {
-  // determine if cell.value is a number
-  const isNumber = !Number.isNaN(Number(cell.value));
-  // get thresholds config from settings
-  const thresholds: IndicatorThresholds | null =
-    isNumber && irsReportingCongif[configId]
-      ? irsReportingCongif[configId].indicatorThresholds
-      : null;
-  // determine cell background color
-  const cellColor = thresholds ? getThresholdColor(cell, thresholds) : WHITE;
-
-  return (
-    <div className="irs-report-indicator-container" style={{ backgroundColor: cellColor }}>
-      {isNumber ? IndicatorThresholdItemPercentage(cell.value) : 'NaN'}
-    </div>
-  );
 }
 
 /** Renders an indicator Cell based on cell.value and threshold configs

--- a/src/helpers/tests/__snapshots__/indicators.test.tsx.snap
+++ b/src/helpers/tests/__snapshots__/indicators.test.tsx.snap
@@ -1,5 +1,70 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`helpers/indicators getIRSLiteThresholdAdherenceIndicator works: 0.11 1`] = `
+<div
+  className="irs-report-indicator-container"
+  style={
+    Object {
+      "backgroundColor": "#dddddd",
+    }
+  }
+>
+  11%
+</div>
+`;
+
+exports[`helpers/indicators getIRSLiteThresholdAdherenceIndicator works: 0.21 1`] = `
+<div
+  className="irs-report-indicator-container"
+  style={
+    Object {
+      "backgroundColor": "#FF4136",
+    }
+  }
+>
+  21%
+</div>
+`;
+
+exports[`helpers/indicators getIRSLiteThresholdAdherenceIndicator works: 0.81 1`] = `
+<div
+  className="irs-report-indicator-container"
+  style={
+    Object {
+      "backgroundColor": "#FFDC00",
+    }
+  }
+>
+  81%
+</div>
+`;
+
+exports[`helpers/indicators getIRSLiteThresholdAdherenceIndicator works: 0.91 1`] = `
+<div
+  className="irs-report-indicator-container"
+  style={
+    Object {
+      "backgroundColor": "#2ECC40",
+    }
+  }
+>
+  91%
+</div>
+`;
+
+exports[`helpers/indicators getIRSLiteThresholdAdherenceIndicator works: invalid number 1`] = `
+<div
+  className="irs-report-indicator-container"
+  style={
+    Object {
+      "backgroundColor": "inherit",
+    }
+  }
+>
+  
+</div>
+`;
+
 exports[`helpers/indicators getIRSThresholdAdherenceIndicator works: 0.11 1`] = `
 <div
   className="irs-report-indicator-container"

--- a/src/helpers/tests/__snapshots__/indicators.test.tsx.snap
+++ b/src/helpers/tests/__snapshots__/indicators.test.tsx.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`helpers/indicators getIRSThresholdAdherenceIndicator works: 0.11 1`] = `
+<div
+  className="irs-report-indicator-container"
+  style={
+    Object {
+      "backgroundColor": "#dddddd",
+    }
+  }
+>
+  11%
+</div>
+`;
+
+exports[`helpers/indicators getIRSThresholdAdherenceIndicator works: 0.21 1`] = `
+<div
+  className="irs-report-indicator-container"
+  style={
+    Object {
+      "backgroundColor": "#FF4136",
+    }
+  }
+>
+  21%
+</div>
+`;
+
+exports[`helpers/indicators getIRSThresholdAdherenceIndicator works: 0.81 1`] = `
+<div
+  className="irs-report-indicator-container"
+  style={
+    Object {
+      "backgroundColor": "#FFDC00",
+    }
+  }
+>
+  81%
+</div>
+`;
+
+exports[`helpers/indicators getIRSThresholdAdherenceIndicator works: 0.91 1`] = `
+<div
+  className="irs-report-indicator-container"
+  style={
+    Object {
+      "backgroundColor": "#2ECC40",
+    }
+  }
+>
+  91%
+</div>
+`;
+
+exports[`helpers/indicators getIRSThresholdAdherenceIndicator works: invalid number 1`] = `
+<div
+  className="irs-report-indicator-container"
+  style={
+    Object {
+      "backgroundColor": "inherit",
+    }
+  }
+>
+  
+</div>
+`;

--- a/src/helpers/tests/indicators.test.tsx
+++ b/src/helpers/tests/indicators.test.tsx
@@ -4,7 +4,12 @@ import { PERSONS, STRUCTURES } from '../../configs/lang';
 import { indicatorThresholdsIRS } from '../../configs/settings';
 import { Goal } from '../../store/ducks/goals';
 import * as fixtures from '../../store/ducks/tests/fixtures';
-import { getGoalReport, getIRSThresholdAdherenceIndicator, goalRatioAchieved } from '../indicators';
+import {
+  getGoalReport,
+  getIRSThresholdAdherenceIndicator,
+  goalRatioAchieved,
+  renderPercentage,
+} from '../indicators';
 
 describe('helpers/indicators', () => {
   it('goalPercentAchieved works', () => {
@@ -128,5 +133,12 @@ describe('helpers/indicators', () => {
     expect(
       getIRSThresholdAdherenceIndicator({ value: ':)' } as Cell, indicatorThresholdsIRS)
     ).toMatchSnapshot('invalid number');
+  });
+
+  it('renderPercentage works', () => {
+    expect(renderPercentage({ value: 0.91 } as Cell)).toEqual('91.00%');
+    expect(renderPercentage({ value: 0.176666666 } as Cell)).toEqual('17.67%');
+    expect(renderPercentage({ value: 1333.37 } as Cell)).toEqual('133337.00%');
+    expect(renderPercentage({ value: 'mosh' } as Cell)).toEqual('');
   });
 });

--- a/src/helpers/tests/indicators.test.tsx
+++ b/src/helpers/tests/indicators.test.tsx
@@ -1,8 +1,10 @@
 import { map } from 'lodash';
+import { Cell } from 'react-table';
 import { PERSONS, STRUCTURES } from '../../configs/lang';
+import { indicatorThresholdsIRS } from '../../configs/settings';
 import { Goal } from '../../store/ducks/goals';
 import * as fixtures from '../../store/ducks/tests/fixtures';
-import { getGoalReport, goalRatioAchieved } from '../indicators';
+import { getGoalReport, getIRSThresholdAdherenceIndicator, goalRatioAchieved } from '../indicators';
 
 describe('helpers/indicators', () => {
   it('goalPercentAchieved works', () => {
@@ -108,5 +110,23 @@ describe('helpers/indicators', () => {
       prettyPercentAchieved: '60%',
       targetValue: 5,
     });
+  });
+
+  it('getIRSThresholdAdherenceIndicator works', () => {
+    expect(
+      getIRSThresholdAdherenceIndicator({ value: 0.91 } as Cell, indicatorThresholdsIRS)
+    ).toMatchSnapshot('0.91');
+    expect(
+      getIRSThresholdAdherenceIndicator({ value: 0.81 } as Cell, indicatorThresholdsIRS)
+    ).toMatchSnapshot('0.81');
+    expect(
+      getIRSThresholdAdherenceIndicator({ value: 0.21 } as Cell, indicatorThresholdsIRS)
+    ).toMatchSnapshot('0.21');
+    expect(
+      getIRSThresholdAdherenceIndicator({ value: 0.11 } as Cell, indicatorThresholdsIRS)
+    ).toMatchSnapshot('0.11');
+    expect(
+      getIRSThresholdAdherenceIndicator({ value: ':)' } as Cell, indicatorThresholdsIRS)
+    ).toMatchSnapshot('invalid number');
   });
 });

--- a/src/helpers/tests/indicators.test.tsx
+++ b/src/helpers/tests/indicators.test.tsx
@@ -6,6 +6,7 @@ import { Goal } from '../../store/ducks/goals';
 import * as fixtures from '../../store/ducks/tests/fixtures';
 import {
   getGoalReport,
+  getIRSLiteThresholdAdherenceIndicator,
   getIRSThresholdAdherenceIndicator,
   goalRatioAchieved,
   renderPercentage,
@@ -132,6 +133,24 @@ describe('helpers/indicators', () => {
     ).toMatchSnapshot('0.11');
     expect(
       getIRSThresholdAdherenceIndicator({ value: ':)' } as Cell, indicatorThresholdsIRS)
+    ).toMatchSnapshot('invalid number');
+  });
+
+  it('getIRSLiteThresholdAdherenceIndicator works', () => {
+    expect(
+      getIRSLiteThresholdAdherenceIndicator({ value: 0.91 } as Cell, indicatorThresholdsIRS)
+    ).toMatchSnapshot('0.91');
+    expect(
+      getIRSLiteThresholdAdherenceIndicator({ value: 0.81 } as Cell, indicatorThresholdsIRS)
+    ).toMatchSnapshot('0.81');
+    expect(
+      getIRSLiteThresholdAdherenceIndicator({ value: 0.21 } as Cell, indicatorThresholdsIRS)
+    ).toMatchSnapshot('0.21');
+    expect(
+      getIRSLiteThresholdAdherenceIndicator({ value: 0.11 } as Cell, indicatorThresholdsIRS)
+    ).toMatchSnapshot('0.11');
+    expect(
+      getIRSLiteThresholdAdherenceIndicator({ value: ':)' } as Cell, indicatorThresholdsIRS)
     ).toMatchSnapshot('invalid number');
   });
 


### PR DESCRIPTION
This PR does the following:

- At last, fixes: #1430 by ensuring `getColumnsToUse` does not get confused by virtual jurisdictions
- Ensures indicator helper functions do not return `NaN`.  In cases where the output is invalid, they now return nothing.
- Adds tests for indicator helper functions
- Removes `getThresholdAdherenceIndicator` as this is dead code