### PR TITLE
Fix endless loading on irs map

### DIFF
--- a/src/components/GisidaLite/helpers.tsx
+++ b/src/components/GisidaLite/helpers.tsx
@@ -1,6 +1,10 @@
+import { viewport } from '@mapbox/geo-viewport';
+import GeojsonExtent from '@mapbox/geojson-extent';
 import { center as turfCenter, FeatureCollection as TurfFeatureCollection } from '@turf/turf';
 import { Style } from 'mapbox-gl';
 import { DIGITAL_GLOBE_CONNECT_ID } from '../../configs/env';
+import { StructureFeatureCollection } from '../../store/ducks/generic/structures';
+import { Jurisdiction } from '../../store/ducks/jurisdictions';
 
 /** Get the centre coordinates from a feature collection */
 export const getCenter = (fc: TurfFeatureCollection): [number, number] | undefined => {
@@ -90,3 +94,34 @@ export const gsLiteStyle: Style | string = DIGITAL_GLOBE_CONNECT_ID
       version: 8,
     }
   : 'mapbox://styles/mapbox/satellite-v9';
+
+/**
+ * gets map zoom, center and bounds form structures or jurisdictions
+ * @param {StructureFeatureCollection | null} structures - structure points
+ * @param {Jurisdiction | null} jurisdiction - jurisdiction
+ */
+export const getZoomCenterAndBounds = (
+  structures: StructureFeatureCollection | null,
+  jurisdiction: Jurisdiction | null
+) => {
+  let mapCenter;
+  let mapBounds;
+  let zoom;
+  if (structures?.features?.length) {
+    mapBounds = GeojsonExtent(structures);
+  }
+  if (!mapBounds && jurisdiction?.geojson) {
+    mapBounds = GeojsonExtent(jurisdiction.geojson);
+  }
+  // get map zoom and center values
+  if (mapBounds) {
+    const centerAndZoom = viewport(mapBounds, [600, 400]);
+    mapCenter = centerAndZoom.center;
+    zoom = centerAndZoom.zoom;
+  }
+  return {
+    mapBounds,
+    mapCenter,
+    zoom,
+  };
+};

--- a/src/components/GisidaLite/helpers.tsx
+++ b/src/components/GisidaLite/helpers.tsx
@@ -99,10 +99,12 @@ export const gsLiteStyle: Style | string = DIGITAL_GLOBE_CONNECT_ID
  * gets map zoom, center and bounds form structures or jurisdictions
  * @param {StructureFeatureCollection | null} structures - structure points
  * @param {Jurisdiction | null} jurisdiction - jurisdiction
