### PR TITLE
Fix submit button remaining disabled on adding new activities when editing plan

### DIFF
--- a/src/components/forms/PlanForm/index.tsx
+++ b/src/components/forms/PlanForm/index.tsx
@@ -1213,9 +1213,10 @@ const PlanForm = (props: PlanFormProps) => {
                                       type="button"
                                       className="btn btn-primary btn-sm mb-1 addActivity"
                                       onClick={() => {
-                                        values.activities.push(thisActivity);
+                                        const newActivities = [...values.activities, thisActivity];
+                                        setFieldValue('activities', newActivities);
                                         const newActivityValues = getConditionAndTriggers(
-                                          values.activities,
+                                          newActivities,
                                           disabledFields.includes('activities')
                                         );
                                         setActionConditions(newActivityValues.conditions);


### PR DESCRIPTION
Closes #1587
Formik was not evaluating validity of the plans form on pushing new activity to the activities array. The fix was to use `setFieldValue` instead of push.