### PR TITLE
Fix  definitionUri value not updating

### DIFF
--- a/src/components/forms/PlanForm/helpers.ts
+++ b/src/components/forms/PlanForm/helpers.ts
@@ -509,6 +509,7 @@ export function extractActivitiesFromPlanForm(
       const actionFields: Partial<PlanAction> = {
         ...(condition && { condition }),
         ...(trigger && { trigger }),
+        ...(element.actionDefinitionUri && { definitionUri: element.actionDefinitionUri }),
         description: element.actionDescription,
         identifier: thisActionIdentifier,
         prefix,

--- a/src/components/forms/PlanForm/tests/fixtures.ts
+++ b/src/components/forms/PlanForm/tests/fixtures.ts
@@ -1782,3 +1782,15 @@ export const extractedMDAActivities = {
     },
   ],
 };
+
+export const extractedMDAActivitiesCopy = {
+  ...extractedMDAActivities,
+  action: [
+    {
+      ...extractedMDAActivities.action[0],
+      definitionUri: 'family_reg_uri_test.json',
+    },
+    extractedMDAActivities.action[1],
+    extractedMDAActivities.action[2],
+  ],
+};

--- a/src/components/forms/PlanForm/tests/helpers.test.ts
+++ b/src/components/forms/PlanForm/tests/helpers.test.ts
@@ -36,6 +36,7 @@ import {
   expectedPlanDefinition,
   extractedActivitiesFromForms,
   extractedMDAActivities,
+  extractedMDAActivitiesCopy,
   fiReasonTestPlan,
   MDAPlanActivities,
   planActivities,
@@ -108,6 +109,12 @@ describe('containers/forms/PlanForm/helpers', () => {
     );
     expect(extractActivitiesFromPlanForm(MDAPlanActivities, InterventionType.MDA)).toEqual(
       extractedMDAActivities
+    );
+    // definition uri default plan template value is replaced
+    const MDAPlanActivitiesCopy = [...MDAPlanActivities];
+    MDAPlanActivitiesCopy[0].actionDefinitionUri = 'family_reg_uri_test.json';
+    expect(extractActivitiesFromPlanForm(MDAPlanActivitiesCopy, InterventionType.MDA)).toEqual(
+      extractedMDAActivitiesCopy
     );
     MockDate.reset();
   });


### PR DESCRIPTION
Closes #1519 
`Definition Uri` field on plan was always being reset to the default value defined on the plan template on save. This PR ensures the values is set to what user enters on the field.