+ * @param {[number, number]} dimensions - map dimensions
  */
 export const getZoomCenterAndBounds = (
   structures: StructureFeatureCollection | null,
-  jurisdiction: Jurisdiction | null
+  jurisdiction: Jurisdiction | null,
+  dimensions: [number, number]
 ) => {
   let mapCenter;
   let mapBounds;
@@ -115,7 +117,7 @@ export const getZoomCenterAndBounds = (
   }
   // get map zoom and center values
   if (mapBounds) {
-    const centerAndZoom = viewport(mapBounds, [600, 400]);
+    const centerAndZoom = viewport(mapBounds, dimensions);
     mapCenter = centerAndZoom.center;
     zoom = centerAndZoom.zoom;
   }

--- a/src/components/GisidaLite/index.tsx
+++ b/src/components/GisidaLite/index.tsx
@@ -5,9 +5,10 @@ import React, { Fragment, useEffect } from 'react';
 import ReactMapboxGl, { ZoomControl } from 'react-mapbox-gl';
 import { FitBounds, Props } from 'react-mapbox-gl/lib/map';
 import { Events } from 'react-mapbox-gl/lib/map-events';
-import Loading from '../../components/page/Loading';
 import { GISIDA_MAPBOX_TOKEN } from '../../configs/env';
+import { ERROR_LOADING_ITEMS } from '../../configs/lang';
 import { imgArr } from '../../configs/settings';
+import { ErrorPage } from '../page/ErrorPage';
 import { gsLiteStyle } from './helpers';
 
 /** single map icon description */
@@ -115,7 +116,7 @@ const GisidaLite = (props: GisidaLiteProps) => {
   }, [layers]);
 
   if (mapCenter === undefined) {
-    return <Loading />;
+    return <ErrorPage errorMessage={ERROR_LOADING_ITEMS} />;
   }
 
   /**

--- a/src/configs/lang.ts
+++ b/src/configs/lang.ts
@@ -92,7 +92,7 @@ export const SIGN_OUT = translate('SIGN_OUT', 'Sign Out');
 
 export const MAP_LOAD_ERROR = translate('MAP_LOAD_ERROR', 'Could not load the map');
 export const AN_ERROR_OCCURRED = translate('AN_ERROR_OCCURRED', 'An Error Ocurred');
-export const ERROR_LOADING_ITEMS = translate('ERROR_LOADING_ITEMS', 'Error loading points on map');
+export const ERROR_LOADING_ITEMS = translate('ERROR_LOADING_ITEMS', 'Could not load points on map');
 export const PLEASE_FIX_THESE_ERRORS = translate(
   'PLEASE_FIX_THESE_ERRORS',
   'Please fix these errors'

--- a/src/configs/lang.ts
+++ b/src/configs/lang.ts
@@ -92,6 +92,7 @@ export const SIGN_OUT = translate('SIGN_OUT', 'Sign Out');
 
 export const MAP_LOAD_ERROR = translate('MAP_LOAD_ERROR', 'Could not load the map');
 export const AN_ERROR_OCCURRED = translate('AN_ERROR_OCCURRED', 'An Error Ocurred');
+export const ERROR_LOADING_ITEMS = translate('ERROR_LOADING_ITEMS', 'Error loading points on map');
 export const PLEASE_FIX_THESE_ERRORS = translate(
   'PLEASE_FIX_THESE_ERRORS',
   'Please fix these errors'

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -262,3 +262,4 @@ export const SUPERSET_ACCESS_DENIED_MESSAGE = 'Access is Denied';
 export const REACT_MAPBOX_GL_ICON_IMAGE = 'icon-image';
 export const REACT_MAPBOX_GL_ICON_SIZE = 'icon-size';
 export const CIRCLE_PAINT_COLOR_CATEGORICAL_TYPE = 'categorical';
+export const DefaultMapDimensions: [number, number] = [600, 400];

--- a/src/containers/pages/FocusInvestigation/map/active/tests/indexCases.test.tsx
+++ b/src/containers/pages/FocusInvestigation/map/active/tests/indexCases.test.tsx
@@ -249,8 +249,9 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
       wrapper.update();
     });
 
-    expect(wrapper.find('GisidaLite').find('Ripple').length).toEqual(1);
-    expect(wrapper.find('GisidaLite').text()).toEqual('');
+    expect(wrapper.find('GisidaLite').text()).toEqual(
+      'An error ocurred. Please try and refresh the page.The specific error is: Error loading points on map'
+    );
   });
 
   it('displays map if only plans and jurisdiction available', async () => {

--- a/src/containers/pages/FocusInvestigation/map/active/tests/indexCases.test.tsx
+++ b/src/containers/pages/FocusInvestigation/map/active/tests/indexCases.test.tsx
@@ -250,7 +250,7 @@ describe('containers/pages/FocusInvestigation/activeMap', () => {
     });
 
     expect(wrapper.find('GisidaLite').text()).toEqual(
-      'An error ocurred. Please try and refresh the page.The specific error is: Error loading points on map'
+      'An error ocurred. Please try and refresh the page.The specific error is: Could not load points on map'
     );
   });
 

--- a/src/containers/pages/IRS/Map/index.tsx
+++ b/src/containers/pages/IRS/Map/index.tsx
@@ -1,5 +1,3 @@
-import { viewport } from '@mapbox/geo-viewport';
-import GeojsonExtent from '@mapbox/geojson-extent';
 import { ProgressBar } from '@onaio/progress-indicators';
 import reducerRegistry from '@onaio/redux-reducer-registry';
 import superset, { SupersetFormData } from '@onaio/superset-connector';
@@ -15,6 +13,7 @@ import { Col, Row } from 'reactstrap';
 import { Store } from 'redux';
 import { format } from 'util';
 import { MemoizedGisidaLite } from '../../../../components/GisidaLite';
+import { getZoomCenterAndBounds } from '../../../../components/GisidaLite/helpers';
 import NotFound from '../../../../components/NotFound';
 import { ErrorPage } from '../../../../components/page/ErrorPage';
 import HeaderBreadcrumb from '../../../../components/page/HeaderBreadcrumb/HeaderBreadcrumb';
@@ -311,16 +310,8 @@ const IRSReportingMap = (props: IRSReportingMapProps & RouteComponentProps<Route
     return typeof dict === 'string' ? createList(JSON.parse(dict)) : createList(dict);
   };
 
-  let mapCenter;
-  let mapBounds;
-  let zoom;
-  if (structures && structures.features.length) {
-    mapBounds = GeojsonExtent(structures);
-    // get map zoom and center values
-    const centerAndZoom = viewport(mapBounds, [600, 400]);
-    mapCenter = centerAndZoom.center;
-    zoom = centerAndZoom.zoom;
-  }
+  // get map zoom, center and bounds
+  const { zoom, mapBounds, mapCenter } = getZoomCenterAndBounds(structures, jurisdiction);
 
   // define circle paint colors
   const circleColor: CircleColor = {

--- a/src/containers/pages/IRS/Map/index.tsx
+++ b/src/containers/pages/IRS/Map/index.tsx
@@ -44,6 +44,7 @@ import { indicatorThresholdsIRS } from '../../../../configs/settings';
 import {
   BUSINESS_STATUS,
   CIRCLE_PAINT_COLOR_CATEGORICAL_TYPE,
+  DefaultMapDimensions,
   HOME_URL,
   IRS_REPORT_STRUCTURES,
   MULTI_POLYGON,
@@ -311,7 +312,11 @@ const IRSReportingMap = (props: IRSReportingMapProps & RouteComponentProps<Route
   };
 
   // get map zoom, center and bounds
-  const { zoom, mapBounds, mapCenter } = getZoomCenterAndBounds(structures, jurisdiction);
+  const { zoom, mapBounds, mapCenter } = getZoomCenterAndBounds(
+    structures,
+    jurisdiction,
+    DefaultMapDimensions
+  );
 
   // define circle paint colors
   const circleColor: CircleColor = {

--- a/src/containers/pages/IRS/Map/tests/index.test.tsx
+++ b/src/containers/pages/IRS/Map/tests/index.test.tsx
@@ -10,6 +10,7 @@ import { act } from 'react-dom/test-utils';
 import { Helmet } from 'react-helmet';
 import { Router } from 'react-router';
 import { IRSReportingMap } from '../';
+import { GisidaLiteProps } from '../../../../../components/GisidaLite';
 import { JURISDICTION_NOT_FOUND, PLAN_NOT_FOUND } from '../../../../../configs/lang';
 import { MAP, MULTI_POLYGON, POINT, POLYGON, REPORT_IRS_PLAN_URL } from '../../../../../constants';
 import * as errors from '../../../../../helpers/errors';
@@ -586,6 +587,70 @@ describe('components/IRS Reports/IRSReportingMap', () => {
       [new Error(JURISDICTION_NOT_FOUND)],
       [new Error(JURISDICTION_NOT_FOUND)],
       [new Error(PLAN_NOT_FOUND)],
+    ]);
+  });
+
+  it('renders map without structures', async () => {
+    fetch.mockResponseOnce(JSON.stringify({}));
+    const mock: any = jest.fn();
+
+    const supersetServiceMock: any = jest.fn();
+    supersetServiceMock.mockImplementation(async () => []);
+
+    const focusArea = getGenericJurisdictionByJurisdictionId(
+      store.getState(),
+      'zm-focusAreas',
+      '0dc2d15b-be1d-45d3-93d8-043a3a916f30'
+    );
+
+    const jurisdiction: any = getJurisdictionById(
+      store.getState(),
+      '0dc2d15b-be1d-45d3-93d8-043a3a916f30'
+    );
+
+    const props = {
+      focusArea,
+      history,
+      jurisdiction,
+      location: mock,
+      match: {
+        isExact: true,
+        params: {
+          jurisdictionId: '0dc2d15b-be1d-45d3-93d8-043a3a916f30',
+          planId: (plans[0] as GenericPlan).plan_id,
+        },
+        path: `${REPORT_IRS_PLAN_URL}/:planId/:jurisdictionId/${MAP}`,
+        url: `${REPORT_IRS_PLAN_URL}/${
+          (plans[0] as GenericPlan).plan_id
+        }/0dc2d15b-be1d-45d3-93d8-043a3a916f30/${MAP}`,
+      },
+      plan: plans[0] as GenericPlan,
+      service: supersetServiceMock,
+      structures: null,
+    };
+    const wrapper = mount(
+      <Router history={history}>
+        <IRSReportingMap {...props} />
+      </Router>
+    );
+    await act(async () => {
+      await flushPromises();
+    });
+    wrapper.update();
+    const helmet = Helmet.peek();
+    expect(helmet.title).toEqual('IRS 2019-09-05 TEST: Akros_1');
+    // map zoom, mapCenter and Bounds are generated without structures
+    expect(wrapper.find('MemoizedGisidaLiteMock').length).toEqual(1);
+    expect((wrapper.find('MemoizedGisidaLiteMock').props() as GisidaLiteProps).zoom).toEqual(17);
+    expect((wrapper.find('MemoizedGisidaLiteMock').props() as GisidaLiteProps).mapCenter).toEqual([
+      28.3515494577913,
+      -15.418937262794401,
+    ]);
+    expect((wrapper.find('MemoizedGisidaLiteMock').props() as GisidaLiteProps).mapBounds).toEqual([
+      28.3506141678096,
+      -15.42025398943,
+      28.352484747773,
+      -15.4176205361588,
     ]);
   });
 });

--- a/src/containers/pages/IRS/Map/tests/namibia_configs.test.tsx
+++ b/src/containers/pages/IRS/Map/tests/namibia_configs.test.tsx
@@ -33,6 +33,12 @@ import * as fixtures from '../../JurisdictionsReport/fixtures';
 
 /* tslint:disable-next-line no-var-requires */
 const fetch = require('jest-fetch-mock');
