### PR TITLE
Fix plan title not auto completing

### DIFF
--- a/src/components/forms/JurisdictionSelect/index.tsx
+++ b/src/components/forms/JurisdictionSelect/index.tsx
@@ -8,6 +8,7 @@ import { displayError } from '../../../helpers/errors';
 import { reactSelectNoOptionsText } from '../../../helpers/utils';
 import { getFilterParams, OpenSRPService, URLParams } from '../../../services/opensrp';
 import { NOT_AVAILABLE } from '../../TreeWalker/constants';
+import { getNameTitle } from '../PlanForm/helpers';
 import './style.css';
 
 /** interface for jurisdiction options
@@ -269,6 +270,25 @@ export const handleChangeWithOptions = (
           if (fiStatusFieldName) {
             const val = optionVal.fiStatus || NOT_AVAILABLE;
             form.setFieldValue(fiStatusFieldName, val);
+            form.setFieldTouched(labelFieldName, true);
+
+            // update plan title and name
+            const customTarget = new EventTarget() as HTMLInputElement;
+            customTarget.value = val;
+            customTarget.name = fiStatusFieldName;
+            const { jurisdictions } = form.values;
+            const newJur = {
+              id: optionVal.value,
+              name: optionVal.label,
+            };
+            const values = {
+              ...form.values,
+              jurisdictions:
+                jurisdictions.length && jurisdictions[0].id ? [...jurisdictions, newJur] : [newJur],
+            };
+            const nameTitle = getNameTitle(customTarget, values);
+            form.setFieldValue('title', nameTitle[1]);
+            form.setFieldValue('name', nameTitle[0]);
           }
           if (labelFieldName) {
             form.setFieldValue(labelFieldName, optionVal.label); /** dirty hack */

--- a/src/components/forms/PlanForm/helpers.ts
+++ b/src/components/forms/PlanForm/helpers.ts
@@ -3,7 +3,6 @@ import { parseISO } from 'date-fns';
 import { FormikErrors } from 'formik';
 import { findKey, pick } from 'lodash';
 import moment from 'moment';
-import { FormEvent } from 'react';
 import * as Yup from 'yup';
 import {
   ACTION_UUID_NAMESPACE,
@@ -583,16 +582,15 @@ export function extractActivitiesFromPlanForm(
 
 /**
  * Get the plan name and title
- * @param {FormEvent} event - the event object
+ * @param {HTMLInputElement} target - the event target object
  * @param {PlanFormFields} formValues - the form values
  * @returns {[string, string]} - the plan name and title
  */
 export const getNameTitle = (
-  event: FormEvent,
+  target: HTMLInputElement,
   formValues: PlanFormFields,
   editMode: boolean = false
 ): [string, string] => {
-  const target = event.target as HTMLInputElement;
   const currentInterventionType =
     target.name === INTERVENTION_TYPE_CODE ? target.value : formValues.interventionType;
   const currentFiStatus = target.name === FI_STATUS_CODE ? target.value : formValues.fiStatus;

--- a/src/components/forms/PlanForm/index.tsx
+++ b/src/components/forms/PlanForm/index.tsx
@@ -400,7 +400,7 @@ const PlanForm = (props: PlanFormProps) => {
                 'date',
                 'jurisdictions[0].id',
               ];
-              const nameTitle = getNameTitle(e, values, editMode);
+              const nameTitle = getNameTitle(target, values, editMode);
               if (
                 fieldsThatChangePlanTitle.includes(target.name) ||
                 !values.title ||
@@ -579,7 +579,7 @@ const PlanForm = (props: PlanFormProps) => {
                                     : 'async-select'
                                 }
                                 labelFieldName={`jurisdictions[${index}].name`}
-                                fiStatusFieldName="fiStatus"
+                                fiStatusFieldName={autoSelectFIStatus ? 'fiStatus' : ''}
                               />
                               <Field
                                 type="hidden"

--- a/src/components/forms/PlanForm/tests/helpers.test.ts
+++ b/src/components/forms/PlanForm/tests/helpers.test.ts
@@ -31,6 +31,7 @@ import {
   DynamicFIPlan,
   event,
   event2,
+  event3,
   expectedActivity,
   expectedActivityEmptyField,
   expectedExtractActivityFromPlanformResult,
@@ -139,7 +140,7 @@ describe('containers/forms/PlanForm/helpers', () => {
   });
 
   it('check getNameTitle returns the correct value when nothing is selected', () => {
-    const target = event2.target as HTMLInputElement;
+    const target = event3.target as HTMLInputElement;
     expect(getNameTitle(target, values)).toEqual(['IRS-2019-08-09', 'IRS 2019-08-09']);
     expect(getNameTitle(target, valuesWithJurisdiction)).toEqual([
       'IRS-2019-08-09',

--- a/src/components/forms/PlanForm/tests/helpers.test.ts
+++ b/src/components/forms/PlanForm/tests/helpers.test.ts
@@ -31,7 +31,6 @@ import {
   DynamicFIPlan,
   event,
   event2,
-  event3,
   expectedActivity,
   expectedActivityEmptyField,
   expectedExtractActivityFromPlanformResult,
@@ -122,24 +121,27 @@ describe('containers/forms/PlanForm/helpers', () => {
   });
 
   it('check getNameTitle returns the correct value when Focus Investigation(FI) is selected', () => {
-    expect(getNameTitle(event, values)).toEqual(['A1--2019-08-09', 'A1  2019-08-09']);
-    expect(getNameTitle(event, valuesWithJurisdiction)).toEqual([
+    const target = event.target as HTMLInputElement;
+    expect(getNameTitle(target, values)).toEqual(['A1--2019-08-09', 'A1  2019-08-09']);
+    expect(getNameTitle(target, valuesWithJurisdiction)).toEqual([
       'A1-TLv2_01-2019-08-09',
       'A1 TLv2_01 2019-08-09',
     ]);
   });
 
   it('check getNameTitle returns the correct value when IRS is selected', () => {
-    expect(getNameTitle(event2, values)).toEqual(['IRS-2019-08-09', 'IRS 2019-08-09']);
-    expect(getNameTitle(event2, valuesWithJurisdiction)).toEqual([
+    const target = event2.target as HTMLInputElement;
+    expect(getNameTitle(target, values)).toEqual(['IRS-2019-08-09', 'IRS 2019-08-09']);
+    expect(getNameTitle(target, valuesWithJurisdiction)).toEqual([
       'IRS-2019-08-09',
       'IRS 2019-08-09',
     ]);
   });
 
   it('check getNameTitle returns the correct value when nothing is selected', () => {
-    expect(getNameTitle(event3, values)).toEqual(['IRS-2019-08-09', 'IRS 2019-08-09']);
-    expect(getNameTitle(event3, valuesWithJurisdiction)).toEqual([
+    const target = event2.target as HTMLInputElement;
+    expect(getNameTitle(target, values)).toEqual(['IRS-2019-08-09', 'IRS 2019-08-09']);
+    expect(getNameTitle(target, valuesWithJurisdiction)).toEqual([
       'IRS-2019-08-09',
       'IRS 2019-08-09',
     ]);


### PR DESCRIPTION
Closes #1574 
Fixes plan Title and Name not auto populating when plan Focus Classification is auto filled based on the jurisdiction selected.

https://user-images.githubusercontent.com/26719807/121220982-ca9a8400-c88d-11eb-8ca4-c8dc777bae11.mp4

