### PR TITLE
Plan form name field bug on edit

### DIFF
--- a/src/components/forms/PlanForm/helpers.ts
+++ b/src/components/forms/PlanForm/helpers.ts
@@ -587,14 +587,19 @@ export function extractActivitiesFromPlanForm(
  * @param {PlanFormFields} formValues - the form values
  * @returns {[string, string]} - the plan name and title
  */
-export const getNameTitle = (event: FormEvent, formValues: PlanFormFields): [string, string] => {
+export const getNameTitle = (
+  event: FormEvent,
+  formValues: PlanFormFields,
+  editMode: boolean = false
+): [string, string] => {
   const target = event.target as HTMLInputElement;
   const currentInterventionType =
     target.name === INTERVENTION_TYPE_CODE ? target.value : formValues.interventionType;
   const currentFiStatus = target.name === FI_STATUS_CODE ? target.value : formValues.fiStatus;
 
   let currentJurisdiction = '';
-  if (formValues.jurisdictions.length > 0) {
+  const hasJurName = !!(formValues.jurisdictions.length > 0 && formValues.jurisdictions[0].name);
+  if (hasJurName) {
     currentJurisdiction = formValues.jurisdictions[0].name;
   }
 
@@ -612,8 +617,8 @@ export const getNameTitle = (event: FormEvent, formValues: PlanFormFields): [str
         return e;
       }
     });
-    name = result.join('-');
-    title = result.join(' ');
+    name = editMode && target.name !== 'name' ? formValues.name : result.join('-');
+    title = editMode && target.name !== 'title' && !hasJurName ? formValues.name : result.join(' ');
   } else {
     const result = [name, moment(currentDate).format(DATE_FORMAT.toUpperCase())].map(e => {
       if (e) {
@@ -880,8 +885,8 @@ export function getPlanFormValues(planObject: PlanDefinition): PlanFormFields {
     interventionType,
     jurisdictions: planObject.jurisdiction.map(e => ({
       id: e.code,
-      name: e.code,
-    })) /** a little cheating: since we dnt have the name yet, we just use code */,
+      name: '',
+    })) /** a little cheating: since we dnt have the name yet, we just use '' */,
     name: planObject.name,
     opensrpEventId:
       eventIdUseContext.length > 0 ? eventIdUseContext[0].valueCodableConcept : undefined,

--- a/src/components/forms/PlanForm/index.tsx
+++ b/src/components/forms/PlanForm/index.tsx
@@ -400,7 +400,7 @@ const PlanForm = (props: PlanFormProps) => {
                 'date',
                 'jurisdictions[0].id',
               ];
-              const nameTitle = getNameTitle(e, values);
+              const nameTitle = getNameTitle(e, values, editMode);
               if (
                 fieldsThatChangePlanTitle.includes(target.name) ||
                 !values.title ||

--- a/src/components/forms/PlanForm/tests/fixtures.ts
+++ b/src/components/forms/PlanForm/tests/fixtures.ts
@@ -936,7 +936,7 @@ export const planFormValues2 = {
   fiStatus: 'A2',
   identifier: '356b6b84-fc36-4389-a44a-2b038ed2f38d',
   interventionType: 'FI',
-  jurisdictions: [{ id: '3952', name: '3952' }],
+  jurisdictions: [{ id: '3952', name: '' }],
   name: 'A2-Lusaka_Akros_Focus_2',
   opensrpEventId: undefined,
   start: moment('2019-05-20T00:00:00.000Z').toDate(),

--- a/src/components/forms/PlanForm/tests/helpers.test.ts
+++ b/src/components/forms/PlanForm/tests/helpers.test.ts
@@ -311,9 +311,9 @@ describe('containers/forms/PlanForm/helpers', () => {
     expect(plan.taskGenerationStatus).toEqual('True');
     // multiple jurisdictions are gotten right
     expect(getPlanFormValues(plans[1]).jurisdictions).toEqual([
-      { id: '35968df5-f335-44ae-8ae5-25804caa2d86', name: '35968df5-f335-44ae-8ae5-25804caa2d86' },
-      { id: '3952', name: '3952' },
-      { id: 'ac7ba751-35e8-4b46-9e53-3cbaad193697', name: 'ac7ba751-35e8-4b46-9e53-3cbaad193697' },
+      { id: '35968df5-f335-44ae-8ae5-25804caa2d86', name: '' },
+      { id: '3952', name: '' },
+      { id: 'ac7ba751-35e8-4b46-9e53-3cbaad193697', name: '' },
     ]);
   });
 

--- a/src/containers/pages/InterventionPlan/UpdatePlan/tests/fixtures.ts
+++ b/src/containers/pages/InterventionPlan/UpdatePlan/tests/fixtures.ts
@@ -68,15 +68,15 @@ export const updatePlanFormProps = {
     jurisdictions: [
       {
         id: '35968df5-f335-44ae-8ae5-25804caa2d86',
-        name: '35968df5-f335-44ae-8ae5-25804caa2d86',
+        name: '',
       },
       {
         id: '3952',
-        name: '3952',
+        name: '',
       },
       {
         id: 'ac7ba751-35e8-4b46-9e53-3cbaad193697',
-        name: 'ac7ba751-35e8-4b46-9e53-3cbaad193697',
+        name: '',
       },
     ],
     name: 'TwoTwoOne_01_IRS_2019-07-10',


### PR DESCRIPTION
Closes #1605 
This pr ensures plan name and title fields are not edited when a user edits other fields