### PR TITLE
Test data submitted when creating MDA-Point plan

### DIFF
--- a/src/components/forms/PlanForm/tests/fixtures.ts
+++ b/src/components/forms/PlanForm/tests/fixtures.ts
@@ -1952,3 +1952,106 @@ export const MDALitePlanPayload = {
   ],
   version: '2',
 };
+
+export const MDAPointPayload = {
+  action: [
+    {
+      code: 'MDA Dispense',
+      description: 'Percent of eligible people',
+      goalId: 'Point_dispense_MDA',
+      identifier: 'f95efc9d-0fa3-5c24-a611-aa116072b837',
+      prefix: 1,
+      reason: 'Routine',
+      subjectCodableConcept: {
+        text: 'Location',
+      },
+      taskTemplate: 'MDA_Point_Dispense',
+      timingPeriod: {
+        end: '2017-07-20',
+        start: '2017-07-13',
+      },
+      title: 'MDA Dispense',
+    },
+    {
+      code: 'MDA Adverse Event(s)',
+      description: 'Report any adverse events from medication',
+      goalId: 'Point_adverse_effect_MDA',
+      identifier: '6d6371a1-346f-5d37-97bd-81b285036849',
+      prefix: 2,
+      reason: 'Routine',
+      subjectCodableConcept: {
+        text: 'Location',
+      },
+      taskTemplate: 'MDA_Point_Adverse_Event',
+      timingPeriod: {
+        end: '2017-07-20',
+        start: '2017-07-13',
+      },
+      title: 'MDA Adverse Event(s)',
+    },
+  ],
+  goal: [
+    {
+      description: 'Percent of eligible people',
+      id: 'Point_dispense_MDA',
+      priority: 'medium-priority',
+      target: [
+        {
+          detail: {
+            detailQuantity: {
+              comparator: '>=',
+              unit: 'Percent',
+              value: 75,
+            },
+          },
+          due: '2017-07-20',
+          measure: 'Percent of eligible people',
+        },
+      ],
+    },
+    {
+      description: 'Report any adverse events from medication',
+      id: 'Point_adverse_effect_MDA',
+      priority: 'medium-priority',
+      target: [
+        {
+          detail: {
+            detailQuantity: {
+              comparator: '<=',
+              unit: 'Percent',
+              value: 2,
+            },
+          },
+          due: '2017-07-20',
+          measure: 'Percent of people who reported adverse events',
+        },
+      ],
+    },
+  ],
+  date: '2017-07-13',
+  effectivePeriod: {
+    end: '2017-08-02',
+    start: '2017-07-13',
+  },
+  experimental: false,
+  identifier: 'edbffee3-e1ef-5464-b9ed-23b4cf3b1ae5',
+  jurisdiction: [
+    {
+      code: '1337',
+    },
+  ],
+  name: 'MDA-Point-2017-07-13',
+  status: 'draft',
+  title: 'MDA-Point 2017-07-13',
+  useContext: [
+    {
+      code: 'interventionType',
+      valueCodableConcept: 'MDA-Point',
+    },
+    {
+      code: 'taskGenerationStatus',
+      valueCodableConcept: 'False',
+    },
+  ],
+  version: '2',
+};


### PR DESCRIPTION
This pr tests the payload created for MDA-Point plans.
It is part of confirming that the `task generation status` is set to `False` when creating MDA-Point plans.
Part of #1543