### PR TITLE
Show case classification data

### DIFF
--- a/src/helpers/tests/utils.test.tsx
+++ b/src/helpers/tests/utils.test.tsx
@@ -272,6 +272,23 @@ describe('helpers/utils', () => {
       status: 'A1',
       village: 'Laem Klat Moo 8',
     });
+
+    // when case classification is available
+    const caseClassification = 'A';
+    const planCopy = { ...fixtures.plan99, case_classification: caseClassification };
+    expect(extractPlan(planCopy as Plan)).toEqual({
+      ...fixtures.plan99,
+      canton: 'Laem Klat Canton 2',
+      caseClassification,
+      caseNotificationDate: '2019-07-03',
+      case_classification: caseClassification,
+      district: 'Mueng Trat District 2',
+      focusArea: 'Tha Sen 8',
+      province: 'Trat 2',
+      reason: 'Case Triggered',
+      status: 'A1',
+      village: 'Laem Klat Moo 8',
+    });
   });
 
   it('extractPlan handles plans with null jurisdiction name path', () => {

--- a/src/helpers/utils.tsx
+++ b/src/helpers/utils.tsx
@@ -291,7 +291,7 @@ export function extractPlan(plan: Plan) {
   const result: { [key: string]: any } = {
     ...plan,
     canton: null,
-    caseClassification: null,
+    caseClassification: plan.case_classification || null,
     caseNotificationDate: plan.plan_fi_reason === CASE_TRIGGERED ? plan.plan_date : null,
     district: null,
     focusArea: plan.jurisdiction_name,

--- a/src/store/ducks/plans.ts
+++ b/src/store/ducks/plans.ts
@@ -48,6 +48,7 @@ export interface PlanRecordResponse {
 
 /** PlanRecord - base Plan interface for plan objects,  keyed by `id` in state */
 export interface PlanRecord {
+  case_classification?: string;
   id: string;
   plan_date: string;
   plan_effective_period_end: string;


### PR DESCRIPTION
Change Case classification column on FI reporting page to show data if it is available. Initially the column value was set to null.

part of #1506 