+jest.mock('../../../../../components/GisidaLite', () => {
+  const MemoizedGisidaLiteMock = () => <div>Mock component</div>;
+  return {
+    MemoizedGisidaLite: MemoizedGisidaLiteMock,
+  };
+});
 
 jest.mock('../../../../../configs/env', () => ({
   GISIDA_MAPBOX_TOKEN: 'hunter2',

--- a/src/containers/pages/IRSLite/MapLite/index.tsx
+++ b/src/containers/pages/IRSLite/MapLite/index.tsx
@@ -40,6 +40,7 @@ import { indicatorThresholdsIRSLite } from '../../../../configs/settings';
 import {
   BUSINESS_STATUS,
   CIRCLE_PAINT_COLOR_CATEGORICAL_TYPE,
+  DefaultMapDimensions,
   HOME_URL,
   IRS_REPORT_STRUCTURES,
   REPORT_IRS_LITE_PLAN_URL,
@@ -292,7 +293,11 @@ const IRSLiteReportingMap = (
   };
 
   // get map zoom, center and bounds
-  const { zoom, mapBounds, mapCenter } = getZoomCenterAndBounds(structures, jurisdiction);
+  const { zoom, mapBounds, mapCenter } = getZoomCenterAndBounds(
+    structures,
+    jurisdiction,
+    DefaultMapDimensions
+  );
 
   // define polygon paint colors
   const polygonColor: PolygonColor = {

--- a/src/containers/pages/IRSLite/MapLite/index.tsx
+++ b/src/containers/pages/IRSLite/MapLite/index.tsx
@@ -1,5 +1,3 @@
-import { viewport } from '@mapbox/geo-viewport';
-import GeojsonExtent from '@mapbox/geojson-extent';
 import { ProgressBar } from '@onaio/progress-indicators';
 import reducerRegistry from '@onaio/redux-reducer-registry';
 import superset, { SupersetFormData } from '@onaio/superset-connector';
@@ -13,6 +11,7 @@ import { Col, Row } from 'reactstrap';
 import { Store } from 'redux';
 import { format } from 'util';
 import { MemoizedGisidaLite } from '../../../../components/GisidaLite';
+import { getZoomCenterAndBounds } from '../../../../components/GisidaLite/helpers';
 import NotFound from '../../../../components/NotFound';
 import { ErrorPage } from '../../../../components/page/ErrorPage';
 import HeaderBreadcrumb from '../../../../components/page/HeaderBreadcrumb/HeaderBreadcrumb';
@@ -292,16 +291,8 @@ const IRSLiteReportingMap = (
     return typeof dict === 'string' ? createList(JSON.parse(dict)) : createList(dict);
   };
 
-  let mapCenter;
-  let mapBounds;
-  let zoom;
-  if (structures && structures.features && structures.features.length) {
-    mapBounds = GeojsonExtent(structures);
-    // get map zoom and center values
-    const centerAndZoom = viewport(mapBounds, [600, 400]);
-    mapCenter = centerAndZoom.center;
-    zoom = centerAndZoom.zoom;
-  }
+  // get map zoom, center and bounds
+  const { zoom, mapBounds, mapCenter } = getZoomCenterAndBounds(structures, jurisdiction);
 
   // define polygon paint colors
   const polygonColor: PolygonColor = {


### PR DESCRIPTION
This pr fixes endless loading on the map component when there is an error on the points to be loaded. In case of an error the error page will be loaded.

Fixes #1451