### PR TITLE
Update MDA plan template and plans processing

### DIFF
--- a/src/components/forms/PlanForm/helpers.ts
+++ b/src/components/forms/PlanForm/helpers.ts
@@ -166,14 +166,59 @@ export const PlanSchema = Yup.object().shape({
   version: Yup.string(),
 });
 
+/** group plan activities */
+export const AllPlanActivities = {
+  [InterventionType.FI]: pick(planActivities, [
+    BCC_ACTIVITY_CODE,
+    BEDNET_DISTRIBUTION_ACTIVITY_CODE,
+    BLOOD_SCREENING_ACTIVITY_CODE,
+    CASE_CONFIRMATION_ACTIVITY_CODE,
+    FAMILY_REGISTRATION_ACTIVITY_CODE,
+    LARVAL_DIPPING_ACTIVITY_CODE,
+    MOSQUITO_COLLECTION_ACTIVITY_CODE,
+  ]),
+  [InterventionType.IRS]: pick(planActivities, [IRS_ACTIVITY_CODE]),
+  [InterventionType.MDA]: pick(planActivities, [
+    MDA_FAMILY_REGISTRATION,
+    MDA_DISPENSE_ACTIVITY_CODE,
+    MDA_ADHERENCE,
+  ]),
+  [InterventionType.MDAPoint]: pick(planActivities, [
+    MDA_POINT_ADVERSE_EFFECTS_ACTIVITY_CODE,
+    MDA_POINT_DISPENSE_ACTIVITY_CODE,
+  ]),
+  [InterventionType.DynamicFI]: pick(planActivities, [
+    DYNAMIC_BCC_ACTIVITY_CODE,
+    DYNAMIC_BEDNET_DISTRIBUTION_ACTIVITY_CODE,
+    DYNAMIC_BLOOD_SCREENING_ACTIVITY_CODE,
+    DYNAMIC_FAMILY_REGISTRATION_ACTIVITY_CODE,
+    DYNAMIC_LARVAL_DIPPING_ACTIVITY_CODE,
+    DYNAMIC_MOSQUITO_COLLECTION_ACTIVITY_CODE,
+  ]),
+  [InterventionType.DynamicMDA]: pick(planActivities, [
+    DYNAMIC_MDA_COMMUNITY_ADHERENCE_ACTIVITY_CODE,
+    DYNAMIC_MDA_COMMUNITY_DISPENSE_ACTIVITY_CODE,
+    DYNAMIC_FAMILY_REGISTRATION_ACTIVITY_CODE,
+  ]),
+  [InterventionType.DynamicIRS]: pick(planActivities, [DYNAMIC_IRS_ACTIVITY_CODE]),
+  [InterventionType.IRSLite]: [],
+};
+
 /**
  * Convert a plan activity object to an object that can be used in the PlanForm
  * activities section
  * @param activityObj - the plan activity object
  */
