### PR TITLE
Show errors for map form hidden fields

### DIFF
--- a/src/components/forms/PlanForm/index.tsx
+++ b/src/components/forms/PlanForm/index.tsx
@@ -46,12 +46,12 @@ import {
   DYNAMIC_IRS_TITLE,
   DYNAMIC_MDA_TITLE,
   END_DATE,
-  ERRORS_LABEL,
   FOCUS_AREA_HEADER,
   FOCUS_CLASSIFICATION_LABEL,
   FOCUS_INVESTIGATION,
   FOCUS_INVESTIGATION_STATUS_REASON,
   GOAL_LABEL,
+  HIDDEN_ERRORS_LABEL,
   INTERVENTION_TYPE_LABEL,
   IRS_TITLE,
   LOCATIONS,
@@ -1253,15 +1253,13 @@ const PlanForm = (props: PlanFormProps) => {
             {/* show errors for hidden fields */
             intersection(Object.keys(errors), defaultHiddenFields).length > 0 && (
               <div className="alert alert-danger" role="alert">
-                <h4 className="alert-heading text-center">{ERRORS_LABEL}</h4>
+                <h5 className="alert-heading">&emsp;{HIDDEN_ERRORS_LABEL}</h5>
                 <ol>
                   {Object.keys(errors).map(
                     (key, i) =>
                       defaultHiddenFields.includes(key) && (
-                        <li className="error-list">
-                          <small key={i} className="form-text text-danger">
-                            {`${key}: ${errors[key as keyof typeof initialValues]}`}.
-                          </small>
+                        <li key={i} className="error-list">
+                          {`${key}: ${errors[key as keyof typeof initialValues]}`}.
                         </li>
                       )
                   )}

--- a/src/components/forms/PlanForm/index.tsx
+++ b/src/components/forms/PlanForm/index.tsx
@@ -1253,7 +1253,7 @@ const PlanForm = (props: PlanFormProps) => {
               (key, i) =>
                 defaultHiddenFields.includes(key) && (
                   <small key={i} className="form-text text-danger">
-                    {`${i + 1}  ${key}: ${errors[key as keyof typeof initialValues]}`}.
+                    {`${i + 1}.  ${key}: ${errors[key as keyof typeof initialValues]}`}.
                   </small>
                 )
             )}

--- a/src/components/forms/PlanForm/index.tsx
+++ b/src/components/forms/PlanForm/index.tsx
@@ -1,7 +1,7 @@
 import FormikEffect from '@onaio/formik-effect';
 import { Dictionary } from '@onaio/utils';
 import { ErrorMessage, Field, FieldArray, Form, Formik } from 'formik';
-import { xor } from 'lodash';
+import { intersection, xor } from 'lodash';
 import moment from 'moment';
 import React, { FormEvent, useEffect, useState } from 'react';
 import { Redirect } from 'react-router-dom';
@@ -46,6 +46,7 @@ import {
   DYNAMIC_IRS_TITLE,
   DYNAMIC_MDA_TITLE,
   END_DATE,
+  ERRORS_LABEL,
   FOCUS_AREA_HEADER,
   FOCUS_CLASSIFICATION_LABEL,
   FOCUS_INVESTIGATION,
@@ -1249,13 +1250,23 @@ const PlanForm = (props: PlanFormProps) => {
                 </ModalBody>
               </Modal>
             )}
-            {Object.keys(errors).map(
-              (key, i) =>
-                defaultHiddenFields.includes(key) && (
-                  <small key={i} className="form-text text-danger">
-                    {`${i + 1}.  ${key}: ${errors[key as keyof typeof initialValues]}`}.
-                  </small>
-                )
+            {/* show errors for hidden fields */
+            intersection(Object.keys(errors), defaultHiddenFields).length > 0 && (
+              <div className="alert alert-danger" role="alert">
+                <h4 className="alert-heading text-center">{ERRORS_LABEL}</h4>
+                <ol>
+                  {Object.keys(errors).map(
+                    (key, i) =>
+                      defaultHiddenFields.includes(key) && (
+                        <li className="error-list">
+                          <small key={i} className="form-text text-danger">
+                            {`${key}: ${errors[key as keyof typeof initialValues]}`}.
+                          </small>
+                        </li>
+                      )
+                  )}
+                </ol>
+              </div>
             )}
             <hr className="mb-2" />
             <Button

--- a/src/components/forms/PlanForm/index.tsx
+++ b/src/components/forms/PlanForm/index.tsx
@@ -186,6 +186,7 @@ export interface PlanFormProps {
   allowMoreJurisdictions: boolean /** should we allow one to add more jurisdictions */;
   autoSelectFIStatus: boolean /** should fi classification be auto selected */;
   cascadingSelect: boolean /** should we use cascading selects for jurisdiction selection */;
+  defaultHiddenFields: string[] /** field that will always be hidden */;
   disabledActivityFields: string[] /** activity fields that are disabled */;
   disabledFields: string[] /** fields that are disabled */;
   formHandler: (
@@ -217,6 +218,7 @@ const PlanForm = (props: PlanFormProps) => {
     allFormActivities,
     allowMoreJurisdictions,
     cascadingSelect,
+    defaultHiddenFields,
     disabledActivityFields,
     disabledFields,
     formHandler,
@@ -1247,6 +1249,14 @@ const PlanForm = (props: PlanFormProps) => {
                 </ModalBody>
               </Modal>
             )}
+            {Object.keys(errors).map(
+              (key, i) =>
+                defaultHiddenFields.includes(key) && (
+                  <small key={i} className="form-text text-danger">
+                    {`${i + 1}  ${key}: ${errors[key as keyof typeof initialValues]}`}.
+                  </small>
+                )
+            )}
             <hr className="mb-2" />
             <Button
               type="submit"
@@ -1273,6 +1283,13 @@ export const defaultProps: PlanFormProps = {
   autoSelectFIStatus: false,
   beforeSubmit: () => true,
   cascadingSelect: true,
+  defaultHiddenFields: [
+    'opensrpEventId',
+    'version',
+    'taskGenerationStatus',
+    'teamAssignmentStatus',
+    'date',
+  ],
   disabledActivityFields: [],
   disabledFields: [],
   formHandler: (_, __) => void 0,

--- a/src/components/forms/PlanForm/style.css
+++ b/src/components/forms/PlanForm/style.css
@@ -35,4 +35,5 @@
 
 .error-list {
   list-style: decimal !important;
+  font-size: 14px;
 }

--- a/src/components/forms/PlanForm/style.css
+++ b/src/components/forms/PlanForm/style.css
@@ -32,3 +32,7 @@
   margin-top: 0px !important;
   background: #ccc;
 }
+
+.error-list {
+  list-style: decimal !important;
+}

--- a/src/configs/lang.ts
+++ b/src/configs/lang.ts
@@ -1079,3 +1079,5 @@ export const PAGE_NOT_FOUND_ERROR_MESSAGE = translate(
   'PAGE_NOT_FOUND_ERROR_MESSAGE',
   'Oops! The page you are looking for can not be found.'
 );
+
+export const ERRORS_LABEL = translate('ERRORS_LABEL', 'Errors!');

--- a/src/configs/lang.ts
+++ b/src/configs/lang.ts
@@ -1080,4 +1080,7 @@ export const PAGE_NOT_FOUND_ERROR_MESSAGE = translate(
   'Oops! The page you are looking for can not be found.'
 );
 
-export const ERRORS_LABEL = translate('ERRORS_LABEL', 'Errors!');
+export const HIDDEN_ERRORS_LABEL = translate(
+  'HIDDEN_ERRORS_LABEL',
+  'Please resolve the following error(s) before saving this plan'
+);

--- a/src/containers/pages/InterventionPlan/UpdatePlan/tests/index.test.tsx
+++ b/src/containers/pages/InterventionPlan/UpdatePlan/tests/index.test.tsx
@@ -783,6 +783,7 @@ describe('components/InterventionPlan/UpdatePlan', () => {
 
     // submit button is disabled
     expect(wrapper.find('#planform-submit-button button').prop('disabled')).toBeTruthy();
+    expect(wrapper.find('.alert-danger').length).toEqual(0);
 
     // activate the plan and save
     wrapper
@@ -795,9 +796,11 @@ describe('components/InterventionPlan/UpdatePlan', () => {
     });
 
     expect(wrapper.find('#planform-submit-button button').prop('disabled')).toBeTruthy();
-    expect(wrapper.find('small').length).toEqual(1);
-    expect(wrapper.find('small').text()).toEqual(
-      '1.  taskGenerationStatus: taskGenerationStatus must be one of the following values: False, True, Disabled, ignore, internal.'
+    expect(wrapper.find('.alert-danger').length).toEqual(1);
+    expect(wrapper.find('.alert-danger h4').text()).toEqual('Errors!');
+    expect(wrapper.find('.alert-danger small').length).toEqual(1);
+    expect(wrapper.find('.alert-danger small').text()).toEqual(
+      'taskGenerationStatus: taskGenerationStatus must be one of the following values: False, True, Disabled, ignore, internal.'
     );
 
     wrapper.unmount();

--- a/src/containers/pages/InterventionPlan/UpdatePlan/tests/index.test.tsx
+++ b/src/containers/pages/InterventionPlan/UpdatePlan/tests/index.test.tsx
@@ -797,9 +797,15 @@ describe('components/InterventionPlan/UpdatePlan', () => {
 
     expect(wrapper.find('#planform-submit-button button').prop('disabled')).toBeTruthy();
     expect(wrapper.find('.alert-danger').length).toEqual(1);
-    expect(wrapper.find('.alert-danger h4').text()).toEqual('Errors!');
-    expect(wrapper.find('.alert-danger small').length).toEqual(1);
-    expect(wrapper.find('.alert-danger small').text()).toEqual(
+    expect(
+      wrapper
+        .find('.alert-danger h5')
+        .text()
+        .trim()
+    ).toEqual('Please resolve the following error(s) before saving this plan');
+    expect(wrapper.find('.alert-danger ol').length).toEqual(1);
+    expect(wrapper.find('.alert-danger ol li').length).toEqual(1);
+    expect(wrapper.find('.alert-danger ol li').text()).toEqual(
       'taskGenerationStatus: taskGenerationStatus must be one of the following values: False, True, Disabled, ignore, internal.'
     );
 


### PR DESCRIPTION
Closes #1496 
When there is an error in one of the hidden fields the plan form submit button is disabled and a user can't know why. This pr will show those errors at the bottom of the page just before the submit button.