### PR TITLE
Disable trigger and conditions toggle button

### DIFF
--- a/src/components/forms/PlanForm/index.tsx
+++ b/src/components/forms/PlanForm/index.tsx
@@ -1150,6 +1150,7 @@ const PlanForm = (props: PlanFormProps) => {
                                 className="btn-light btn-block"
                                 id={`plan-trigger-conditions-${index}`}
                                 hidden={hiddenFields.includes('triggersAndConditions')}
+                                disabled={hiddenFields.includes('triggersAndConditions')}
                               >
                                 {`${TRIGGERS_LABEL} ${AND} ${CONDITIONS_LABEL}`}
                               </Button>

--- a/src/containers/pages/InterventionPlan/NewPlan/General/tests/index.test.tsx
+++ b/src/containers/pages/InterventionPlan/NewPlan/General/tests/index.test.tsx
@@ -620,6 +620,10 @@ describe('containers/pages/NewPlan', () => {
     // triggers and conditions toggle buttons hidden
     DynamicFIPlanActivitiesCountArray.forEach((_, i) => {
       expect(wrapper.find(`#plan-trigger-conditions-div-${i} button`).prop('hidden')).toBeTruthy();
+      // button disabled
+      expect(
+        wrapper.find(`#plan-trigger-conditions-div-${i} button`).prop('disabled')
+      ).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
Closes #1679 
When Triggers and Conditions buttons are hidden on clicking `Enter key` they toggle the form card. This pr fixes the toggling when button is hidden by  disabling the buttons.