-export function extractActivityForForm(activityObj: PlanActivity): PlanActivityFormFields {
+export function extractActivityForForm(
+  activityObj: PlanActivity,
+  interventionType: InterventionType | null = null
+): PlanActivityFormFields {
+  const planActivitiesToUse = interventionType
+    ? AllPlanActivities[interventionType]
+    : planActivities;
   const planActivityKey: string =
-    findKey(planActivities, (a: PlanActivity) => a.action.code === activityObj.action.code) || '';
+    findKey(planActivitiesToUse, (a: PlanActivity) => a.action.code === activityObj.action.code) ||
+    '';
 
   const condition: PlanActivityExpression[] = [];
   if (activityObj.action.condition) {
@@ -239,43 +284,6 @@ export function extractActivityForForm(activityObj: PlanActivity): PlanActivityF
   };
 }
 
-/** group plan activities */
-export const AllPlanActivities = {
-  [InterventionType.FI]: pick(planActivities, [
-    BCC_ACTIVITY_CODE,
-    BEDNET_DISTRIBUTION_ACTIVITY_CODE,
-    BLOOD_SCREENING_ACTIVITY_CODE,
-    CASE_CONFIRMATION_ACTIVITY_CODE,
-    FAMILY_REGISTRATION_ACTIVITY_CODE,
-    LARVAL_DIPPING_ACTIVITY_CODE,
-    MOSQUITO_COLLECTION_ACTIVITY_CODE,
-  ]),
-  [InterventionType.IRS]: pick(planActivities, [IRS_ACTIVITY_CODE]),
-  [InterventionType.MDA]: pick(planActivities, [
-    MDA_FAMILY_REGISTRATION,
-    MDA_DISPENSE_ACTIVITY_CODE,
-    MDA_ADHERENCE,
-  ]),
-  [InterventionType.MDAPoint]: pick(planActivities, [
-    MDA_POINT_ADVERSE_EFFECTS_ACTIVITY_CODE,
-    MDA_POINT_DISPENSE_ACTIVITY_CODE,
-  ]),
-  [InterventionType.DynamicFI]: pick(planActivities, [
-    DYNAMIC_BCC_ACTIVITY_CODE,
-    DYNAMIC_BEDNET_DISTRIBUTION_ACTIVITY_CODE,
-    DYNAMIC_BLOOD_SCREENING_ACTIVITY_CODE,
-    DYNAMIC_FAMILY_REGISTRATION_ACTIVITY_CODE,
-    DYNAMIC_LARVAL_DIPPING_ACTIVITY_CODE,
-    DYNAMIC_MOSQUITO_COLLECTION_ACTIVITY_CODE,
-  ]),
-  [InterventionType.DynamicMDA]: pick(planActivities, [
-    DYNAMIC_MDA_COMMUNITY_ADHERENCE_ACTIVITY_CODE,
-    DYNAMIC_MDA_COMMUNITY_DISPENSE_ACTIVITY_CODE,
-    DYNAMIC_FAMILY_REGISTRATION_ACTIVITY_CODE,
-  ]),
-  [InterventionType.DynamicIRS]: pick(planActivities, [DYNAMIC_IRS_ACTIVITY_CODE]),
-  [InterventionType.IRSLite]: [],
-};
 export type FormActivity =
   | typeof AllPlanActivities[InterventionType.FI]
   | typeof AllPlanActivities[InterventionType.IRS]
@@ -289,31 +297,43 @@ export type FormActivity =
  * Converts a plan activities objects to a list of activities for use on PlanForm
  * @param items - plan activities
  */
-export function getFormActivities(items: FormActivity) {
+export function getFormActivities(
+  items: FormActivity,
+  interventionType: InterventionType | null = null
+) {
   return Object.values(items)
     .sort((a, b) => a.action.prefix - b.action.prefix)
-    .map(e => extractActivityForForm(e));
+    .map(e => extractActivityForForm(e, interventionType));
 }
 
 const planActivitiesMap: Dictionary<PlanActivityFormFields[]> = {};
 planActivitiesMap[InterventionType.IRS] = getFormActivities(
-  AllPlanActivities[InterventionType.IRS]
+  AllPlanActivities[InterventionType.IRS],
+  InterventionType.IRS
 );
-planActivitiesMap[InterventionType.FI] = getFormActivities(AllPlanActivities[InterventionType.FI]);
+planActivitiesMap[InterventionType.FI] = getFormActivities(
+  AllPlanActivities[InterventionType.FI],
+  InterventionType.FI
+);
 planActivitiesMap[InterventionType.MDA] = getFormActivities(
-  AllPlanActivities[InterventionType.MDA]
+  AllPlanActivities[InterventionType.MDA],
+  InterventionType.MDA
 );
 planActivitiesMap[InterventionType.MDAPoint] = getFormActivities(
-  AllPlanActivities[InterventionType.MDAPoint]
+  AllPlanActivities[InterventionType.MDAPoint],
+  InterventionType.MDAPoint
 );
 planActivitiesMap[InterventionType.DynamicFI] = getFormActivities(
-  AllPlanActivities[InterventionType.DynamicFI]
+  AllPlanActivities[InterventionType.DynamicFI],
+  InterventionType.DynamicFI
 );
 planActivitiesMap[InterventionType.DynamicIRS] = getFormActivities(
-  AllPlanActivities[InterventionType.DynamicIRS]
+  AllPlanActivities[InterventionType.DynamicIRS],
+  InterventionType.DynamicIRS
 );
 planActivitiesMap[InterventionType.DynamicMDA] = getFormActivities(
-  AllPlanActivities[InterventionType.DynamicMDA]
+  AllPlanActivities[InterventionType.DynamicMDA],
+  InterventionType.DynamicMDA
 );
 export { planActivitiesMap };
 
@@ -406,6 +426,19 @@ const getTriggerFromFormField = (
 };
 
 /**
+ * check if action code exists on the plans for specified intervention
+ * @param {InterventionType} interventionType - plan intervention type
+ * @param {PlanActionCodesType} actionCode - plan action code
+ */
+const interventionHasActionCode = (
+  interventionType: InterventionType,
+  actionCode: PlanActionCodesType
+) => {
+  return Object.values(AllPlanActivities[interventionType]).some(
+    item => item.action.code === actionCode
+  );
+};
+/**
  * Get action and plans from PlanForm activities
  * @param {PlanActivityFormFields[]} activities - this of activities from PlanForm
  * @param {string} planIdentifier - this plan identifier
@@ -421,7 +454,10 @@ export function extractActivitiesFromPlanForm(
 
   activities.forEach((element, index) => {
     const prefix = index + 1;
-    if (PlanActionCodes.includes(element.actionCode as PlanActionCodesType)) {
+    if (
+      PlanActionCodes.includes(element.actionCode as PlanActionCodesType) &&
+      interventionHasActionCode(interventionType, element.actionCode as PlanActionCodesType)
+    ) {
       const planActionGoal = (planObj &&
         getActivityFromPlan(planObj, element.actionCode as PlanActionCodesType)) || {
         action: {},
@@ -757,10 +793,13 @@ export function getPlanFormValues(planObject: PlanDefinition): PlanFormFields {
       const goalArray = planObject.goal.filter(goal => goal.id === currentAction.goalId);
 
       goalArray.forEach(currentGoal => {
-        const currentActivity = extractActivityForForm({
-          action: currentAction,
-          goal: currentGoal,
-        });
+        const currentActivity = extractActivityForForm(
+          {
+            action: currentAction,
+            goal: currentGoal,
+          },
+          interventionType
+        );
         accumulator.push(currentActivity);
       });
 

--- a/src/components/forms/PlanForm/helpers.ts
+++ b/src/components/forms/PlanForm/helpers.ts
@@ -370,9 +370,12 @@ export function getPlanActivityFromActionCode(
   actionCode: PlanActionCodesType,
   interventionType: InterventionType
 ): PlanActivity | null {
-  const search = Object.values(AllPlanActivities[interventionType]).filter(
-    item => item.action.code === actionCode
-  );
+  const search =
+    (AllPlanActivities[interventionType] &&
+      Object.values(AllPlanActivities[interventionType]).filter(
+        item => item.action.code === actionCode
+      )) ||
+    [];
   return search.length > 0 ? search[0] : null;
 }
 

--- a/src/components/forms/PlanForm/helpers.ts
+++ b/src/components/forms/PlanForm/helpers.ts
@@ -62,6 +62,8 @@ import {
   IRS_ACTIVITY_CODE,
   LARVAL_DIPPING_ACTIVITY_CODE,
   MDA_ADHERENCE,
+  MDA_DISPENSE_ACTIVITY_CODE,
+  MDA_FAMILY_REGISTRATION,
   MDA_POINT_ADVERSE_EFFECTS_ACTIVITY_CODE,
   MDA_POINT_DISPENSE_ACTIVITY_CODE,
   MOSQUITO_COLLECTION_ACTIVITY_CODE,
@@ -238,48 +240,50 @@ export function extractActivityForForm(activityObj: PlanActivity): PlanActivityF
 }
 
 /** group plan activities */
-export const FIActivities = pick(planActivities, [
-  BCC_ACTIVITY_CODE,
-  BEDNET_DISTRIBUTION_ACTIVITY_CODE,
-  BLOOD_SCREENING_ACTIVITY_CODE,
-  CASE_CONFIRMATION_ACTIVITY_CODE,
-  FAMILY_REGISTRATION_ACTIVITY_CODE,
-  LARVAL_DIPPING_ACTIVITY_CODE,
-  MOSQUITO_COLLECTION_ACTIVITY_CODE,
-]);
-export const IRSActivities = pick(planActivities, [IRS_ACTIVITY_CODE]);
-export const MDAActivities = pick(planActivities, [
-  FAMILY_REGISTRATION_ACTIVITY_CODE,
-  MDA_POINT_DISPENSE_ACTIVITY_CODE,
-  MDA_ADHERENCE,
-]);
-export const MDAPointActivities = pick(planActivities, [
-  MDA_POINT_ADVERSE_EFFECTS_ACTIVITY_CODE,
-  MDA_POINT_DISPENSE_ACTIVITY_CODE,
-]);
-export const DynamicFIActivities = pick(planActivities, [
-  DYNAMIC_BCC_ACTIVITY_CODE,
-  DYNAMIC_BEDNET_DISTRIBUTION_ACTIVITY_CODE,
-  DYNAMIC_BLOOD_SCREENING_ACTIVITY_CODE,
-  DYNAMIC_FAMILY_REGISTRATION_ACTIVITY_CODE,
-  DYNAMIC_LARVAL_DIPPING_ACTIVITY_CODE,
-  DYNAMIC_MOSQUITO_COLLECTION_ACTIVITY_CODE,
-]);
-export const DynamicMDAActivities = pick(planActivities, [
-  DYNAMIC_MDA_COMMUNITY_ADHERENCE_ACTIVITY_CODE,
-  DYNAMIC_MDA_COMMUNITY_DISPENSE_ACTIVITY_CODE,
-  DYNAMIC_FAMILY_REGISTRATION_ACTIVITY_CODE,
-]);
-export const DynamicIRSActivities = pick(planActivities, [DYNAMIC_IRS_ACTIVITY_CODE]);
-
+export const AllPlanActivities = {
+  [InterventionType.FI]: pick(planActivities, [
+    BCC_ACTIVITY_CODE,
+    BEDNET_DISTRIBUTION_ACTIVITY_CODE,
+    BLOOD_SCREENING_ACTIVITY_CODE,
+    CASE_CONFIRMATION_ACTIVITY_CODE,
+    FAMILY_REGISTRATION_ACTIVITY_CODE,
+    LARVAL_DIPPING_ACTIVITY_CODE,
+    MOSQUITO_COLLECTION_ACTIVITY_CODE,
+  ]),
+  [InterventionType.IRS]: pick(planActivities, [IRS_ACTIVITY_CODE]),
+  [InterventionType.MDA]: pick(planActivities, [
+    MDA_FAMILY_REGISTRATION,
+    MDA_DISPENSE_ACTIVITY_CODE,
+    MDA_ADHERENCE,
+  ]),
+  [InterventionType.MDAPoint]: pick(planActivities, [
+    MDA_POINT_ADVERSE_EFFECTS_ACTIVITY_CODE,
+    MDA_POINT_DISPENSE_ACTIVITY_CODE,
+  ]),
+  [InterventionType.DynamicFI]: pick(planActivities, [
+    DYNAMIC_BCC_ACTIVITY_CODE,
+    DYNAMIC_BEDNET_DISTRIBUTION_ACTIVITY_CODE,
+    DYNAMIC_BLOOD_SCREENING_ACTIVITY_CODE,
+    DYNAMIC_FAMILY_REGISTRATION_ACTIVITY_CODE,
+    DYNAMIC_LARVAL_DIPPING_ACTIVITY_CODE,
+    DYNAMIC_MOSQUITO_COLLECTION_ACTIVITY_CODE,
+  ]),
+  [InterventionType.DynamicMDA]: pick(planActivities, [
+    DYNAMIC_MDA_COMMUNITY_ADHERENCE_ACTIVITY_CODE,
+    DYNAMIC_MDA_COMMUNITY_DISPENSE_ACTIVITY_CODE,
+    DYNAMIC_FAMILY_REGISTRATION_ACTIVITY_CODE,
+  ]),
+  [InterventionType.DynamicIRS]: pick(planActivities, [DYNAMIC_IRS_ACTIVITY_CODE]),
+  [InterventionType.IRSLite]: [],
+};
 export type FormActivity =
-  | typeof FIActivities
-  | typeof IRSActivities
-  | typeof MDAActivities
-  | typeof MDAPointActivities
-  | typeof DynamicFIActivities
-  | typeof DynamicIRSActivities
-  | typeof DynamicMDAActivities;
+  | typeof AllPlanActivities[InterventionType.FI]
+  | typeof AllPlanActivities[InterventionType.IRS]
+  | typeof AllPlanActivities[InterventionType.MDA]
+  | typeof AllPlanActivities[InterventionType.MDAPoint]
+  | typeof AllPlanActivities[InterventionType.DynamicFI]
+  | typeof AllPlanActivities[InterventionType.DynamicMDA]
+  | typeof AllPlanActivities[InterventionType.DynamicIRS];
 
 /**
  * Converts a plan activities objects to a list of activities for use on PlanForm
@@ -292,13 +296,25 @@ export function getFormActivities(items: FormActivity) {
 }
 
 const planActivitiesMap: Dictionary<PlanActivityFormFields[]> = {};
-planActivitiesMap[InterventionType.IRS] = getFormActivities(IRSActivities);
-planActivitiesMap[InterventionType.FI] = getFormActivities(FIActivities);
-planActivitiesMap[InterventionType.MDA] = getFormActivities(MDAActivities);
-planActivitiesMap[InterventionType.MDAPoint] = getFormActivities(MDAPointActivities);
-planActivitiesMap[InterventionType.DynamicFI] = getFormActivities(DynamicFIActivities);
-planActivitiesMap[InterventionType.DynamicIRS] = getFormActivities(DynamicIRSActivities);
-planActivitiesMap[InterventionType.DynamicMDA] = getFormActivities(DynamicMDAActivities);
+planActivitiesMap[InterventionType.IRS] = getFormActivities(
+  AllPlanActivities[InterventionType.IRS]
+);
+planActivitiesMap[InterventionType.FI] = getFormActivities(AllPlanActivities[InterventionType.FI]);
+planActivitiesMap[InterventionType.MDA] = getFormActivities(
+  AllPlanActivities[InterventionType.MDA]
+);
+planActivitiesMap[InterventionType.MDAPoint] = getFormActivities(
+  AllPlanActivities[InterventionType.MDAPoint]
+);
+planActivitiesMap[InterventionType.DynamicFI] = getFormActivities(
+  AllPlanActivities[InterventionType.DynamicFI]
+);
+planActivitiesMap[InterventionType.DynamicIRS] = getFormActivities(
+  AllPlanActivities[InterventionType.DynamicIRS]
+);
+planActivitiesMap[InterventionType.DynamicMDA] = getFormActivities(
+  AllPlanActivities[InterventionType.DynamicMDA]
+);
 export { planActivitiesMap };
 
 /**
@@ -332,27 +348,12 @@ export function getActivityFromPlan(
  */
 export function getPlanActivityFromActionCode(
   actionCode: PlanActionCodesType,
-  isDynamic: boolean = false
+  interventionType: InterventionType
 ): PlanActivity | null {
-  const search = Object.values(planActivities).filter(item => {
-    if (isDynamic) {
-      return (
-        item.action.code === actionCode &&
-        (Object.keys(item.action).includes(CONDITION) || Object.keys(item.action).includes(TRIGGER))
-      );
-    } else {
-      return (
-        item.action.code === actionCode &&
-        !Object.keys(item.action).includes(CONDITION) &&
-        !Object.keys(item.action).includes(TRIGGER)
-      );
-    }
-  });
-  if (search.length > 0) {
-    return search[0];
-  }
-
-  return null;
+  const search = Object.values(AllPlanActivities[interventionType]).filter(
+    item => item.action.code === actionCode
+  );
+  return search.length > 0 ? search[0] : null;
 }
 
 /**
@@ -411,6 +412,7 @@ const getTriggerFromFormField = (
  */
 export function extractActivitiesFromPlanForm(
   activities: PlanActivityFormFields[],
+  interventionType: InterventionType,
   planIdentifier: string = '',
   planObj: PlanDefinition | null = null
 ) {
@@ -430,12 +432,9 @@ export function extractActivitiesFromPlanForm(
       let thisAction: PlanAction = planActivities.BCC.action;
       let thisGoal: PlanGoal = planActivities.BCC.goal;
 
-      // lets figure out if this is a dynamic activity
-      const isDynamic =
-        Object.keys(element).includes(CONDITION) || Object.keys(element).includes(TRIGGER);
       const planActivity = getPlanActivityFromActionCode(
         element.actionCode as PlanActionCodesType,
-        isDynamic
+        interventionType
       );
 
       if (planActivity) {
@@ -636,6 +635,7 @@ export function generatePlanDefinition(
 
   const actionAndGoals = extractActivitiesFromPlanForm(
     formValue.activities,
+    formValue.interventionType,
     planObj ? planObj.identifier : '',
     planObj
   );
@@ -822,8 +822,11 @@ export function getPlanFormValues(planObject: PlanDefinition): PlanFormFields {
  * Get goal unit from action code
  * @param {PlanActionCodesType} actionCode - the plan action code
  */
-export function getGoalUnitFromActionCode(actionCode: PlanActionCodesType): GoalUnit {
-  const planActivity = getPlanActivityFromActionCode(actionCode);
+export function getGoalUnitFromActionCode(
+  actionCode: PlanActionCodesType,
+  interventionType: InterventionType
+): GoalUnit {
+  const planActivity = getPlanActivityFromActionCode(actionCode, interventionType);
   if (planActivity) {
     return planActivity.goal.target[0].detail.detailQuantity.unit;
   }

--- a/src/components/forms/PlanForm/helpers.ts
+++ b/src/components/forms/PlanForm/helpers.ts
@@ -655,7 +655,7 @@ export function generatePlanDefinition(
     useContext.push({ code: FI_STATUS_CODE, valueCodableConcept: formValue.fiStatus });
   }
 
-  if (formValue.fiReason) {
+  if (formValue.fiReason && isFIOrDynamicFI(formValue.interventionType)) {
     useContext.push({ code: FI_REASON_CODE, valueCodableConcept: formValue.fiReason });
   }
 

--- a/src/components/forms/PlanForm/index.tsx
+++ b/src/components/forms/PlanForm/index.tsx
@@ -923,7 +923,9 @@ const PlanForm = (props: PlanFormProps) => {
                                     {
                                       goalUnitDisplay[
                                         getGoalUnitFromActionCode(
-                                          values.activities[index].actionCode as PlanActionCodesType
+                                          values.activities[index]
+                                            .actionCode as PlanActionCodesType,
+                                          values.interventionType
                                         )
                                       ]
                                     }

--- a/src/components/forms/PlanForm/tests/fixtures.ts
+++ b/src/components/forms/PlanForm/tests/fixtures.ts
@@ -380,8 +380,8 @@ export const expectedExtractActivityFromPlanformResult = {
       code: 'MDA Adherence',
       description:
         'Visit all residential structures (100%) and confirm adherence of each registered person',
-      goalId: 'MDA_Dispense',
-      identifier: 'f1edff2a-d93c-56fb-b832-3f87b595c8fb',
+      goalId: 'MDA_Adherence',
+      identifier: '3f7fdb4b-935b-57d8-a27b-8903be074080',
       prefix: 8,
       reason: 'Routine',
       subjectCodableConcept: {

--- a/src/components/forms/PlanForm/tests/fixtures.ts
+++ b/src/components/forms/PlanForm/tests/fixtures.ts
@@ -7,6 +7,30 @@ import {
   planActivities as planActivitiesFromConfig,
   PlanActivity,
 } from '../../../../configs/settings';
+import {
+  BCC_ACTIVITY_CODE,
+  BEDNET_DISTRIBUTION_ACTIVITY_CODE,
+  BLOOD_SCREENING_ACTIVITY_CODE,
+  CASE_CONFIRMATION_ACTIVITY_CODE,
+  DYNAMIC_BCC_ACTIVITY_CODE,
+  DYNAMIC_BEDNET_DISTRIBUTION_ACTIVITY_CODE,
+  DYNAMIC_BLOOD_SCREENING_ACTIVITY_CODE,
+  DYNAMIC_FAMILY_REGISTRATION_ACTIVITY_CODE,
+  DYNAMIC_IRS_ACTIVITY_CODE,
+  DYNAMIC_LARVAL_DIPPING_ACTIVITY_CODE,
+  DYNAMIC_MDA_COMMUNITY_ADHERENCE_ACTIVITY_CODE,
+  DYNAMIC_MDA_COMMUNITY_DISPENSE_ACTIVITY_CODE,
+  DYNAMIC_MOSQUITO_COLLECTION_ACTIVITY_CODE,
+  FAMILY_REGISTRATION_ACTIVITY_CODE,
+  IRS_ACTIVITY_CODE,
+  LARVAL_DIPPING_ACTIVITY_CODE,
+  MDA_ADHERENCE,
+  MDA_DISPENSE_ACTIVITY_CODE,
+  MDA_FAMILY_REGISTRATION,
+  MDA_POINT_ADVERSE_EFFECTS_ACTIVITY_CODE,
+  MDA_POINT_DISPENSE_ACTIVITY_CODE,
+  MOSQUITO_COLLECTION_ACTIVITY_CODE,
+} from '../../../../constants';
 import { InterventionType, PlanStatus } from '../../../../store/ducks/plans';
 import { PlanActivityFormFields, PlanFormFields } from '../types';
 import { GoalUnit } from '../types';
@@ -376,25 +400,6 @@ export const expectedExtractActivityFromPlanformResult = {
       },
       title: 'Behaviour Change Communication',
     },
-    {
-      code: 'MDA Adherence',
-      description:
-        'Visit all residential structures (100%) and confirm adherence of each registered person',
-      goalId: 'MDA_Adherence',
-      identifier: '3f7fdb4b-935b-57d8-a27b-8903be074080',
-      prefix: 8,
-      reason: 'Routine',
-      subjectCodableConcept: {
-        text: 'Person',
-      },
-      taskTemplate: 'MDA_Adherence',
-      timingPeriod: {
-        end: '2019-08-16',
-        start: '2019-08-09',
-      },
-      title: 'MDA Adherence',
-      type: 'create',
-    },
   ],
   goal: [
     {
@@ -523,25 +528,6 @@ export const expectedExtractActivityFromPlanformResult = {
           },
           due: '2019-08-16',
           measure: 'BCC Activities Completed',
-        },
-      ],
-    },
-    {
-      description:
-        'Visit all residential structures (100%) and confirm adherence of each registered person',
-      id: 'MDA_Adherence',
-      priority: 'medium-priority',
-      target: [
-        {
-          detail: {
-            detailQuantity: {
-              comparator: '>=',
-              unit: 'Percent',
-              value: 100,
-            },
-          },
-          due: '2019-08-16',
-          measure: 'Percent of dispense recipients',
         },
       ],
     },
@@ -1573,4 +1559,226 @@ export const DynamicFIPlan = {
     },
   ],
   experimental: false,
+};
+
+export const planNamesAndInterventions = [
+  {
+    intervention: InterventionType.FI,
+    plans: [
+      BCC_ACTIVITY_CODE,
+      BEDNET_DISTRIBUTION_ACTIVITY_CODE,
+      BLOOD_SCREENING_ACTIVITY_CODE,
+      CASE_CONFIRMATION_ACTIVITY_CODE,
+      FAMILY_REGISTRATION_ACTIVITY_CODE,
+      LARVAL_DIPPING_ACTIVITY_CODE,
+      MOSQUITO_COLLECTION_ACTIVITY_CODE,
+    ],
+  },
+  {
+    intervention: InterventionType.IRS,
+    plans: [IRS_ACTIVITY_CODE],
+  },
+  {
+    intervention: InterventionType.MDA,
+    plans: [MDA_FAMILY_REGISTRATION, MDA_DISPENSE_ACTIVITY_CODE, MDA_ADHERENCE],
+  },
+  {
+    intervention: InterventionType.MDAPoint,
+    plans: [MDA_POINT_ADVERSE_EFFECTS_ACTIVITY_CODE, MDA_POINT_DISPENSE_ACTIVITY_CODE],
+  },
+  {
+    intervention: InterventionType.DynamicFI,
+    plans: [
+      DYNAMIC_BCC_ACTIVITY_CODE,
+      DYNAMIC_BEDNET_DISTRIBUTION_ACTIVITY_CODE,
+      DYNAMIC_BLOOD_SCREENING_ACTIVITY_CODE,
+      DYNAMIC_FAMILY_REGISTRATION_ACTIVITY_CODE,
+      DYNAMIC_LARVAL_DIPPING_ACTIVITY_CODE,
+      DYNAMIC_MOSQUITO_COLLECTION_ACTIVITY_CODE,
+    ],
+  },
+  {
+    intervention: InterventionType.DynamicMDA,
+    plans: [
+      DYNAMIC_MDA_COMMUNITY_ADHERENCE_ACTIVITY_CODE,
+      DYNAMIC_MDA_COMMUNITY_DISPENSE_ACTIVITY_CODE,
+      DYNAMIC_FAMILY_REGISTRATION_ACTIVITY_CODE,
+    ],
+  },
+  {
+    intervention: InterventionType.DynamicIRS,
+    plans: [DYNAMIC_IRS_ACTIVITY_CODE],
+  },
+];
+
+export const MDAPlanActivities: PlanActivityFormFields[] = [
+  {
+    actionCode: 'RACD Register Family',
+    actionDefinitionUri: '',
+    actionDescription:
+      'Register all families & family members in all residential structures enumerated (100%) within the operational area',
+    actionIdentifier: '',
+    actionReason: 'Investigation',
+    actionTitle: 'Family Registration',
+    goalDescription:
+      'Register all families & family members in all residential structures enumerated (100%) within the operational area',
+    goalDue: parseISO('2019-08-16T08:39:42.773Z'),
+    goalPriority: 'medium-priority',
+    goalValue: 100,
+    timingPeriodEnd: parseISO('2019-08-16T08:39:42.773Z'),
+    timingPeriodStart: parseISO('2019-08-09T08:39:42.773Z'),
+  },
+  {
+    actionCode: 'MDA Dispense',
+    actionDefinitionUri: '',
+    actionDescription:
+      'Visit all residential structures (100%) dispense prophylaxis to each registered person',
+    actionIdentifier: '',
+    actionReason: 'Routine',
+    actionTitle: 'MDA Dispense',
+    goalDescription:
+      'Visit all residential structures (100%) dispense prophylaxis to each registered person',
+    goalDue: parseISO('2019-08-16T08:39:42.773Z'),
+    goalPriority: 'medium-priority',
+    goalValue: 100,
+    timingPeriodEnd: parseISO('2019-08-16T08:39:42.773Z'),
+    timingPeriodStart: parseISO('2019-08-09T08:39:42.773Z'),
+  },
+  {
+    actionCode: 'MDA Adherence',
+    actionDefinitionUri: '',
+    actionDescription:
+      'Visit all residential structures (100%) and confirm adherence of each registered person',
+    actionIdentifier: '',
+    actionReason: 'Routine',
+    actionTitle: 'MDA Adherence',
+    goalDescription:
+      'Visit all residential structures (100%) and confirm adherence of each registered person',
+    goalDue: parseISO('2019-08-16T08:39:42.773Z'),
+    goalPriority: 'low-priority',
+    goalValue: 100,
+    timingPeriodEnd: parseISO('2019-08-16T08:39:42.773Z'),
+    timingPeriodStart: parseISO('2019-08-09T08:39:42.773Z'),
+  },
+];
+
+export const extractedMDAActivities = {
+  action: [
+    {
+      code: 'RACD Register Family',
+      description:
+        'Register all families & family members in all residential structures enumerated (100%) within the operational area',
+      goalId: 'RACD_register_families',
+      identifier: '541258e7-4bd0-5699-89ba-7e832e5452b3',
+      prefix: 1,
+      reason: 'Investigation',
+      subjectCodableConcept: {
+        text: 'Residential_Structure',
+      },
+      taskTemplate: 'RACD_register_families',
+      timingPeriod: {
+        end: '2019-08-16',
+        start: '2019-08-09',
+      },
+      title: 'Family Registration',
+      type: 'create',
+    },
+    {
+      code: 'MDA Dispense',
+      description:
+        'Visit all residential structures (100%) dispense prophylaxis to each registered person',
+      goalId: 'MDA_Dispense',
+      identifier: 'f1edff2a-d93c-56fb-b832-3f87b595c8fb',
+      prefix: 2,
+      reason: 'Routine',
+      subjectCodableConcept: {
+        text: 'Person',
+      },
+      taskTemplate: 'MDA_Dispense',
+      timingPeriod: {
+        end: '2019-08-16',
+        start: '2019-08-09',
+      },
+      title: 'MDA Dispense',
+      type: 'create',
+    },
+    {
+      code: 'MDA Adherence',
+      description:
+        'Visit all residential structures (100%) and confirm adherence of each registered person',
+      goalId: 'MDA_Adherence',
+      identifier: '3f7fdb4b-935b-57d8-a27b-8903be074080',
+      prefix: 3,
+      reason: 'Routine',
+      subjectCodableConcept: {
+        text: 'Person',
+      },
+      taskTemplate: 'MDA_Adherence',
+      timingPeriod: {
+        end: '2019-08-16',
+        start: '2019-08-09',
+      },
+      title: 'MDA Adherence',
+      type: 'create',
+    },
+  ],
+  goal: [
+    {
+      description:
+        'Register all families & family members in all residential structures enumerated (100%) within the operational area',
+      id: 'RACD_register_families',
+      priority: 'medium-priority',
+      target: [
+        {
+          detail: {
+            detailQuantity: {
+              comparator: '>=',
+              unit: 'Percent',
+              value: 100,
+            },
+          },
+          due: '2019-08-16',
+          measure: 'Percent of residential structures with full family registration',
+        },
+      ],
+    },
+    {
+      description:
+        'Visit all residential structures (100%) dispense prophylaxis to each registered person',
+      id: 'MDA_Dispense',
+      priority: 'medium-priority',
+      target: [
+        {
+          detail: {
+            detailQuantity: {
+              comparator: '>=',
+              unit: 'Percent',
+              value: 100,
+            },
+          },
+          due: '2019-08-16',
+          measure: 'Percent of Registered person(s)',
+        },
+      ],
+    },
+    {
+      description:
+        'Visit all residential structures (100%) and confirm adherence of each registered person',
+      id: 'MDA_Adherence',
+      priority: 'low-priority',
+      target: [
+        {
+          detail: {
+            detailQuantity: {
+              comparator: '>=',
+              unit: 'Percent',
+              value: 100,
+            },
+          },
+          due: '2019-08-16',
+          measure: 'Percent of dispense recipients',
+        },
+      ],
+    },
+  ],
 };

--- a/src/components/forms/PlanForm/tests/helpers.test.ts
+++ b/src/components/forms/PlanForm/tests/helpers.test.ts
@@ -9,6 +9,7 @@ import { IGNORE, TRUE } from '../../../../constants';
 import { plans } from '../../../../store/ducks/opensrp/PlanDefinition/tests/fixtures';
 import { InterventionType } from '../../../../store/ducks/plans';
 import {
+  AllPlanActivities,
   doesFieldHaveErrors,
   extractActivitiesFromPlanForm,
   extractActivityForForm,
@@ -34,13 +35,16 @@ import {
   expectedExtractActivityFromPlanformResult,
   expectedPlanDefinition,
   extractedActivitiesFromForms,
+  extractedMDAActivities,
   fiReasonTestPlan,
+  MDAPlanActivities,
   planActivities,
   planActivityWithEmptyfields,
   planActivityWithoutTargets,
   planFormValues,
   planFormValues2,
   planFormValues3,
+  planNamesAndInterventions,
   values,
   values2,
   valuesWithJurisdiction,
@@ -51,13 +55,25 @@ jest.mock('../../../../configs/env');
 describe('containers/forms/PlanForm/helpers', () => {
   it('extractActivityForForm works for all activities', () => {
     for (const [key, activityObj] of Object.entries(planActivitiesFromConfig)) {
-      expect(extractActivityForForm(activityObj)).toEqual((expectedActivity as any)[key]);
+      const intervention = planNamesAndInterventions.find(item => item.plans.includes(key))
+        ?.intervention;
+      expect(extractActivityForForm(activityObj, intervention as InterventionType)).toEqual(
+        (expectedActivity as any)[key]
+      );
     }
     for (const [key, activityObj] of Object.entries(planActivityWithEmptyfields)) {
-      expect(extractActivityForForm(activityObj)).toEqual((expectedActivityEmptyField as any)[key]);
+      const intervention = planNamesAndInterventions.find(item => item.plans.includes(key))
+        ?.intervention;
+      expect(extractActivityForForm(activityObj, intervention as InterventionType)).toEqual(
+        (expectedActivityEmptyField as any)[key]
+      );
     }
     for (const [key, obj] of Object.entries(planActivityWithoutTargets)) {
-      expect(extractActivityForForm(obj)).toEqual((expectedActivity as any)[key]);
+      const intervention = planNamesAndInterventions.find(item => item.plans.includes(key))
+        ?.intervention;
+      expect(extractActivityForForm(obj, intervention as InterventionType)).toEqual(
+        (expectedActivity as any)[key]
+      );
     }
   });
 
@@ -87,8 +103,11 @@ describe('containers/forms/PlanForm/helpers', () => {
     envModule.PLAN_UUID_NAMESPACE = '85f7dbbf-07d0-4c92-aa2d-d50d141dde00';
     envModule.ACTION_UUID_NAMESPACE = '35968df5-f335-44ae-8ae5-25804caa2d86';
     MockDate.set('1/30/2000', 0);
-    expect(extractActivitiesFromPlanForm(activities)).toEqual(
+    expect(extractActivitiesFromPlanForm(activities, InterventionType.FI)).toEqual(
       expectedExtractActivityFromPlanformResult
+    );
+    expect(extractActivitiesFromPlanForm(MDAPlanActivities, InterventionType.MDA)).toEqual(
+      extractedMDAActivities
     );
     MockDate.reset();
   });
@@ -278,9 +297,18 @@ describe('containers/forms/PlanForm/helpers', () => {
       GoalUnit.PERCENT, // MDA Adverse events
     ];
     for (let index = 0; index < PlanActionCodes.length; index++) {
-      expect(getGoalUnitFromActionCode(PlanActionCodes[index])).toEqual(expectedUnits[index]);
+      const intervention = Object.values(InterventionType).find(inter =>
+        Object.values(AllPlanActivities[inter]).some(
+          item => item.action.code === PlanActionCodes[index]
+        )
+      );
+      expect(
+        getGoalUnitFromActionCode(PlanActionCodes[index], intervention as InterventionType)
+      ).toEqual(expectedUnits[index]);
     }
-    expect(getGoalUnitFromActionCode('mosh' as PlanActionCodesType)).toEqual(GoalUnit.UNKNOWN);
+    expect(getGoalUnitFromActionCode('mosh' as PlanActionCodesType, InterventionType.FI)).toEqual(
+      GoalUnit.UNKNOWN
+    );
   });
 
   it('onSubmitSuccess works if', () => {

--- a/src/configs/lang.ts
+++ b/src/configs/lang.ts
@@ -422,6 +422,10 @@ export const MDA_POINT_DISPENSE_ACTIVITY_DESCRIPTION = translate(
   'MDA_POINT_DISPENSE_ACTIVITY_DESCRIPTION',
   'Dispense medication to each eligible person'
 );
+export const MDA_DISPENSE_ACTIVITY_DESCRIPTION = translate(
+  'MDA_DISPENSE_ACTIVITY_DESCRIPTION',
+  'Visit all residential structures (100%) dispense prophylaxis to each registered person'
+);
 export const MDA_POINT_DISPENSE_COLLECTION_GOAL = translate(
   'MDA_POINT_DISPENSE_ACTIVITY_DESCRIPTION',
   'Percent of eligible people'

--- a/src/configs/settings.ts
+++ b/src/configs/settings.ts
@@ -76,6 +76,7 @@ import {
   LARVAL_DIPPING_GOAL_MEASURE,
   LOW_PRIORITY_LABEL,
   MDA_ADHERENCE_DESCRIPTION,
+  MDA_DISPENSE_ACTIVITY_DESCRIPTION,
   MDA_POINT_ADVERSE_EFFECT_ACTIVITY_DESCRIPTION,
   MDA_POINT_ADVERSE_EFFECT_COLLECTION_GOAL,
   MDA_POINT_DISPENSE_ACTIVITY_DESCRIPTION,
@@ -143,6 +144,8 @@ import {
   LOW_PRIORITY,
   MDA_ADHERENCE,
   MDA_ADHERENCE_CODE,
+  MDA_DISPENSE_ACTIVITY_CODE,
+  MDA_FAMILY_REGISTRATION,
   MDA_POINT_ADVERSE_EFFECTS_ACTIVITY_CODE,
   MDA_POINT_ADVERSE_EFFECTS_CODE,
   MDA_POINT_DISPENSE_ACTIVITY_CODE,
@@ -350,7 +353,12 @@ export interface PlanActionTimingPeriod {
 }
 
 /** plan action subjectCodableConcept text type  */
-export type subjectCodableConceptType = 'Family' | 'Person' | 'Location' | 'Jurisdiction';
+export type subjectCodableConceptType =
+  | 'Family'
+  | 'Person'
+  | 'Location'
+  | 'Jurisdiction'
+  | 'Residential_Structure';
 
 /** Plan Action subjectCodableConcept */
 export interface PlanActionsubjectCodableConcept {
@@ -453,6 +461,8 @@ export const PlanActivityTitles = [
   DYNAMIC_MDA_COMMUNITY_DISPENSE_ACTIVITY_CODE,
   DYNAMIC_MDA_COMMUNITY_ADHERENCE_ACTIVITY_CODE,
   MDA_ADHERENCE,
+  MDA_FAMILY_REGISTRATION,
+  MDA_DISPENSE_ACTIVITY_CODE,
 ] as const;
 
 /** default plan activities */
@@ -565,6 +575,82 @@ export const planActivities: PlanActivities = {
           },
           due: '',
           measure: 'Percent of dispense recipients',
+        },
+      ],
+    },
+  },
+  MDADispenseCode: {
+    action: {
+      code: MDA_POINT_DISPENSE_CODE,
+      description: MDA_DISPENSE_ACTIVITY_DESCRIPTION,
+      goalId: 'MDA_Dispense',
+      identifier: '',
+      prefix: 2,
+      reason: ROUTINE,
+      subjectCodableConcept: {
+        text: 'Person',
+      },
+      taskTemplate: 'MDA_Dispense',
+      timingPeriod: {
+        end: '',
+        start: '',
+      },
+      title: MDA_POINT_DISPENSE_CODE,
+      type: CREATE_TYPE,
+    },
+    goal: {
+      description: MDA_DISPENSE_ACTIVITY_DESCRIPTION,
+      id: 'MDA_Dispense',
+      priority: MEDIUM_PRIORITY,
+      target: [
+        {
+          detail: {
+            detailQuantity: {
+              comparator: '>=',
+              unit: GoalUnit.PERCENT,
+              value: 100,
+            },
+          },
+          due: '',
+          measure: 'Percent of Registered person(s)',
+        },
+      ],
+    },
+  },
+  MDAFamilyRegistration: {
+    action: {
+      code: RACD_REGISTER_FAMILY_CODE,
+      description: REGISTER_FAMILY_ACTIVITY_DESCRIPTION,
+      goalId: 'RACD_register_families',
+      identifier: '',
+      prefix: 1,
+      reason: INVESTIGATION,
+      subjectCodableConcept: {
+        text: 'Residential_Structure',
+      },
+      taskTemplate: 'RACD_register_families',
+      timingPeriod: {
+        end: '',
+        start: '',
+      },
+      title: REGISTER_FAMILY_ACTIVITY,
+      type: CREATE_TYPE,
+    },
+    goal: {
+      description: REGISTER_FAMILY_ACTIVITY_DESCRIPTION,
+      id: 'RACD_register_families',
+      priority: MEDIUM_PRIORITY,
+      target: [
+        {
+          detail: {
+            detailQuantity: {
+              comparator: '>=',
+              unit: GoalUnit.PERCENT,
+              value: 100,
+            },
+          },
+          due: '',
+          measure: REGISTER_FAMILY_ACTIVITY_GOAL_MEASURE,
         },
       ],
     },

--- a/src/configs/settings.ts
+++ b/src/configs/settings.ts
@@ -535,7 +535,7 @@ export const planActivities: PlanActivities = {
     action: {
       code: MDA_ADHERENCE_CODE,
       description: MDA_ADHERENCE_DESCRIPTION,
-      goalId: 'MDA_Dispense',
+      goalId: 'MDA_Adherence',
       identifier: '',
       prefix: 3,
       reason: ROUTINE,

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -200,6 +200,8 @@ export const DYNAMIC_IRS_ACTIVITY_CODE = 'dynamicIRS';
 export const DYNAMIC_MDA_COMMUNITY_DISPENSE_ACTIVITY_CODE = 'dynamicCommunityDispenseMDA';
 export const DYNAMIC_MDA_COMMUNITY_ADHERENCE_ACTIVITY_CODE = 'dynamicCommunityAdherenceMDA';
 export const MDA_ADHERENCE = 'MDAAdherence';
+export const MDA_FAMILY_REGISTRATION = 'MDAFamilyRegistration';
+export const MDA_DISPENSE_ACTIVITY_CODE = 'MDADispenseCode';
 
 // task action codes
 export const BCC_CODE = 'BCC';


### PR DESCRIPTION
This PR corrects MDA plan data posted to API to match the specifications on [this comment](https://github.com/onaio/reveal-frontend/issues/1429#issuecomment-745738416).

Introduces following changes:
- An object that holds all plans based on their intervention
- Gets plan activities and goals from the above created object based on the intervention selected instead of searching through all plans templates
-  Creates new templates for MDA plan

This changes ensures right plan activities and goals are always found from the plans template in cases were we have multiple plans templates with similar action codes.
Fixes #1429 